### PR TITLE
docs: lock 4 eng-review decisions + add tests section

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 ---
 tags: [project, talos, architecture, design]
 created: 2026-04-28
-modified: 2026-04-28
+modified: 2026-04-29
 status: draft
 ---
 
@@ -12,34 +12,45 @@ Runtime design for [[spec|Talos spec]]. Locked decisions, schemas, flows.
 ## Layer cake
 
 ```
-┌────────────────────────────────────────────────────┐
-│ Surface: CLI REPL │ MCP Server (stdio/SSE) │ Web  │
-├────────────────────────────────────────────────────┤
-│ Talos Runtime (~800 LOC TS)                        │
-│  ├ Provider router  (BYOK Anthropic/OpenAI/Gemini) │
-│  ├ Agent registry   (multi-agent ready, single v1) │
-│  ├ Conversation manager (threads, runs, summaries) │
-│  ├ Prompt builder   (persona + retrieved context)  │
-│  ├ Agent loop       (Vercel AI SDK streamText)     │
-│  ├ Middleware       (keeperhub, guardrails, audit) │
-│  └ MCP host         (spawn, aggregate, namespace)  │
-├────────────────────────────────────────────────────┤
-│ Persistence (PGLite, Drizzle ORM)                  │
-│  ├ Knowledge: ETH ecosystem (cron-fed nightly)     │
-│  └ Conversations: threads, runs, steps, tool_calls │
-├────────────────────────────────────────────────────┤
-│ Wallet: viem + optional ZeroDev AA                 │
-├────────────────────────────────────────────────────┤
-│ MCP tools: AgentKit, Blockscout, EVM, Li.Fi,       │
-│  Aave, Uniswap, Lido, Safe, Curve                  │
-└────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────┐
+│ Thin clients                                            │
+│   talos chat   |   Telegram users   |   MCP hosts      │
+│      ▼                  ▼                  ▼            │
+│   ws:7711         (in-process)       stdio + WS proxy  │
+└──────┼──────────────────┼──────────────────┼───────────┘
+       ▼                  ▼                  ▼
+┌────────────────────────────────────────────────────────┐
+│ talosd (always-running daemon, launchd/systemd)         │
+│                                                         │
+│  Control plane: WebSocket on 127.0.0.1:7711            │
+│   + bearer-token auth (~/.config/talos/daemon.token)   │
+│                                                         │
+│  Channel adapters:  cli-ws  |  telegram  |  mcp-server │
+│                                                         │
+│  Talos Runtime (Vercel AI SDK v6):                     │
+│   ├ Provider router (BYOK Anthropic/OpenAI/Gemini)     │
+│   ├ Agent registry  (multi-agent ready, single v1)     │
+│   ├ Conversation mgr (threads, runs, summaries)        │
+│   ├ Prompt builder  (persona + retrieved context)      │
+│   ├ Agent loop      (streamText, hot MCP host)         │
+│   └ Middleware      (keeperhub, guardrails, audit)     │
+├────────────────────────────────────────────────────────┤
+│ Persistence (PGLite, Drizzle ORM, kept open)            │
+│  ├ Knowledge: ETH ecosystem (cron-fed nightly)         │
+│  └ Conversations: threads, runs, steps, tool_calls     │
+├────────────────────────────────────────────────────────┤
+│ Wallet: viem + optional ZeroDev AA                      │
+├────────────────────────────────────────────────────────┤
+│ MCP tool servers (hot, no respawn cost):                │
+│  AgentKit, Blockscout, EVM, Li.Fi, Aave, Uniswap, Lido │
+└────────────────────────────────────────────────────────┘
 ```
 
 ## Locked decisions
 
 | # | Decision | Choice |
 |---|---|---|
-| 1 | Agent loop substrate | Vercel AI SDK (`ai` package) |
+| 1 | Agent loop substrate | Vercel AI SDK **v6** (`ai` ≥ 6.0, `@ai-sdk/mcp` for MCP client) |
 | 2 | Persistence | PGLite single store (knowledge + conversations) |
 | 3 | ORM | Drizzle (schema-as-TS, auto-generated migrations) |
 | 4 | Embedding model | OpenAI `text-embedding-3-small` (1536-dim) |
@@ -52,6 +63,17 @@ Runtime design for [[spec|Talos spec]]. Locked decisions, schemas, flows.
 | 11 | Multi-agent abstraction | First-class `Agent` type now, single agent in v1 |
 | 12 | Tool naming | `{server}_{tool}`, underscores, regex `[a-zA-Z0-9_]{1,64}` |
 | 13 | MCP-server export thread model | One thread per host session, `talos_new_thread` to reset |
+| 14 | Process model | Daemon (`talosd`) + thin clients — always-running, OpenClaw-pattern |
+| 15 | Daemon control plane | **WebSocket** on 127.0.0.1:7711 + bearer-token auth |
+| 16 | Auto-start | `talos chat` and `talos serve --mcp` start daemon if not running |
+| 17 | OS service | `talos install-service` ships in v1 (launchd / systemd user service) |
+| 18 | v1 channels | CLI (WS REPL) + Telegram (long-poll) + MCP-server (stdio→WS proxy) |
+| 19 | Telegram streaming | Edit-in-place — one message per run, progressively updated |
+| 20 | Multi-tenancy | Single-user model in v1; one wallet shared across channels; Telegram username/userId whitelist |
+| 21 | KeeperHub default annotation | **Audit-by-default** — undeclared tools route through workflows; regex allowlist (`KNOWN_READONLY`) bypasses known read-only patterns |
+| 22 | Thread keying | CLI: `cli:{$USER}:default` persistent · TG: `tg:{chatId}` persistent · MCP: `mcp:{pid}:{startedAt}` per host session · cross-thread recall bridges across all |
+| 23 | PGLite ownership | Daemon owns at runtime. One-shot commands (`init`, `migrate`, `doctor`) open the DB directly when daemon is stopped, then close. Never concurrent. |
+| 24 | Test stack | Vitest + PGLite-in-memory + seeded LLM eval; demo-flow eval is the regression gate |
 
 ## Runtime: agent loop
 
@@ -79,7 +101,7 @@ async function* run(intent: string, ctx: { agent, thread, threadId }) {
     system,
     messages: await mem.recent(ctx.threadId, 20),
     tools: mcpHost.aggregatedTools(),
-    maxSteps: 20,
+    stopWhen: stepCountIs(20),                  // v6: replaces maxSteps
     experimental_telemetry: { isEnabled: true },
   })
 
@@ -89,10 +111,11 @@ async function* run(intent: string, ctx: { agent, thread, threadId }) {
     yield part                                 // surface to CLI / MCP host
 
     switch (part.type) {
-      case 'tool-call':       await audit.logToolCall(runId, part); break
-      case 'tool-result':     await audit.logToolResult(runId, part); break
-      case 'step-finish':     await mem.persistStep(runId, part); break
-      case 'finish':          await mem.closeRun(runId, part.usage); break
+      case 'text-delta':      /* part.text — token chunk */ break
+      case 'tool-call':       await audit.logToolCall(runId, part); break    // part.input
+      case 'tool-result':     await audit.logToolResult(runId, part); break  // part.output (raw MCP content array)
+      case 'finish-step':     await mem.persistStep(runId, part); break      // v6: was step-finish
+      case 'finish':          await mem.closeRun(runId, part.totalUsage); break
     }
   }
 
@@ -192,6 +215,23 @@ CREATE INDEX know_emb_hnsw          ON knowledge_chunks   USING hnsw (embedding 
 - Auto-generates migration SQL from schema diffs (`drizzle-kit generate`).
 - Same DB serves knowledge layer + conversation layer → one embedding pipeline, one backup, one place to reason about storage.
 
+### Ownership and concurrent-handle rule
+
+PGLite locks the database file when opened. Two processes opening `~/.config/talos/talos.db` at the same time will collide — one wins, the other errors. The plan respects this with a single ownership rule:
+
+**At runtime, the daemon owns the DB.** It opens PGLite at boot, holds the handle for the daemon's lifetime, and serves all queries through the WS control plane.
+
+**One-shot commands open the DB directly, but only when the daemon is stopped.** These commands are:
+- `talos init` — first-time setup writes schema and seed data, then closes
+- `talos migrate` — explicit schema upgrade (not normally needed; daemon migrates on boot)
+- `talos doctor --repair-schema` — diagnostic / recovery
+
+Each one-shot command checks `~/.config/talos/daemon.pid`; if a daemon is running, refuses with a clear error ("stop the daemon first: `talos stop`").
+
+The migration runner is a shared utility (`src/db/migrate.ts` exporting `runMigrations(db)`) called by both init and the daemon's startup path. Init writes the initial schema; the daemon re-runs `runMigrations` on every boot to apply any unapplied migrations from a Talos upgrade. Idempotent — applies only what's missing.
+
+This keeps init self-contained (no daemon dependency, fast-fail UX) and gives future CLI tooling a clean direct-access path.
+
 ## Memory: three-tier retrieval
 
 Every run starts with three retrieval steps before the LLM call.
@@ -216,17 +256,20 @@ Naive "always inject top-K cross-thread" pollutes prompts with irrelevant memori
 
 Every layer that does work emits typed events into a per-run channel. CLI subscribes, prints live. MCP-server mode maps events to MCP `notifications/progress` messages so embedding hosts (OpenClaw, Claude Desktop) see live progress too.
 
-### Vercel AI SDK native events (from `streamText.fullStream`)
+### Vercel AI SDK v6 native events (from `streamText.fullStream`)
 
-| Type | Meaning | UX |
-|---|---|---|
-| `text-delta` | Token chunk from model | Print to stdout as it arrives |
-| `tool-call` | LLM decided to call a tool | `↳ calling aave_supply { ... }` |
-| `tool-call-streaming-start` | Args streaming in | (optional, low-noise) |
-| `tool-result` | Tool returned | `  ✓ result preview` |
-| `step-finish` | One LLM step complete | (silent, persist to DB) |
-| `finish` | Full multi-step run complete | Done |
-| `error` | Provider/tool error | Bubble up |
+| Type | Field | Meaning | UX |
+|---|---|---|---|
+| `start` | — | Run begins | (silent) |
+| `text-delta` | `text` | Token chunk from model | Print to stdout as it arrives |
+| `tool-input-start` | `toolName` | LLM about to emit tool args | (optional, low-noise) |
+| `tool-input-delta` | `delta` | Args streaming in | (optional, low-noise) |
+| `tool-call` | `input` | LLM finalized a tool call | `↳ calling aave_supply { ... }` |
+| `tool-result` | `output` | Tool returned (raw MCP content array — flatten in middleware) | `  ✓ result preview` |
+| `tool-error` | `error` | Tool threw | Surface to user, abort or retry |
+| `finish-step` | `usage`, `finishReason` | One LLM step complete | (silent, persist to DB) |
+| `finish` | `totalUsage`, `finishReason` | Full multi-step run complete | Done |
+| `error` | `error` | Provider/transport error | Bubble up |
 
 ### Talos middleware events (custom, layered on top)
 
@@ -278,7 +321,46 @@ Loop:
 8. On confirmation → stream `tx_confirmed`.
 9. Return tool result enriched with `workflowId`, `txHash` to LLM.
 
-Read-only tools (`mutates: false` or absent) bypass KeeperHub entirely. No latency cost on `aave_get_position`, `uniswap_quote`, etc.
+### Default is audit-by-default (safe-by-default)
+
+Tools without an explicit `mutates: false` annotation are routed through KeeperHub. This protects against third-party MCP servers (AgentKit, Blockscout, Li.Fi, EVM MCP) that don't know about our annotation field — silently bypassing audit on `agentkit_swap` because nobody declared it would be a load-bearing bug for the audit-trail prize.
+
+A regex allowlist bypasses well-known read-only patterns to avoid the round-trip cost (~200ms per workflow create):
+
+```ts
+const KNOWN_READONLY: RegExp[] = [
+  /_get_/,            // get_balance, get_position, get_block_number
+  /_quote$/,          // uniswap_quote
+  /_status$/,
+  /_balance$/,
+  /_position$/,
+  /_search/,
+  /^blockscout_/,     // Blockscout server is fully read-only
+]
+
+function shouldAudit(toolName: string, annotations?: { mutates?: boolean }): boolean {
+  if (annotations?.mutates === false) return false           // explicit opt-out
+  if (KNOWN_READONLY.some(rx => rx.test(toolName))) return false  // known-safe pattern
+  return true                                                 // default: audit
+}
+```
+
+Adding a new third-party MCP requires either declaring `mutates: false` in our wrapper or adding the tool name to the allowlist. Defaulting to "audit everything" trades a small latency cost on missed read-only tools for zero silent bypass holes.
+
+### KeeperHub auth (OAuth 2.1 + DCR)
+
+Spike confirmed: KeeperHub's MCP endpoint is gated by OAuth 2.1, fully discoverable via `.well-known/oauth-authorization-server` and `.well-known/oauth-protected-resource`.
+
+- Authorization Code flow with PKCE (S256)
+- **Dynamic Client Registration** at `/api/oauth/register` — Talos registers itself, no manual API key entry
+- Public-client mode (PKCE-only, `token_endpoint_auth_methods_supported: ['none']`) — no client secret to store
+- Scopes: `mcp:read`, `mcp:write`, `mcp:admin`
+
+`talos init` flow: hit well-known → register client → open browser to `/oauth/authorize` → loopback redirect captures code → exchange at `/api/oauth/token` → persist refresh + access token at `~/.config/talos/keeperhub.json` (0600). AI SDK v6's `@ai-sdk/mcp` ships `OAuthClientProvider` types for this.
+
+### Tool-result flattening
+
+MCP tool results arrive as `{ content: [{ type: 'text', text: '...' }, ...] }`. The LLM sees this verbatim by default — noisy. A middleware step flattens to plain text (or JSON if a single text block parses) before reinjecting into the conversation. Errors (`isError: true`) get tagged so the model can react appropriately.
 
 ## Multi-agent: future-proof now, single agent in v1
 
@@ -325,9 +407,188 @@ Sub-agent has its own memory namespace and tool subset. Result flows back as a t
 | v1.1 | + `talos-eth-research`, `talos-eth-exec` | Read/write split, KeeperHub only on exec |
 | v2 | User-defined in `~/.config/talos/agents/*.yaml` | Custom personas, tool subsets |
 
+## Daemon and channels
+
+**Pattern (OpenClaw-shaped):** one always-running daemon, many channels. Channels are in-process plugins. Clients (CLI, MCP hosts) are thin — they don't carry runtime state.
+
+### Why a daemon
+
+The runtime owns expensive, long-lived state: PGLite (~1s cold boot), MCP server subprocesses (1-3s each × 11 servers), provider clients with cached config, the knowledge cron schedule. Re-paying that cost per CLI invocation is unacceptable. The daemon pays it once. CLI and Telegram messages hit a hot runtime in <100ms.
+
+### Control plane
+
+WebSocket server bound to `127.0.0.1:7711`. JSON message frames. Bearer-token auth — token is a 32-byte URL-safe random written on first daemon start to `~/.config/talos/daemon.token` (mode 0600). Clients read the token from disk and pass `Authorization: Bearer <token>` in the WS upgrade headers.
+
+| Direction | Frame type | Purpose |
+|---|---|---|
+| C → S | `run` | `{ threadId, intent, agentId? }` — start a new run |
+| C → S | `abort` | `{ runId }` — cancel an in-flight run |
+| C → S | `threads.list` / `threads.get` | thread queries |
+| C → S | `status` | wallet, chains, sync, channels |
+| S → C | `event` | `{ runId, part: TextStreamPart }` — streamed |
+| S → C | `error` | protocol-level error |
+
+The `event` frames mirror Vercel AI SDK's `TextStreamPart` 1:1 — no translation between runtime and clients.
+
+### Thread keying
+
+Each channel keys its threads deterministically so reconnects feel like resumption, not a fresh start.
+
+| Channel | Thread ID format | Lifetime |
+|---|---|---|
+| **CLI** | `cli:{$USER}:default` | Persistent. Every `talos chat` reattaches. `/thread new` creates `cli:{$USER}:{ulid}` for explicit fresh starts. |
+| **Telegram** | `tg:{chatId}` | Persistent per Telegram chat. DM with the bot ≠ group chat. |
+| **MCP-server** | `mcp:{hostPid}:{startedAt}` | One per host process session. Claude Desktop closing → fresh thread on next open. |
+
+Cross-thread recall (cosine ≥ 0.78, top-3) bridges across all channels. So if you supplied USDC via CLI yesterday and ask about your position via Telegram today, the agent gets a "Prior context:" injection in the system prompt. It does *not* resume the CLI conversation — that would be confusing across channels.
+
+Resume vs recall is the key distinction:
+- **Resume**: same thread, full message history. "Pick up where we left off."
+- **Recall**: different thread, top-K relevant chunks injected as background. "By the way, you've talked about this."
+
+Adapter contract for thread allocation: `threads.findOrCreate(key: string) → threadId`. Idempotent; first call creates, subsequent calls return the same thread.
+
+### Channel adapter contract
+
+Every channel is a plugin loaded at daemon startup based on `channels.yaml`:
+
+```ts
+interface ChannelAdapter {
+  name: string                                        // 'cli' | 'telegram' | 'mcp-server'
+  start(ctx: AdapterContext): Promise<void>
+  stop(): Promise<void>
+}
+
+interface AdapterContext {
+  runtime: Runtime                                    // entry to agent loop
+  threads: ThreadStore
+  config: Record<string, unknown>                     // adapter's slice of channels.yaml
+  logger: Logger
+}
+```
+
+Each adapter:
+- Listens on its own protocol (WS for CLI, long-poll for TG, stdio for MCP-server)
+- Translates incoming messages → `runtime.run(intent, threadId)`
+- Maps the streamed `TextStreamPart`s back to its surface
+
+### CLI channel (`talos chat`)
+
+Thin WebSocket client. ~200 LOC. Connects to daemon, opens REPL, prints events live. Built on Node's `readline` + `chalk` + `cli-spinners`. Slash commands (`/help`, `/thread new`, `/status`, `/clear`) handled client-side — no daemon roundtrip.
+
+`^C` sends `abort` for the in-flight run, returns to prompt. `^D` exits cleanly.
+
+If the daemon isn't running and `auto_start_daemon: true` in config: spawn `talosd` in the background and wait for it to come up before connecting.
+
+### Telegram channel
+
+Long-polling Bot API via [grammY](https://grammy.dev). Per Telegram chat → its own thread (`tg:{chatId}`). Whitelist enforced at message receipt — non-allowed users silently ignored.
+
+**Edit-in-place streaming** is the polish:
+
+```ts
+bot.on('message:text', async (tgCtx) => {
+  if (!cfg.allowedUsers.includes(tgCtx.from.username)) return
+  const threadId = await threads.findOrCreate(`tg:${tgCtx.chat.id}`)
+  const msg = await tgCtx.reply('↻ thinking…')
+  let trace: string[] = ['↻ thinking…']
+  let lastEdit = Date.now()
+  let final = ''
+
+  for await (const part of runtime.run(tgCtx.message.text, { threadId })) {
+    if (part.type === 'tool-call')      trace.push(`↻ ${part.toolName}`)
+    else if (part.type === 'tool-result') trace[trace.length - 1] += '  ✓'
+    else if (part.type === 'text-delta') final += part.text
+    else if (part.type === 'finish')      trace = [final.trim()]
+
+    // Telegram rate limit: ~1 edit/sec per chat
+    if (Date.now() - lastEdit > 1100) {
+      await bot.api.editMessageText(tgCtx.chat.id, msg.message_id, trace.join('\n'))
+      lastEdit = Date.now()
+    }
+  }
+  await bot.api.editMessageText(tgCtx.chat.id, msg.message_id, trace.join('\n'))
+})
+```
+
+One message per run. Watcher sees the trace progress live, then snap to final answer. Non-spammy.
+
+### MCP-server channel (`talos serve --mcp`)
+
+Two-hop proxy: the host (Claude Desktop, OpenClaw, Cursor) spawns `talos serve --mcp` as a subprocess, talks stdio MCP to it. The proxy holds an MCP server on stdio + a WS client to the daemon. Tools/calls/results flow through unchanged. Daemon's `event` frames map to MCP `notifications/progress`.
+
+```
+host  ◀──stdio MCP──▶  talos-mcp-proxy  ◀──WS──▶  talosd
+```
+
+If daemon isn't running on first invocation: auto-start it. ~150 LOC for the proxy.
+
+### channels.yaml
+
+```yaml
+# ~/.config/talos/channels.yaml
+auto_start_daemon: true
+
+daemon:
+  bind: 127.0.0.1:7711
+  log_file: ~/.config/talos/daemon.log
+
+channels:
+  cli:
+    enabled: true                        # always on
+  telegram:
+    enabled: false
+    bot_token_ref: env:TALOS_TG_BOT_TOKEN   # never store token inline
+    allowed_users: ['@allensaji']
+    polling_interval_ms: 1000
+  mcp_server:
+    enabled: true                        # served on stdio when invoked
+```
+
+### Lifecycle
+
+```
+talos init                  # one-time wizard
+talos install-service       # writes launchd plist / systemd user unit
+talos start                 # runs daemon (foreground unless --detach)
+talos stop
+talos restart
+talos status                # daemon? channels? sync? wallet?
+talos logs [-f]
+talos channels list | add <name> [opts] | remove <name> | enable <name> | disable <name>
+talos chat                  # thin client
+talos serve --mcp           # MCP-server proxy mode
+```
+
+### Auth model
+
+- Daemon binds to `127.0.0.1` only. No LAN/WAN exposure in v1.
+- Bearer token in `~/.config/talos/daemon.token` (0600). Rotated on `talos restart --rotate-token`.
+- Telegram is **in-process** with the daemon — no auth between TG adapter and runtime; the secret here is the bot token (config-managed).
+- KeeperHub OAuth tokens stored separately in `~/.config/talos/keeperhub.json` (0600). Refresh handled by daemon.
+
+### Concurrency
+
+Multiple channels can run requests in parallel. Each `runtime.run()` invocation:
+- Has its own `AbortController` keyed by `runId`
+- Operates on its own thread context (memory + retrieval are thread-scoped)
+- Shares hot resources: PGLite pool (MVCC), MCP server subprocesses (parallel-call safe per spec), provider clients
+
+Knowledge cron is daemon-scoped; runs on a single timer regardless of how many channels are active.
+
+### Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Daemon crashes | OS service auto-restarts (launchd/systemd). In-flight runs lost; threads stay consistent (closed `runs.finishedAt` with `error: aborted`) |
+| Channel adapter throws | Logged, adapter restarted; daemon stays up; other channels unaffected |
+| MCP server subprocess dies | Hot-restart on next call; tool list refreshed |
+| KeeperHub OAuth expires | Daemon refreshes via refresh_token transparently; surfaces error if refresh fails |
+| Provider rate-limit | Bubbles to client as `error` event; user retries |
+
 ## MCP-server export mode
 
-`talos serve --mcp` is the same runtime, different surface. Single thread per host session keeps Talos *agent-ful* rather than *tool-ful* (host gets continuity across calls).
+`talos serve --mcp` is the **MCP-server channel adapter**, exposed as a top-level command for convenience. Same runtime, different surface. Single thread per host session keeps Talos *agent-ful* rather than *tool-ful* (host gets continuity across calls).
 
 | Tool | What it does |
 |---|---|

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,7 +1,7 @@
 ---
 tags: [project, talos, hackathon, eth-open-agents, spec]
 created: 2026-04-27
-modified: 2026-04-28
+modified: 2026-04-29
 status: locked
 ---
 
@@ -73,7 +73,7 @@ Runtime design (frameworks, schemas, flows): see [[architecture]].
 - **F5.8** P2 Voice interface via dTelecom provider (x402 micropayments)
 - **F5.9** P0 First-class `Agent` type + AgentRegistry (multi-agent ready, single agent v1)
 - **F5.10** P0 Vercel AI SDK (`ai` package) as agent loop substrate
-- **F5.11** P0 Tag-based KeeperHub middleware: tools self-declare `mutates: true`
+- **F5.11** P0 Audit-by-default KeeperHub middleware: undeclared tools route through workflows; regex `KNOWN_READONLY` allowlist bypasses known read-only patterns
 
 ## 6. Onboarding (the wedge)
 
@@ -86,6 +86,7 @@ Runtime design (frameworks, schemas, flows): see [[architecture]].
 - **F6.7** P1 ZeroDev project ID auto-prompt with link to free tier signup
 - **F6.8** P1 `talos status` command shows current capabilities, last cron run, balances
 - **F6.9** P1 `talos doctor` command diagnoses misconfigs
+- **F6.10** P0 `init` is idempotent: detects existing config, prompts keep / reset / partial-reset (re-do OAuth only)
 
 ## 7. Distribution
 
@@ -104,7 +105,9 @@ Runtime design (frameworks, schemas, flows): see [[architecture]].
 
 ## 9. Embeddability (Talos-as-MCP)
 
-- **F9.1** P0 `talos serve --mcp` exposes Talos as an MCP server over stdio
+(Implemented as the `mcp-server` channel adapter under Section 11.)
+
+- **F9.1** P0 `talos serve --mcp` proxies host stdio MCP ↔ daemon WS (auto-starts daemon)
 - **F9.2** P0 Tool: `query_eth_knowledge` — hits local PGLite vector DB, returns top-N chunks + cited sources
 - **F9.3** P0 Tool: `eth_action` — runs full agent loop, returns KeeperHub workflow URL + tx hash
 - **F9.4** P0 Tool: `eth_status` — wallet, chains, last-sync, enabled MCPs
@@ -119,7 +122,7 @@ Runtime design (frameworks, schemas, flows): see [[architecture]].
 
 Detail in [[architecture]] §Persistence + §Memory.
 
-- **F10.1** P0 PGLite single-store at `~/.config/talos/talos.db` (knowledge + conversations in one DB)
+- **F10.1** P0 PGLite single-store at `~/.config/talos/talos.db` (knowledge + conversations); daemon owns at runtime, one-shot commands open directly only when daemon is stopped
 - **F10.2** P0 Drizzle ORM with auto-generated SQL migrations
 - **F10.3** P0 Schema: `threads`, `runs`, `steps`, `tool_calls`, `message_embeddings`, `knowledge_chunks`
 - **F10.4** P0 Hybrid retrieval: pgvector HNSW (semantic) + tsvector GIN (keyword)
@@ -132,9 +135,67 @@ Detail in [[architecture]] §Persistence + §Memory.
 - **F10.11** P1 `talos thread <id>` to load and continue past threads
 - **F10.12** P2 In-memory LRU cache for query embeddings (1000 entries)
 
+## 11. Daemon & Channels (always-running, OpenClaw-pattern)
+
+Detail in [[architecture]] §Daemon and channels.
+
+- **F11.1** P0 `talosd` long-running daemon — holds runtime, hot MCP servers, PGLite, knowledge cron
+- **F11.2** P0 WebSocket control plane on `127.0.0.1:7711`; bearer-token auth via `~/.config/talos/daemon.token` (0600)
+- **F11.3** P0 In-process channel adapter contract; channels loaded at boot from `channels.yaml`
+- **F11.4** P0 Lifecycle: `talos start | stop | restart | status | logs [-f]`
+- **F11.5** P0 `talos install-service` — installs as launchd (macOS) / systemd user service (Linux)
+- **F11.6** P0 Auto-start: `talos chat` and `talos serve --mcp` start daemon if not running
+- **F11.7** P0 Concurrent runs across channels; each has its own `AbortController` and thread context
+- **F11.8** P0 Thread keying: CLI `cli:{$USER}:default` persistent, TG `tg:{chatId}` persistent, MCP `mcp:{pid}:{startedAt}` per host session; cross-thread recall bridges across all
+- **F11.9** P0 CLI channel: `talos chat` thin WS client REPL; ^C aborts run, ^D exits; slash commands client-side
+- **F11.10** P0 MCP-server channel: `talos serve --mcp` proxies host stdio ↔ daemon WS (replaces standalone mode)
+- **F11.11** P0 Telegram channel: long-poll Bot API via grammY; per-chat threads
+- **F11.12** P0 Telegram streaming UX: edit-in-place (one message per run, progressive updates, ~1s throttle)
+- **F11.13** P0 Single-user model: one wallet shared across channels; Telegram username/userId whitelist
+- **F11.14** P0 `talos channels list | add | remove | enable | disable`
+- **F11.15** P0 `channels.yaml` config schema; bot tokens via env-ref, never inline
+- **F11.16** P1 Daemon log file with rotation at `~/.config/talos/daemon.log`
+- **F11.17** P1 Daemon config hot-reload (SIGHUP rereads `channels.yaml` without restart)
+- **F11.18** P1 OS service template generator (`talos install-service --print` for inspection)
+- **F11.19** P2 Discord channel adapter
+- **F11.20** P2 Web dashboard channel: tiny SPA at `127.0.0.1:7711/ui`
+
+## 12. Tests
+
+Stack: Vitest + PGLite-in-memory + seeded LLM eval. Demo-flow eval is the regression gate.
+
+### P0 — required for v1
+
+- **F12.1** P0 Provider router resolves model id → SDK adapter (unit)
+- **F12.2** P0 KeeperHub middleware: `mutates: true` → routes through workflow (unit)
+- **F12.3** P0 KeeperHub middleware: undeclared annotation → defaults to mutating (unit)
+- **F12.4** P0 KeeperHub middleware: name matches `KNOWN_READONLY` allowlist → bypasses (unit)
+- **F12.5** P0 Tool-result flattening: single text → string (unit)
+- **F12.6** P0 Tool-result flattening: text-with-JSON → parsed object (unit)
+- **F12.7** P0 Cross-thread recall: cosine ≥ 0.78 threshold gate enforces (unit)
+- **F12.8** P0 Thread auto-summarization triggers at exactly 20 runs (unit)
+- **F12.9** P0 Migrations: empty DB → schema at vN (integration)
+- **F12.10** P0 Migrations: vN-1 → vN, no data loss (integration)
+- **F12.11** P0 WS auth: bad bearer token → 401 (integration)
+- **F12.12** P0 WS auth: valid token → connect + can run (integration)
+- **F12.13** P0 Run abort: AbortController cancels `streamText`, persists `runs.error: 'aborted'` (integration)
+- **F12.14** P0 Telegram whitelist: non-allowed user silently dropped (unit)
+- **F12.15** P0 `init` idempotency: re-running with existing config prompts keep/reset/partial (unit)
+- **F12.16** P0 **CRITICAL** Demo-flow eval: "supply 100 USDC to Aave on arbitrum" hits expected MCP sequence on locked seed (eval)
+
+### P1 — required for v1.1
+
+- **F12.17** P1 Tool-result flattening: multi-text blocks joined with `\n\n` (unit)
+- **F12.18** P1 Tool-result flattening: error → wrapped with `error` tag (unit)
+- **F12.19** P1 Concurrent runs across channels don't interfere (integration)
+- **F12.20** P1 MCP-server proxy: stdio in → WS out → events back, end-to-end (integration)
+- **F12.21** P1 Telegram edit-in-place: rate-limit throttle (~1.1s) holds (integration)
+- **F12.22** P1 Knowledge cron: one source 503, others succeed, partial state surfaced (integration)
+- **F12.23** P1 OAuth flow end-to-end against mocked KeeperHub (integration)
+
 ## Counts
 
-86 features. P0 = 55. P1 = 23. P2 = 8.
+130 features. P0 = 87. P1 = 33. P2 = 10.
 
 ## Open questions (deferred)
 


### PR DESCRIPTION
## Summary
Locks four decisions from the engineering review:

1. **KeeperHub default = audit-by-default.** Undeclared tools route through workflows; `KNOWN_READONLY` regex allowlist bypasses known read-only patterns. Closes the silent-bypass bug for third-party MCPs.
2. **Thread keying policy.** CLI: `cli:{$USER}:default` persistent. TG: `tg:{chatId}` persistent. MCP-server: `mcp:{pid}:{startedAt}` per host session. Cross-thread recall bridges across all.
3. **PGLite ownership.** Daemon owns at runtime; one-shot commands (`init`, `migrate`, `doctor`) open directly only when daemon is stopped. Shared `runMigrations` utility.
4. **Section 12 — Tests.** New 23-test plan (16 P0, 7 P1) including the demo-flow eval as the regression gate.

Plus F6.10 (init idempotency) added as a P0 since F12.15 enforces it.

Counts: 106 → 130 features. P0: 70 → 87.

## Test plan
- [x] Both files render
- [x] Cross-links between spec.md and architecture.md still resolve
- [x] Locked decisions table has 24 rows
- [x] Test section gates demo flow with eval