### PR TITLE
feat(persistence): thread_summaries warm-tier table

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "files": {
-    "includes": ["**", "!dist", "!drizzle/**/*.sql", "!node_modules", "!coverage"]
+    "includes": ["**", "!dist", "!drizzle/**/*.sql", "!drizzle/meta", "!node_modules", "!coverage"]
   },
   "formatter": {
     "enabled": true,

--- a/drizzle/0001_dizzy_ted_forrester.sql
+++ b/drizzle/0001_dizzy_ted_forrester.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "thread_summaries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"thread_id" text NOT NULL,
+	"run_range_start" uuid,
+	"run_range_end" uuid,
+	"summary" text NOT NULL,
+	"embedding" vector(1536) NOT NULL,
+	"token_count" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "thread_summaries" ADD CONSTRAINT "thread_summaries_thread_id_threads_id_fk" FOREIGN KEY ("thread_id") REFERENCES "public"."threads"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "thread_summaries" ADD CONSTRAINT "thread_summaries_run_range_start_runs_id_fk" FOREIGN KEY ("run_range_start") REFERENCES "public"."runs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "thread_summaries" ADD CONSTRAINT "thread_summaries_run_range_end_runs_id_fk" FOREIGN KEY ("run_range_end") REFERENCES "public"."runs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "thread_summaries_thread_idx" ON "thread_summaries" USING btree ("thread_id");--> statement-breakpoint
+CREATE INDEX "thread_summaries_hnsw_idx" ON "thread_summaries" USING hnsw ("embedding" vector_cosine_ops);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,804 @@
+{
+  "id": "bdccb434-8ad0-4a89-a06a-8e66ceac1dab",
+  "prevId": "c3f7abcd-5327-465b-b848-afad22a41f2b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.knowledge_chunks": {
+      "name": "knowledge_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_chunks_source_idx": {
+          "name": "knowledge_chunks_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_hnsw_idx": {
+          "name": "knowledge_chunks_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_embeddings": {
+      "name": "message_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tsv": {
+          "name": "tsv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_embeddings_thread_idx": {
+          "name": "message_embeddings_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_embeddings_hnsw_idx": {
+          "name": "message_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_embeddings_thread_id_threads_id_fk": {
+          "name": "message_embeddings_thread_id_threads_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_embeddings_run_id_runs_id_fk": {
+          "name": "message_embeddings_run_id_runs_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_thread_idx": {
+          "name": "runs_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_status_idx": {
+          "name": "runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_thread_id_threads_id_fk": {
+          "name": "runs_thread_id_threads_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steps": {
+      "name": "steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "step_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "steps_run_idx": {
+          "name": "steps_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "steps_run_id_runs_id_fk": {
+          "name": "steps_run_id_runs_id_fk",
+          "tableFrom": "steps",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_summaries": {
+      "name": "thread_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_range_start": {
+          "name": "run_range_start",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_range_end": {
+          "name": "run_range_end",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "thread_summaries_thread_idx": {
+          "name": "thread_summaries_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_summaries_hnsw_idx": {
+          "name": "thread_summaries_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_summaries_thread_id_threads_id_fk": {
+          "name": "thread_summaries_thread_id_threads_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_summaries_run_range_start_runs_id_fk": {
+          "name": "thread_summaries_run_range_start_runs_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_range_start"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "thread_summaries_run_range_end_runs_id_fk": {
+          "name": "thread_summaries_run_range_end_runs_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_range_end"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "threads_channel_idx": {
+          "name": "threads_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_calls": {
+      "name": "tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit": {
+          "name": "audit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_idx": {
+          "name": "tool_calls_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tool_calls_name_idx": {
+          "name": "tool_calls_name_idx",
+          "columns": [
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_calls_step_id_steps_id_fk": {
+          "name": "tool_calls_step_id_steps_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_role": {
+      "name": "step_role",
+      "schema": "public",
+      "values": [
+        "assistant",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777409293125,
       "tag": "0000_shiny_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777436013792,
+      "tag": "0001_dizzy_ted_forrester",
+      "breakpoints": true
     }
   ]
 }

--- a/src/persistence/queries.ts
+++ b/src/persistence/queries.ts
@@ -7,9 +7,11 @@ import {
   type NewRun,
   type NewStep,
   type NewThread,
+  type NewThreadSummary,
   type NewToolCall,
   runs,
   steps,
+  threadSummaries,
   threads,
   toolCalls,
 } from './schema'
@@ -155,6 +157,102 @@ export async function searchMessages(
   `)
 
   return (result.rows as Array<Record<string, unknown>>).map(rowToHit)
+}
+
+// ---------- thread summaries (Warm tier) ----------
+
+export async function writeThreadSummary(
+  db: Db,
+  input: Omit<NewThreadSummary, 'embedding'> & { embedding: number[] },
+) {
+  if (input.embedding.length !== EMBEDDING_DIMS) {
+    throw new TalosDbError(
+      `summary embedding must be ${EMBEDDING_DIMS}-d (got ${input.embedding.length})`,
+      'DB_BAD_EMBEDDING',
+    )
+  }
+  const [row] = await db.insert(threadSummaries).values(input).returning()
+  if (!row) throw new TalosDbError('writeThreadSummary returned no row', 'DB_NO_ROW')
+  return row
+}
+
+export async function latestThreadSummary(db: Db, threadId: string) {
+  const result = await db.execute(sql`
+    SELECT * FROM thread_summaries
+    WHERE thread_id = ${threadId}
+    ORDER BY created_at DESC
+    LIMIT 1
+  `)
+  const row = result.rows[0]
+  return row ? (row as unknown as ThreadSummaryRow) : null
+}
+
+export type ThreadSummaryHit = {
+  id: string
+  threadId: string
+  summary: string
+  vsim: number
+  createdAt: string
+}
+
+export type ThreadSummarySearchOptions = {
+  topK?: number
+  excludeThreadId?: string
+  threshold?: number
+}
+
+/**
+ * Cross-thread cold recall over thread_summaries. Vector-only (no keyword fusion)
+ * because summaries are already condensed text — the vector is the high-signal channel.
+ * Threshold-gated: returns only rows with vsim >= threshold (default 0.78 from
+ * architecture's adaptive cold recall rule).
+ */
+export async function searchThreadSummaries(
+  db: Db,
+  queryEmbedding: number[],
+  options: ThreadSummarySearchOptions = {},
+): Promise<ThreadSummaryHit[]> {
+  if (queryEmbedding.length !== EMBEDDING_DIMS) {
+    throw new TalosDbError(
+      `queryEmbedding must be ${EMBEDDING_DIMS}-d (got ${queryEmbedding.length})`,
+      'DB_BAD_EMBEDDING',
+    )
+  }
+  const topK = options.topK ?? 3
+  const threshold = options.threshold ?? 0.78
+  const excludeThreadId = options.excludeThreadId ?? null
+
+  const embeddingLiteral = `[${queryEmbedding.join(',')}]`
+
+  const result = await db.execute(sql`
+    SELECT id, thread_id, summary, created_at,
+           1 - (embedding <=> ${embeddingLiteral}::vector) AS vsim
+    FROM thread_summaries
+    WHERE (${excludeThreadId}::text IS NULL OR thread_id <> ${excludeThreadId})
+    ORDER BY embedding <=> ${embeddingLiteral}::vector
+    LIMIT ${topK}
+  `)
+
+  return (result.rows as Array<Record<string, unknown>>)
+    .map((row) => ({
+      id: String(row.id),
+      threadId: String(row.thread_id),
+      summary: String(row.summary),
+      vsim: Number(row.vsim),
+      createdAt: String(row.created_at),
+    }))
+    .filter((h) => h.vsim >= threshold)
+}
+
+type ThreadSummaryRow = {
+  id: string
+  thread_id: string
+  run_range_start: string | null
+  run_range_end: string | null
+  summary: string
+  embedding: unknown
+  token_count: number | null
+  created_at: string
 }
 
 function rowToHit(row: Record<string, unknown>): SearchHit {

--- a/src/persistence/schema.ts
+++ b/src/persistence/schema.ts
@@ -109,6 +109,26 @@ export const messageEmbeddings = pgTable(
   ],
 )
 
+export const threadSummaries = pgTable(
+  'thread_summaries',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    threadId: text('thread_id')
+      .notNull()
+      .references(() => threads.id, { onDelete: 'cascade' }),
+    runRangeStart: uuid('run_range_start').references(() => runs.id, { onDelete: 'set null' }),
+    runRangeEnd: uuid('run_range_end').references(() => runs.id, { onDelete: 'set null' }),
+    summary: text('summary').notNull(),
+    embedding: vector('embedding', { dimensions: 1536 }).notNull(),
+    tokenCount: integer('token_count'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('thread_summaries_thread_idx').on(t.threadId),
+    index('thread_summaries_hnsw_idx').using('hnsw', sql`${t.embedding} vector_cosine_ops`),
+  ],
+)
+
 export const knowledgeChunks = pgTable(
   'knowledge_chunks',
   {
@@ -139,3 +159,5 @@ export type MessageEmbedding = typeof messageEmbeddings.$inferSelect
 export type NewMessageEmbedding = typeof messageEmbeddings.$inferInsert
 export type KnowledgeChunk = typeof knowledgeChunks.$inferSelect
 export type NewKnowledgeChunk = typeof knowledgeChunks.$inferInsert
+export type ThreadSummary = typeof threadSummaries.$inferSelect
+export type NewThreadSummary = typeof threadSummaries.$inferInsert

--- a/tests/integration/thread-summaries.test.ts
+++ b/tests/integration/thread-summaries.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createDb,
+  type DbHandle,
+  latestThreadSummary,
+  openRun,
+  runMigrations,
+  searchThreadSummaries,
+  upsertThread,
+  writeThreadSummary,
+} from '@/persistence'
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+describe('thread_summaries — warm-tier persistence', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('writes + reads the latest summary for a thread', async () => {
+    await upsertThread(handle.db, { id: 't-warm', channel: 'cli' })
+    const r1 = await openRun(handle.db, { threadId: 't-warm', prompt: 'first batch' })
+    const r2 = await openRun(handle.db, { threadId: 't-warm', prompt: 'second batch' })
+
+    await writeThreadSummary(handle.db, {
+      threadId: 't-warm',
+      runRangeStart: r1.id,
+      runRangeEnd: r1.id,
+      summary: 'discussed Aave supply',
+      embedding: fakeEmbedding(1),
+      tokenCount: 42,
+    })
+
+    await writeThreadSummary(handle.db, {
+      threadId: 't-warm',
+      runRangeStart: r2.id,
+      runRangeEnd: r2.id,
+      summary: 'discussed Uniswap swap',
+      embedding: fakeEmbedding(2),
+      tokenCount: 50,
+    })
+
+    const latest = await latestThreadSummary(handle.db, 't-warm')
+    expect(latest).not.toBeNull()
+    expect(latest?.summary).toBe('discussed Uniswap swap')
+    expect(latest?.token_count).toBe(50)
+  })
+
+  it('returns null for a thread with no summary', async () => {
+    await upsertThread(handle.db, { id: 't-empty', channel: 'cli' })
+    const latest = await latestThreadSummary(handle.db, 't-empty')
+    expect(latest).toBeNull()
+  })
+
+  it('cross-thread recall ranks by vector similarity, threshold-gated', async () => {
+    await upsertThread(handle.db, { id: 't-a', channel: 'cli' })
+    await upsertThread(handle.db, { id: 't-b', channel: 'cli' })
+    await upsertThread(handle.db, { id: 't-c', channel: 'cli' })
+
+    await writeThreadSummary(handle.db, {
+      threadId: 't-a',
+      summary: 'thread A: aave supply on arbitrum',
+      embedding: fakeEmbedding(1),
+    })
+    await writeThreadSummary(handle.db, {
+      threadId: 't-b',
+      summary: 'thread B: uniswap swap on mainnet',
+      embedding: fakeEmbedding(50),
+    })
+    await writeThreadSummary(handle.db, {
+      threadId: 't-c',
+      summary: 'thread C: similar to A',
+      embedding: fakeEmbedding(1),
+    })
+
+    const hits = await searchThreadSummaries(handle.db, fakeEmbedding(1), {
+      topK: 3,
+      threshold: 0.5,
+    })
+    expect(hits.length).toBeGreaterThan(0)
+    const top = hits[0]
+    expect(top).toBeDefined()
+    if (top) {
+      expect(top.vsim).toBeGreaterThan(0.5)
+    }
+    for (let i = 1; i < hits.length; i++) {
+      const prev = hits[i - 1]
+      const curr = hits[i]
+      if (prev && curr) expect(prev.vsim).toBeGreaterThanOrEqual(curr.vsim)
+    }
+  })
+
+  it('excludes a given thread when excludeThreadId is set', async () => {
+    await upsertThread(handle.db, { id: 't-self', channel: 'cli' })
+    await upsertThread(handle.db, { id: 't-other', channel: 'cli' })
+
+    await writeThreadSummary(handle.db, {
+      threadId: 't-self',
+      summary: 'self thread',
+      embedding: fakeEmbedding(1),
+    })
+    await writeThreadSummary(handle.db, {
+      threadId: 't-other',
+      summary: 'other thread',
+      embedding: fakeEmbedding(1),
+    })
+
+    const hits = await searchThreadSummaries(handle.db, fakeEmbedding(1), {
+      topK: 5,
+      threshold: 0,
+      excludeThreadId: 't-self',
+    })
+    expect(hits.every((h) => h.threadId !== 't-self')).toBe(true)
+    expect(hits.some((h) => h.threadId === 't-other')).toBe(true)
+  })
+
+  it('threshold filters out low-similarity matches', async () => {
+    await upsertThread(handle.db, { id: 't-q1', channel: 'cli' })
+    await writeThreadSummary(handle.db, {
+      threadId: 't-q1',
+      summary: 'totally unrelated',
+      embedding: fakeEmbedding(999),
+    })
+
+    const hits = await searchThreadSummaries(handle.db, fakeEmbedding(1), {
+      topK: 5,
+      threshold: 0.9,
+    })
+    expect(hits.length).toBe(0)
+  })
+
+  it('rejects wrong-dimension embeddings on write and search', async () => {
+    await upsertThread(handle.db, { id: 't-bad', channel: 'cli' })
+    await expect(
+      writeThreadSummary(handle.db, {
+        threadId: 't-bad',
+        summary: 'bad',
+        embedding: [1, 2, 3],
+      }),
+    ).rejects.toThrow(/embedding must be 1536/)
+
+    await expect(searchThreadSummaries(handle.db, [1, 2, 3])).rejects.toThrow(
+      /queryEmbedding must be 1536/,
+    )
+  })
+})


### PR DESCRIPTION
Closes #16.

## Summary

Fills the documented architectural gap: the locked architecture mandates `mem.summarizeThread()` every 20 runs, but had no destination table. This adds it.

## Schema

```ts
thread_summaries(
  id uuid pk,
  thread_id text fk threads(id) on delete cascade,
  run_range_start uuid fk runs(id) on delete set null,
  run_range_end uuid fk runs(id) on delete set null,
  summary text,
  embedding vector(1536),
  token_count integer,
  created_at timestamptz
)
+ HNSW index on embedding
+ btree on thread_id
```

`run_range_*` use `ON DELETE SET NULL` so a summary survives even if individual runs are pruned in the future. Thread deletion still cascades the summary (it has no meaning without its thread).

## Helpers

- `writeThreadSummary(db, { threadId, runRange?, summary, embedding, tokenCount? })`
- `latestThreadSummary(db, threadId)` -> latest row or null
- `searchThreadSummaries(db, queryEmbedding, { topK?, excludeThreadId?, threshold? })` -> threshold-gated cross-thread vector recall (default 0.78 from architecture's adaptive cold recall rule)

Cross-thread search is **vector-only** here (no keyword fusion). Summaries are already condensed - the vector is the high-signal channel; keyword overlap on a 200-word summary doesn't add useful ranking. This is a deliberate divergence from `searchMessages` which fuses tsvector for the noisier raw-message corpus.

## Verification

- `pnpm typecheck` green
- `pnpm lint` green
- `pnpm test` green (22 passed, 1 todo)
- `pnpm build` green

## Tests

- write + read latest
- cross-thread recall orders by vector similarity descending
- excludeThreadId filters out current thread
- threshold filters out low-similarity matches
- wrong-dimension embeddings rejected (write + search)

## Side fix

`biome.json` was lint-erroring on drizzle-kit's auto-generated `drizzle/meta/*.json` snapshots. Added `!drizzle/meta` to the ignore list - drizzle-kit owns that file's formatting.

## Out of scope

- The 20-run trigger logic (lives in #7 runtime)
- LLM-side summarization prompt (also runtime)
- Compaction of multiple summaries into super-summaries