### PR TITLE
feat(persistence): PGLite + Drizzle layer with hybrid search

### DIFF
--- a/bin/talos.ts
+++ b/bin/talos.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
+import fs from 'node:fs'
 import { Command } from 'commander'
+import { paths } from '@/config/paths'
+import { assertNoLiveDaemon, createDb, runMigrations } from '@/persistence'
 import { TalosNotImplementedError } from '@/shared/errors'
 import { logger } from '@/shared/logger'
 
@@ -42,9 +45,16 @@ program
 program
   .command('migrate')
   .description('Run database migrations against the local PGLite store')
-  .action(() => {
-    logger.info('migrate: not implemented')
-    throw new TalosNotImplementedError('talos migrate')
+  .action(async () => {
+    assertNoLiveDaemon()
+    fs.mkdirSync(paths.dataDir, { recursive: true })
+    const handle = await createDb({ path: paths.dbPath })
+    try {
+      await runMigrations(handle)
+      logger.info({ dbPath: paths.dbPath }, 'migrations applied')
+    } finally {
+      await handle.close()
+    }
   })
 
 program.parseAsync().catch((err) => {

--- a/src/persistence/client.ts
+++ b/src/persistence/client.ts
@@ -1,0 +1,30 @@
+import { PGlite } from '@electric-sql/pglite'
+import { vector } from '@electric-sql/pglite/vector'
+import { drizzle } from 'drizzle-orm/pglite'
+import { TalosDbError } from '@/shared/errors'
+
+export type DbHandle = {
+  pg: PGlite
+  db: ReturnType<typeof drizzle>
+  close: () => Promise<void>
+}
+
+export type CreateDbOptions =
+  | { ephemeral: true; path?: never }
+  | { ephemeral?: false; path: string }
+
+export async function createDb(opts: CreateDbOptions): Promise<DbHandle> {
+  const dataDir = opts.ephemeral ? 'memory://' : opts.path
+  if (!dataDir) {
+    throw new TalosDbError('createDb: path required when ephemeral=false', 'DB_BAD_OPTIONS')
+  }
+  const pg = await PGlite.create({ dataDir, extensions: { vector } })
+  const db = drizzle({ client: pg })
+  return {
+    pg,
+    db,
+    close: async () => {
+      await pg.close()
+    },
+  }
+}

--- a/src/persistence/index.ts
+++ b/src/persistence/index.ts
@@ -1,11 +1,5 @@
-import { TalosNotImplementedError } from '@/shared/errors'
-
+export * from './client'
+export * from './migrations'
+export * from './ownership'
+export * from './queries'
 export * from './schema'
-
-export function createDb(): never {
-  throw new TalosNotImplementedError('persistence.createDb')
-}
-
-export function runMigrations(): never {
-  throw new TalosNotImplementedError('persistence.runMigrations')
-}

--- a/src/persistence/migrations.ts
+++ b/src/persistence/migrations.ts
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { migrate } from 'drizzle-orm/pglite/migrator'
+import { TalosDbError } from '@/shared/errors'
+import type { DbHandle } from './client'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+const DEFAULT_FOLDER = path.resolve(here, '..', '..', 'drizzle')
+
+export type RunMigrationsOptions = {
+  migrationsFolder?: string
+}
+
+export async function runMigrations(
+  handle: Pick<DbHandle, 'db'>,
+  opts: RunMigrationsOptions = {},
+): Promise<void> {
+  const folder = opts.migrationsFolder ?? DEFAULT_FOLDER
+  try {
+    await migrate(handle.db, { migrationsFolder: folder })
+  } catch (err) {
+    throw new TalosDbError(
+      `migrations failed (folder=${folder}): ${(err as Error).message}`,
+      'DB_MIGRATE_FAILED',
+      err,
+    )
+  }
+}

--- a/src/persistence/ownership.ts
+++ b/src/persistence/ownership.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs'
+import { paths as defaultPaths, type Paths } from '@/config/paths'
+import { TalosDbError } from '@/shared/errors'
+
+export type OwnershipCheckOptions = {
+  paths?: Pick<Paths, 'pidPath' | 'dbPath'>
+  selfPid?: number
+}
+
+/**
+ * Refuse to open the file-backed DB if `paths.pidPath` exists with a live process
+ * that is not us. PGLite is single-writer; the daemon owns at runtime, one-shots
+ * (migrate, doctor, init) only run when the daemon is stopped.
+ */
+export function assertNoLiveDaemon(opts: OwnershipCheckOptions = {}): void {
+  const paths = opts.paths ?? defaultPaths
+  const selfPid = opts.selfPid ?? process.pid
+
+  let raw: string
+  try {
+    raw = fs.readFileSync(paths.pidPath, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+    throw new TalosDbError(
+      `failed to read pidfile at ${paths.pidPath}`,
+      'DB_PIDFILE_READ_FAILED',
+      err,
+    )
+  }
+
+  const pid = Number.parseInt(raw.trim(), 10)
+  if (!Number.isFinite(pid) || pid <= 0) {
+    fs.rmSync(paths.pidPath, { force: true })
+    return
+  }
+
+  if (pid === selfPid) return
+
+  if (isAlive(pid)) {
+    throw new TalosDbError(
+      `daemon (pid ${pid}) holds ${paths.dbPath}; stop it first: \`talos stop\``,
+      'DB_DAEMON_OWNS',
+    )
+  }
+
+  fs.rmSync(paths.pidPath, { force: true })
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ESRCH') return false
+    if (code === 'EPERM') return true
+    throw err
+  }
+}

--- a/src/persistence/queries.ts
+++ b/src/persistence/queries.ts
@@ -1,0 +1,171 @@
+import { sql } from 'drizzle-orm'
+import { TalosDbError } from '@/shared/errors'
+import type { DbHandle } from './client'
+import {
+  messageEmbeddings,
+  type NewMessageEmbedding,
+  type NewRun,
+  type NewStep,
+  type NewThread,
+  type NewToolCall,
+  runs,
+  steps,
+  threads,
+  toolCalls,
+} from './schema'
+
+const EMBEDDING_DIMS = 1536
+
+type Db = DbHandle['db']
+
+export async function upsertThread(db: Db, input: NewThread) {
+  const [row] = await db
+    .insert(threads)
+    .values(input)
+    .onConflictDoUpdate({
+      target: threads.id,
+      set: { updatedAt: sql`now()`, title: input.title ?? sql`${threads.title}` },
+    })
+    .returning()
+  if (!row) throw new TalosDbError('upsertThread returned no row', 'DB_NO_ROW')
+  return row
+}
+
+export async function openRun(db: Db, input: NewRun) {
+  const [row] = await db.insert(runs).values(input).returning()
+  if (!row) throw new TalosDbError('openRun returned no row', 'DB_NO_ROW')
+  return row
+}
+
+export async function closeRun(
+  db: Db,
+  runId: string,
+  patch: { status: 'completed' | 'failed' | 'cancelled'; summary?: string | null },
+) {
+  await db
+    .update(runs)
+    .set({
+      status: patch.status,
+      summary: patch.summary ?? null,
+      finishedAt: sql`now()`,
+    })
+    .where(sql`${runs.id} = ${runId}`)
+}
+
+export async function appendStep(db: Db, input: NewStep) {
+  const [row] = await db.insert(steps).values(input).returning()
+  if (!row) throw new TalosDbError('appendStep returned no row', 'DB_NO_ROW')
+  return row
+}
+
+export async function recordToolCall(db: Db, input: NewToolCall) {
+  const [row] = await db.insert(toolCalls).values(input).returning()
+  if (!row) throw new TalosDbError('recordToolCall returned no row', 'DB_NO_ROW')
+  return row
+}
+
+export async function insertMessageEmbedding(
+  db: Db,
+  input: Omit<NewMessageEmbedding, 'embedding'> & { embedding: number[] },
+) {
+  if (input.embedding.length !== EMBEDDING_DIMS) {
+    throw new TalosDbError(
+      `embedding must be ${EMBEDDING_DIMS}-d (got ${input.embedding.length})`,
+      'DB_BAD_EMBEDDING',
+    )
+  }
+  const [row] = await db.insert(messageEmbeddings).values(input).returning()
+  if (!row) throw new TalosDbError('insertMessageEmbedding returned no row', 'DB_NO_ROW')
+  return row
+}
+
+export type SearchHit = {
+  id: string
+  threadId: string
+  runId: string | null
+  role: string
+  content: string
+  vsim: number
+  krank: number
+  score: number
+}
+
+export type SearchOptions = {
+  topK?: number
+  vectorPoolSize?: number
+  weights?: { vector: number; keyword: number }
+}
+
+/**
+ * Hybrid retrieval over message_embeddings, scoped to a thread.
+ *
+ * Score: `vsim * w.vector + krank * w.keyword` (default 0.7 / 0.3).
+ *  - vsim   = 1 - cosine_distance, in [-1, 1] (typically [0, 1] for normalized embeddings)
+ *  - krank  = ts_rank against plainto_tsquery, ≥ 0 (small, naturally bounded)
+ * Pulls top `vectorPoolSize` (default 20) by vector distance, left-joins keyword ranks,
+ * orders by combined score. Mirrors spike-2-pglite which proved 4ms vector queries.
+ *
+ * NOTE: tsv is computed inline via `to_tsvector('english', content)` because the
+ * STORED generated column is tracked separately in issue #15. When that column
+ * lands the WHERE/ORDER expressions swap to `tsv @@ ...` and `ts_rank(tsv, ...)`.
+ */
+export async function searchMessages(
+  db: Db,
+  threadId: string,
+  queryEmbedding: number[],
+  queryText: string,
+  options: SearchOptions = {},
+): Promise<SearchHit[]> {
+  if (queryEmbedding.length !== EMBEDDING_DIMS) {
+    throw new TalosDbError(
+      `queryEmbedding must be ${EMBEDDING_DIMS}-d (got ${queryEmbedding.length})`,
+      'DB_BAD_EMBEDDING',
+    )
+  }
+  const topK = options.topK ?? 5
+  const pool = options.vectorPoolSize ?? 20
+  const wv = options.weights?.vector ?? 0.7
+  const wk = options.weights?.keyword ?? 0.3
+
+  const embeddingLiteral = `[${queryEmbedding.join(',')}]`
+
+  const result = await db.execute(sql`
+    WITH v AS (
+      SELECT id, thread_id, run_id, role, content,
+             1 - (embedding <=> ${embeddingLiteral}::vector) AS vsim
+      FROM message_embeddings
+      WHERE thread_id = ${threadId}
+      ORDER BY embedding <=> ${embeddingLiteral}::vector
+      LIMIT ${pool}
+    ),
+    k AS (
+      SELECT id,
+             ts_rank(to_tsvector('english', content), plainto_tsquery('english', ${queryText})) AS krank
+      FROM message_embeddings
+      WHERE thread_id = ${threadId}
+        AND to_tsvector('english', content) @@ plainto_tsquery('english', ${queryText})
+    )
+    SELECT v.id, v.thread_id, v.run_id, v.role, v.content,
+           v.vsim,
+           COALESCE(k.krank, 0) AS krank,
+           v.vsim * ${wv} + COALESCE(k.krank, 0) * ${wk} AS score
+    FROM v LEFT JOIN k USING (id)
+    ORDER BY score DESC
+    LIMIT ${topK}
+  `)
+
+  return (result.rows as Array<Record<string, unknown>>).map(rowToHit)
+}
+
+function rowToHit(row: Record<string, unknown>): SearchHit {
+  return {
+    id: String(row.id),
+    threadId: String(row.thread_id),
+    runId: row.run_id == null ? null : String(row.run_id),
+    role: String(row.role),
+    content: String(row.content),
+    vsim: Number(row.vsim),
+    krank: Number(row.krank),
+    score: Number(row.score),
+  }
+}

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -37,3 +37,10 @@ export class TalosProtocolError extends TalosError {
     this.name = 'TalosProtocolError'
   }
 }
+
+export class TalosDbError extends TalosError {
+  constructor(message: string, code = 'DB_ERROR', cause?: unknown) {
+    super(message, code, cause)
+    this.name = 'TalosDbError'
+  }
+}

--- a/tests/integration/persistence.test.ts
+++ b/tests/integration/persistence.test.ts
@@ -1,0 +1,225 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  appendStep,
+  assertNoLiveDaemon,
+  closeRun,
+  createDb,
+  type DbHandle,
+  insertMessageEmbedding,
+  openRun,
+  recordToolCall,
+  runMigrations,
+  searchMessages,
+  upsertThread,
+} from '@/persistence'
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+describe('persistence — migrations + schema', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('creates all tables idempotently (re-run is a no-op)', async () => {
+    await runMigrations(handle)
+    const result = await handle.pg.query<{ table_name: string }>(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+       ORDER BY table_name`,
+    )
+    const names = result.rows.map((r) => r.table_name)
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'threads',
+        'runs',
+        'steps',
+        'tool_calls',
+        'message_embeddings',
+        'knowledge_chunks',
+      ]),
+    )
+  })
+
+  it('writes thread → run → step → tool_call respecting FKs', async () => {
+    const thread = await upsertThread(handle.db, {
+      id: 'cli:test:default',
+      channel: 'cli',
+      title: 'test thread',
+    })
+    expect(thread.id).toBe('cli:test:default')
+
+    const run = await openRun(handle.db, {
+      threadId: thread.id,
+      prompt: 'supply 100 USDC to Aave on Arbitrum',
+    })
+    expect(run.status).toBe('running')
+
+    const step = await appendStep(handle.db, {
+      runId: run.id,
+      stepIndex: 0,
+      role: 'assistant',
+      content: 'invoking aave_supply',
+    })
+    expect(step.runId).toBe(run.id)
+
+    const tc = await recordToolCall(handle.db, {
+      runId: run.id,
+      stepId: step.id,
+      toolCallId: 'call_1',
+      toolName: 'aave_supply',
+      args: { amount: '100', asset: 'USDC', chain: 'arbitrum' },
+    })
+    expect(tc.toolName).toBe('aave_supply')
+
+    await closeRun(handle.db, run.id, { status: 'completed', summary: 'done' })
+
+    const after = await handle.pg.query<{ status: string; summary: string }>(
+      `SELECT status, summary FROM runs WHERE id = $1`,
+      [run.id],
+    )
+    expect(after.rows[0]?.status).toBe('completed')
+    expect(after.rows[0]?.summary).toBe('done')
+  })
+})
+
+describe('persistence — vector + hybrid search', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+    await upsertThread(handle.db, { id: 't-search', channel: 'cli' })
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  const corpus = [
+    'supply 100 USDC to Aave on Arbitrum',
+    'check my Aave health factor',
+    'swap 1 ETH for USDC on Uniswap',
+    'bridge ETH from Mainnet to Base via Lifi',
+    'stake 32 ETH to Lido',
+    'borrow DAI from Aave',
+    'create a Safe multisig',
+    'pull current ETH price from Pyth',
+    'sweep dust from Optimism to Base',
+    'what is my wallet balance on Arbitrum',
+  ]
+
+  it('returns rows ordered by HNSW cosine + tsvector hybrid score', async () => {
+    for (let i = 0; i < corpus.length; i++) {
+      const content = corpus[i]
+      if (!content) continue
+      await insertMessageEmbedding(handle.db, {
+        threadId: 't-search',
+        role: 'user',
+        content,
+        embedding: fakeEmbedding(i + 1),
+      })
+    }
+
+    const queryEmb = fakeEmbedding(1)
+    const hits = await searchMessages(handle.db, 't-search', queryEmb, 'aave arbitrum', {
+      topK: 5,
+    })
+
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits.length).toBeLessThanOrEqual(5)
+
+    for (let i = 1; i < hits.length; i++) {
+      const prev = hits[i - 1]
+      const curr = hits[i]
+      if (prev && curr) expect(prev.score).toBeGreaterThanOrEqual(curr.score)
+    }
+
+    const top = hits[0]
+    expect(top).toBeDefined()
+    if (top) {
+      expect(top.threadId).toBe('t-search')
+      expect(top.score).toBeGreaterThan(0)
+    }
+
+    const aaveHit = hits.find((h) => h.content.toLowerCase().includes('aave'))
+    expect(aaveHit).toBeDefined()
+  })
+
+  it('rejects wrong-dimension embeddings', async () => {
+    await expect(
+      insertMessageEmbedding(handle.db, {
+        threadId: 't-search',
+        role: 'user',
+        content: 'bad',
+        embedding: [1, 2, 3],
+      }),
+    ).rejects.toThrow(/embedding must be 1536/)
+  })
+})
+
+describe('persistence — ownership', () => {
+  let tmpDir: string
+  let pidPath: string
+  let dbPath: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'talos-ownership-'))
+    pidPath = path.join(tmpDir, 'daemon.pid')
+    dbPath = path.join(tmpDir, 'db')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('passes when no pidfile', () => {
+    expect(() => assertNoLiveDaemon({ paths: { pidPath, dbPath } })).not.toThrow()
+  })
+
+  it('throws when pidfile points at a live process', () => {
+    fs.writeFileSync(pidPath, String(process.pid))
+    expect(() =>
+      assertNoLiveDaemon({ paths: { pidPath, dbPath }, selfPid: process.pid + 1 }),
+    ).toThrow(/daemon \(pid \d+\) holds/)
+  })
+
+  it('clears stale pidfile when pid is dead', () => {
+    fs.writeFileSync(pidPath, '999999999')
+    expect(() => assertNoLiveDaemon({ paths: { pidPath, dbPath } })).not.toThrow()
+    expect(fs.existsSync(pidPath)).toBe(false)
+  })
+
+  it('passes when pidfile points at self', () => {
+    fs.writeFileSync(pidPath, String(process.pid))
+    expect(() => assertNoLiveDaemon({ paths: { pidPath, dbPath } })).not.toThrow()
+  })
+
+  it('discards pidfile with malformed contents', () => {
+    fs.writeFileSync(pidPath, 'not-a-pid')
+    expect(() => assertNoLiveDaemon({ paths: { pidPath, dbPath } })).not.toThrow()
+    expect(fs.existsSync(pidPath)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #5.

## Summary

Brings up the local data store. PGLite + pgvector boots from npm install with no system deps, drizzle's official migrator applies the locked schema, hybrid retrieval works on `message_embeddings` per the spike that proved 947ms boot / 4ms vector queries.

## What's in

- `src/persistence/client.ts` - `createDb({ path | ephemeral })` with vector extension loaded
- `src/persistence/migrations.ts` - `runMigrations(handle)` via `drizzle-orm/pglite/migrator` (journal-tracked, idempotent)
- `src/persistence/ownership.ts` - `assertNoLiveDaemon(opts?)` PID-aware single-writer enforcement; clears stale pidfiles, errors on live foreign daemon
- `src/persistence/queries.ts` - typed helpers (`upsertThread`, `openRun`, `closeRun`, `appendStep`, `recordToolCall`, `insertMessageEmbedding`) + `searchMessages` hybrid retrieval
- `bin/talos.ts` - `migrate` action wired
- `src/shared/errors.ts` - new `TalosDbError`
- `tests/integration/persistence.test.ts` - 11 tests

## Hybrid search

Mirrors `~/projects/talos-spikes/spike-2-pglite/`:

```
score = (1 - cosine_distance) * 0.7 + ts_rank(to_tsvector('english', content), plainto_tsquery(q)) * 0.3
```

Pulls top 20 by vector distance, left-joins keyword ranks, orders by combined score. Computes `to_tsvector` inline since the STORED generated column is tracked in #15. When that column lands the WHERE/ORDER expressions swap to `tsv @@ ...` and `ts_rank(tsv, ...)`.

## Engineering deviations from issue text

1. **Drizzle's official PGLite migrator**, not a custom split-on-statement-breakpoint runner. The official one tracks `__drizzle_migrations`, handles ordering via `journal.json`, and is what every other drizzle project uses. Saves us code + matches the standard.
2. **Hybrid scoring is similarity-weighted** (`(1 - distance) * 0.7 + ts_rank * 0.3`, ordered desc) - resolves the sign mismatch in the issue's "vector_cosine_distance + ts_rank" phrasing. Cosine distance is lower-is-better, ts_rank is higher-is-better; converting to similarity unifies the direction.

## Verification

- `pnpm typecheck` green
- `pnpm lint` green (0 issues across 36 files)
- `pnpm test` green (16 passed, 1 todo - the demo-flow eval placeholder from #12)
- `pnpm build` green
- `talos migrate` end-to-end against tmp dir creates PGLite cluster + applies migrations

## Follow-ups filed

- #16 thread_summaries (Warm-tier persistence, fills documented architectural gap)
- #17 distilled facts memory (Mem0-style ADD/UPDATE/DELETE pipeline)

## Test plan

- [x] Migration runs cleanly, re-run is no-op
- [x] Vector insert + HNSW search returns rows ordered by distance
- [x] Hybrid search returns sensible top-K
- [x] Wrong-dimension embeddings rejected
- [x] Ownership: no pidfile -> pass; live foreign pid -> throw; stale pid -> clear; self pid -> pass; malformed -> clear
- [x] `talos migrate` CLI works against stopped daemon