### PR TITLE
feat(persistence): distilled facts memory with Mem0 reconcile pipeline

### DIFF
--- a/drizzle/0002_unknown_may_parker.sql
+++ b/drizzle/0002_unknown_may_parker.sql
@@ -1,0 +1,35 @@
+CREATE TYPE "public"."fact_event" AS ENUM('ADD', 'UPDATE', 'DELETE');--> statement-breakpoint
+CREATE TABLE "fact_history" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"fact_id" uuid NOT NULL,
+	"event" "fact_event" NOT NULL,
+	"old_text" text,
+	"new_text" text,
+	"run_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "facts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"agent_id" text NOT NULL,
+	"channel" text NOT NULL,
+	"thread_id" text,
+	"text" text NOT NULL,
+	"embedding" vector(1536) NOT NULL,
+	"hash" text NOT NULL,
+	"attributed_to_run_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"superseded_by" uuid,
+	"deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "fact_history" ADD CONSTRAINT "fact_history_fact_id_facts_id_fk" FOREIGN KEY ("fact_id") REFERENCES "public"."facts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "fact_history" ADD CONSTRAINT "fact_history_run_id_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."runs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "facts" ADD CONSTRAINT "facts_attributed_to_run_id_runs_id_fk" FOREIGN KEY ("attributed_to_run_id") REFERENCES "public"."runs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "facts" ADD CONSTRAINT "facts_superseded_by_facts_id_fk" FOREIGN KEY ("superseded_by") REFERENCES "public"."facts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "fact_history_fact_idx" ON "fact_history" USING btree ("fact_id");--> statement-breakpoint
+CREATE INDEX "fact_history_run_idx" ON "fact_history" USING btree ("run_id");--> statement-breakpoint
+CREATE INDEX "facts_scope_idx" ON "facts" USING btree ("agent_id","channel","thread_id");--> statement-breakpoint
+CREATE INDEX "facts_live_hash_idx" ON "facts" USING btree ("agent_id","channel","hash") WHERE deleted_at IS NULL AND superseded_by IS NULL;--> statement-breakpoint
+CREATE INDEX "facts_hnsw_idx" ON "facts" USING hnsw ("embedding" vector_cosine_ops);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1115 @@
+{
+  "id": "b866fe24-5a3b-4847-aa38-2c817a777600",
+  "prevId": "bdccb434-8ad0-4a89-a06a-8e66ceac1dab",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.fact_history": {
+      "name": "fact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fact_id": {
+          "name": "fact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "fact_event",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_text": {
+          "name": "old_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_text": {
+          "name": "new_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fact_history_fact_idx": {
+          "name": "fact_history_fact_idx",
+          "columns": [
+            {
+              "expression": "fact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fact_history_run_idx": {
+          "name": "fact_history_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fact_history_fact_id_facts_id_fk": {
+          "name": "fact_history_fact_id_facts_id_fk",
+          "tableFrom": "fact_history",
+          "tableTo": "facts",
+          "columnsFrom": [
+            "fact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fact_history_run_id_runs_id_fk": {
+          "name": "fact_history_run_id_runs_id_fk",
+          "tableFrom": "fact_history",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.facts": {
+      "name": "facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributed_to_run_id": {
+          "name": "attributed_to_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "facts_scope_idx": {
+          "name": "facts_scope_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "facts_live_hash_idx": {
+          "name": "facts_live_hash_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL AND superseded_by IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "facts_hnsw_idx": {
+          "name": "facts_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "facts_attributed_to_run_id_runs_id_fk": {
+          "name": "facts_attributed_to_run_id_runs_id_fk",
+          "tableFrom": "facts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "attributed_to_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "facts_superseded_by_facts_id_fk": {
+          "name": "facts_superseded_by_facts_id_fk",
+          "tableFrom": "facts",
+          "tableTo": "facts",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_chunks": {
+      "name": "knowledge_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_chunks_source_idx": {
+          "name": "knowledge_chunks_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_hnsw_idx": {
+          "name": "knowledge_chunks_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_embeddings": {
+      "name": "message_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tsv": {
+          "name": "tsv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_embeddings_thread_idx": {
+          "name": "message_embeddings_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_embeddings_hnsw_idx": {
+          "name": "message_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_embeddings_thread_id_threads_id_fk": {
+          "name": "message_embeddings_thread_id_threads_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_embeddings_run_id_runs_id_fk": {
+          "name": "message_embeddings_run_id_runs_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_thread_idx": {
+          "name": "runs_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_status_idx": {
+          "name": "runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_thread_id_threads_id_fk": {
+          "name": "runs_thread_id_threads_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steps": {
+      "name": "steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "step_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "steps_run_idx": {
+          "name": "steps_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "steps_run_id_runs_id_fk": {
+          "name": "steps_run_id_runs_id_fk",
+          "tableFrom": "steps",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_summaries": {
+      "name": "thread_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_range_start": {
+          "name": "run_range_start",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_range_end": {
+          "name": "run_range_end",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "thread_summaries_thread_idx": {
+          "name": "thread_summaries_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_summaries_hnsw_idx": {
+          "name": "thread_summaries_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_summaries_thread_id_threads_id_fk": {
+          "name": "thread_summaries_thread_id_threads_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_summaries_run_range_start_runs_id_fk": {
+          "name": "thread_summaries_run_range_start_runs_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_range_start"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "thread_summaries_run_range_end_runs_id_fk": {
+          "name": "thread_summaries_run_range_end_runs_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_range_end"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "threads_channel_idx": {
+          "name": "threads_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_calls": {
+      "name": "tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit": {
+          "name": "audit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_idx": {
+          "name": "tool_calls_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tool_calls_name_idx": {
+          "name": "tool_calls_name_idx",
+          "columns": [
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_calls_step_id_steps_id_fk": {
+          "name": "tool_calls_step_id_steps_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.fact_event": {
+      "name": "fact_event",
+      "schema": "public",
+      "values": [
+        "ADD",
+        "UPDATE",
+        "DELETE"
+      ]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_role": {
+      "name": "step_role",
+      "schema": "public",
+      "values": [
+        "assistant",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777436013792,
       "tag": "0001_dizzy_ted_forrester",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777436294325,
+      "tag": "0002_unknown_may_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/src/persistence/facts.ts
+++ b/src/persistence/facts.ts
@@ -1,0 +1,420 @@
+/**
+ * Mem0-style distilled facts memory.
+ *
+ * Why a separate store: embedding raw chat is the wrong primitive for "what does the
+ * user prefer". Facts are extracted, deduped, and reconciled in a single LLM call per
+ * turn (ADD / UPDATE / DELETE / NONE), then written with append-only history.
+ *
+ * Pipeline (mirrors mem0/memory/main.py:662-895):
+ *   1. extract candidate facts from new messages         <- FactExtractor
+ *   2. vector-search top-K existing facts in same scope  <- recallFacts
+ *   3. one LLM call returns ops per candidate            <- FactReconciler
+ *   4. apply ops in a transaction with history rows      <- applyFactOps
+ *
+ * The LLM-side extractor + reconciler live in the runtime (#7); this module ships
+ * the data plane and accepts them as injected dependencies so tests can mock them.
+ */
+
+import crypto from 'node:crypto'
+import { sql } from 'drizzle-orm'
+import { TalosDbError } from '@/shared/errors'
+import type { DbHandle } from './client'
+import { factHistory, facts } from './schema'
+
+const EMBEDDING_DIMS = 1536
+
+type Db = DbHandle['db']
+
+// ---------- types ----------
+
+export type FactScope = {
+  agentId: string
+  channel: string
+  /** null = applies to all threads in (agentId, channel) */
+  threadId?: string | null
+}
+
+export type ExtractedFact = {
+  text: string
+  embedding: number[]
+}
+
+export type ExistingFact = {
+  id: string
+  text: string
+  /** vector similarity to the candidate that surfaced this fact */
+  vsim: number
+}
+
+export type FactOp =
+  | {
+      kind: 'ADD'
+      text: string
+      embedding: number[]
+      runId?: string | null
+    }
+  | {
+      kind: 'UPDATE'
+      targetId: string
+      text: string
+      embedding: number[]
+      runId?: string | null
+    }
+  | {
+      kind: 'DELETE'
+      targetId: string
+      runId?: string | null
+    }
+  | { kind: 'NONE' }
+
+export type FactExtractor = (
+  messages: Array<{ role: string; content: string }>,
+) => Promise<ExtractedFact[]>
+
+export type FactReconcilerInput = {
+  scope: FactScope
+  candidates: ExtractedFact[]
+  existing: ExistingFact[]
+}
+
+export type FactReconciler = (input: FactReconcilerInput) => Promise<FactOp[]>
+
+export type FactRecallHit = {
+  id: string
+  text: string
+  vsim: number
+  krank: number
+  score: number
+  createdAt: string
+}
+
+export type RecallOptions = {
+  topK?: number
+  vectorPoolSize?: number
+  weights?: { vector: number; keyword: number }
+  /** include facts with thread_id IS NULL (channel-wide) in addition to scope.threadId */
+  includeChannelWide?: boolean
+}
+
+// ---------- helpers ----------
+
+export function normalizeFactText(text: string): string {
+  return text.toLowerCase().trim().replace(/\s+/g, ' ')
+}
+
+export function hashFactText(text: string): string {
+  return crypto.createHash('md5').update(normalizeFactText(text)).digest('hex')
+}
+
+function assertEmbeddingDims(embedding: number[], label: string): void {
+  if (embedding.length !== EMBEDDING_DIMS) {
+    throw new TalosDbError(
+      `${label} must be ${EMBEDDING_DIMS}-d (got ${embedding.length})`,
+      'DB_BAD_EMBEDDING',
+    )
+  }
+}
+
+function embeddingLiteral(embedding: number[]): string {
+  return `[${embedding.join(',')}]`
+}
+
+// ---------- recall ----------
+
+/**
+ * Hybrid recall over live facts in scope. Scoring identical to searchMessages:
+ * `vsim * 0.7 + ts_rank * 0.3` over a top-N vector pool.
+ *
+ * Filters: deleted_at IS NULL, superseded_by IS NULL.
+ * Scope: exact (agent_id, channel) match. thread_id matches `scope.threadId` exactly,
+ * plus optionally facts with thread_id IS NULL when `includeChannelWide=true`.
+ */
+export async function recallFacts(
+  db: Db,
+  scope: FactScope,
+  queryEmbedding: number[],
+  queryText: string,
+  options: RecallOptions = {},
+): Promise<FactRecallHit[]> {
+  assertEmbeddingDims(queryEmbedding, 'queryEmbedding')
+
+  const topK = options.topK ?? 5
+  const pool = options.vectorPoolSize ?? 20
+  const wv = options.weights?.vector ?? 0.7
+  const wk = options.weights?.keyword ?? 0.3
+  const includeChannelWide = options.includeChannelWide ?? true
+
+  const emb = embeddingLiteral(queryEmbedding)
+  const threadId = scope.threadId ?? null
+
+  const threadClause =
+    threadId === null
+      ? sql`thread_id IS NULL`
+      : includeChannelWide
+        ? sql`(thread_id = ${threadId} OR thread_id IS NULL)`
+        : sql`thread_id = ${threadId}`
+
+  const rows = await db.execute(sql`
+    WITH live AS (
+      SELECT id, text, embedding, created_at
+      FROM facts
+      WHERE agent_id = ${scope.agentId}
+        AND channel = ${scope.channel}
+        AND deleted_at IS NULL
+        AND superseded_by IS NULL
+        AND ${threadClause}
+    ),
+    v AS (
+      SELECT id, text, created_at,
+             1 - (embedding <=> ${emb}::vector) AS vsim
+      FROM live
+      ORDER BY embedding <=> ${emb}::vector
+      LIMIT ${pool}
+    ),
+    k AS (
+      SELECT id,
+             ts_rank(to_tsvector('english', text), plainto_tsquery('english', ${queryText})) AS krank
+      FROM live
+      WHERE to_tsvector('english', text) @@ plainto_tsquery('english', ${queryText})
+    )
+    SELECT v.id, v.text, v.created_at, v.vsim,
+           COALESCE(k.krank, 0) AS krank,
+           v.vsim * ${wv} + COALESCE(k.krank, 0) * ${wk} AS score
+    FROM v LEFT JOIN k USING (id)
+    ORDER BY score DESC
+    LIMIT ${topK}
+  `)
+
+  return (rows.rows as Array<Record<string, unknown>>).map((row) => ({
+    id: String(row.id),
+    text: String(row.text),
+    vsim: Number(row.vsim),
+    krank: Number(row.krank),
+    score: Number(row.score),
+    createdAt: String(row.created_at),
+  }))
+}
+
+// ---------- write ----------
+
+/**
+ * Apply a batch of fact ops in a single transaction. Each op writes a fact_history row.
+ * Returns the IDs of facts that were created or affected, in the same order as input.
+ *
+ * Op semantics:
+ *  - ADD     : insert new live fact + history(event=ADD, new_text=text)
+ *  - UPDATE  : insert replacement fact, set old.superseded_by = new.id,
+ *              + history(fact_id=new, event=UPDATE, old_text, new_text)
+ *  - DELETE  : set deleted_at = now() on target, + history(event=DELETE, old_text)
+ *  - NONE    : skipped
+ *
+ * Idempotency: ADD ops that hash-match a live fact in the same (agent, channel) scope
+ * are skipped (no insert, no history). The scope is derived from the input scope.
+ */
+export async function applyFactOps(
+  db: Db,
+  scope: FactScope,
+  ops: FactOp[],
+): Promise<Array<{ op: FactOp; factId: string | null; skipped: boolean }>> {
+  for (const op of ops) {
+    if (op.kind === 'ADD' || op.kind === 'UPDATE') {
+      assertEmbeddingDims(op.embedding, `${op.kind} op embedding`)
+    }
+  }
+
+  const results: Array<{ op: FactOp; factId: string | null; skipped: boolean }> = []
+
+  await db.transaction(async (tx) => {
+    for (const op of ops) {
+      if (op.kind === 'NONE') {
+        results.push({ op, factId: null, skipped: true })
+        continue
+      }
+
+      if (op.kind === 'ADD') {
+        const hash = hashFactText(op.text)
+
+        const dup = await tx.execute(sql`
+          SELECT id FROM facts
+          WHERE agent_id = ${scope.agentId}
+            AND channel = ${scope.channel}
+            AND hash = ${hash}
+            AND deleted_at IS NULL
+            AND superseded_by IS NULL
+          LIMIT 1
+        `)
+        if (dup.rows.length > 0) {
+          const existingId = String((dup.rows[0] as Record<string, unknown>).id)
+          results.push({ op, factId: existingId, skipped: true })
+          continue
+        }
+
+        const inserted = await tx
+          .insert(facts)
+          .values({
+            agentId: scope.agentId,
+            channel: scope.channel,
+            threadId: scope.threadId ?? null,
+            text: op.text,
+            embedding: op.embedding,
+            hash,
+            attributedToRunId: op.runId ?? null,
+          })
+          .returning({ id: facts.id })
+
+        const factId = inserted[0]?.id
+        if (!factId) throw new TalosDbError('ADD insert returned no row', 'DB_NO_ROW')
+
+        await tx.insert(factHistory).values({
+          factId,
+          event: 'ADD',
+          oldText: null,
+          newText: op.text,
+          runId: op.runId ?? null,
+        })
+
+        results.push({ op, factId, skipped: false })
+        continue
+      }
+
+      if (op.kind === 'UPDATE') {
+        const target = await tx.execute(sql`
+          SELECT id, agent_id, channel, thread_id, text
+          FROM facts
+          WHERE id = ${op.targetId}
+            AND deleted_at IS NULL
+            AND superseded_by IS NULL
+          LIMIT 1
+        `)
+        const row = target.rows[0] as Record<string, unknown> | undefined
+        if (!row) {
+          throw new TalosDbError(
+            `UPDATE target ${op.targetId} not found or not live`,
+            'DB_FACT_TARGET_MISSING',
+          )
+        }
+
+        const oldText = String(row.text)
+        const newHash = hashFactText(op.text)
+
+        const inserted = await tx
+          .insert(facts)
+          .values({
+            agentId: String(row.agent_id),
+            channel: String(row.channel),
+            threadId: row.thread_id == null ? null : String(row.thread_id),
+            text: op.text,
+            embedding: op.embedding,
+            hash: newHash,
+            attributedToRunId: op.runId ?? null,
+          })
+          .returning({ id: facts.id })
+
+        const newId = inserted[0]?.id
+        if (!newId) throw new TalosDbError('UPDATE insert returned no row', 'DB_NO_ROW')
+
+        await tx.execute(sql`
+          UPDATE facts
+          SET superseded_by = ${newId}, updated_at = now()
+          WHERE id = ${op.targetId}
+        `)
+
+        await tx.insert(factHistory).values({
+          factId: newId,
+          event: 'UPDATE',
+          oldText,
+          newText: op.text,
+          runId: op.runId ?? null,
+        })
+
+        results.push({ op, factId: newId, skipped: false })
+        continue
+      }
+
+      // DELETE
+      const target = await tx.execute(sql`
+        SELECT text FROM facts
+        WHERE id = ${op.targetId}
+          AND deleted_at IS NULL
+        LIMIT 1
+      `)
+      const row = target.rows[0] as Record<string, unknown> | undefined
+      if (!row) {
+        throw new TalosDbError(
+          `DELETE target ${op.targetId} not found or already deleted`,
+          'DB_FACT_TARGET_MISSING',
+        )
+      }
+      const oldText = String(row.text)
+
+      await tx.execute(sql`
+        UPDATE facts SET deleted_at = now(), updated_at = now()
+        WHERE id = ${op.targetId}
+      `)
+
+      await tx.insert(factHistory).values({
+        factId: op.targetId,
+        event: 'DELETE',
+        oldText,
+        newText: null,
+        runId: op.runId ?? null,
+      })
+
+      results.push({ op, factId: op.targetId, skipped: false })
+    }
+  })
+
+  return results
+}
+
+// ---------- pipeline orchestrator ----------
+
+export type PipelineDeps = {
+  extract: FactExtractor
+  reconcile: FactReconciler
+  /** how many existing facts to retrieve per candidate (default 5) */
+  candidatePoolSize?: number
+  /** runId attributed to all ops emitted in this pass (optional) */
+  runId?: string | null
+}
+
+/**
+ * Full Mem0 pass: extract → search existing → reconcile → apply.
+ * The LLM-backed extract + reconcile come from the runtime; this orchestrator
+ * is pure data flow and can be tested with deterministic stubs.
+ */
+export async function reconcileAndApplyFacts(
+  db: Db,
+  scope: FactScope,
+  newMessages: Array<{ role: string; content: string }>,
+  deps: PipelineDeps,
+): Promise<FactOp[]> {
+  const candidates = await deps.extract(newMessages)
+  if (candidates.length === 0) return []
+
+  const candidatePoolSize = deps.candidatePoolSize ?? 5
+  const existingIdSet = new Map<string, ExistingFact>()
+  for (const c of candidates) {
+    const hits = await recallFacts(db, scope, c.embedding, c.text, {
+      topK: candidatePoolSize,
+    })
+    for (const h of hits) {
+      const prior = existingIdSet.get(h.id)
+      if (!prior || h.vsim > prior.vsim) {
+        existingIdSet.set(h.id, { id: h.id, text: h.text, vsim: h.vsim })
+      }
+    }
+  }
+  const existing = Array.from(existingIdSet.values())
+
+  const ops = await deps.reconcile({ scope, candidates, existing })
+  if (ops.length === 0) return []
+
+  const opsWithRun: FactOp[] = ops.map((op) => {
+    if (op.kind === 'NONE') return op
+    return { ...op, runId: op.runId ?? deps.runId ?? null }
+  })
+
+  await applyFactOps(db, scope, opsWithRun)
+  return opsWithRun
+}

--- a/src/persistence/index.ts
+++ b/src/persistence/index.ts
@@ -1,4 +1,5 @@
 export * from './client'
+export * from './facts'
 export * from './migrations'
 export * from './ownership'
 export * from './queries'

--- a/src/persistence/schema.ts
+++ b/src/persistence/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import {
+  type AnyPgColumn,
   index,
   integer,
   jsonb,
@@ -14,6 +15,8 @@ import {
 export const runStatus = pgEnum('run_status', ['running', 'completed', 'failed', 'cancelled'])
 
 export const stepRole = pgEnum('step_role', ['assistant', 'tool'])
+
+export const factEvent = pgEnum('fact_event', ['ADD', 'UPDATE', 'DELETE'])
 
 export const threads = pgTable(
   'threads',
@@ -147,6 +150,51 @@ export const knowledgeChunks = pgTable(
   ],
 )
 
+export const facts = pgTable(
+  'facts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    agentId: text('agent_id').notNull(),
+    channel: text('channel').notNull(),
+    threadId: text('thread_id'),
+    text: text('text').notNull(),
+    embedding: vector('embedding', { dimensions: 1536 }).notNull(),
+    hash: text('hash').notNull(),
+    attributedToRunId: uuid('attributed_to_run_id').references(() => runs.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    supersededBy: uuid('superseded_by').references((): AnyPgColumn => facts.id, {
+      onDelete: 'set null',
+    }),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (t) => [
+    index('facts_scope_idx').on(t.agentId, t.channel, t.threadId),
+    index('facts_live_hash_idx')
+      .on(t.agentId, t.channel, t.hash)
+      .where(sql`deleted_at IS NULL AND superseded_by IS NULL`),
+    index('facts_hnsw_idx').using('hnsw', sql`${t.embedding} vector_cosine_ops`),
+  ],
+)
+
+export const factHistory = pgTable(
+  'fact_history',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    factId: uuid('fact_id')
+      .notNull()
+      .references(() => facts.id, { onDelete: 'cascade' }),
+    event: factEvent('event').notNull(),
+    oldText: text('old_text'),
+    newText: text('new_text'),
+    runId: uuid('run_id').references(() => runs.id, { onDelete: 'set null' }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index('fact_history_fact_idx').on(t.factId), index('fact_history_run_idx').on(t.runId)],
+)
+
 export type Thread = typeof threads.$inferSelect
 export type NewThread = typeof threads.$inferInsert
 export type Run = typeof runs.$inferSelect
@@ -161,3 +209,7 @@ export type KnowledgeChunk = typeof knowledgeChunks.$inferSelect
 export type NewKnowledgeChunk = typeof knowledgeChunks.$inferInsert
 export type ThreadSummary = typeof threadSummaries.$inferSelect
 export type NewThreadSummary = typeof threadSummaries.$inferInsert
+export type Fact = typeof facts.$inferSelect
+export type NewFact = typeof facts.$inferInsert
+export type FactHistoryRow = typeof factHistory.$inferSelect
+export type NewFactHistoryRow = typeof factHistory.$inferInsert

--- a/tests/integration/facts.test.ts
+++ b/tests/integration/facts.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  applyFactOps,
+  createDb,
+  type DbHandle,
+  type ExtractedFact,
+  type FactExtractor,
+  type FactOp,
+  type FactReconciler,
+  type FactScope,
+  hashFactText,
+  normalizeFactText,
+  recallFacts,
+  reconcileAndApplyFacts,
+  runMigrations,
+} from '@/persistence'
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+const SCOPE: FactScope = { agentId: 'talos-eth', channel: 'cli', threadId: 't-facts' }
+
+describe('facts — text helpers', () => {
+  it('normalizes whitespace + case', () => {
+    expect(normalizeFactText('  Hello  WORLD  ')).toBe('hello world')
+    expect(normalizeFactText('Aave  on\tArbitrum\n')).toBe('aave on arbitrum')
+  })
+
+  it('hash collides on equivalent normalized text', () => {
+    expect(hashFactText('Aave on Arbitrum')).toBe(hashFactText('aave  on  arbitrum'))
+    expect(hashFactText('a')).not.toBe(hashFactText('b'))
+  })
+})
+
+describe('facts — applyFactOps', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('ADD inserts a live fact + history(ADD) row', async () => {
+    const result = await applyFactOps(handle.db, SCOPE, [
+      { kind: 'ADD', text: 'user prefers Aave on Arbitrum', embedding: fakeEmbedding(1) },
+    ])
+
+    expect(result.length).toBe(1)
+    const r = result[0]
+    expect(r).toBeDefined()
+    if (!r) return
+    expect(r.skipped).toBe(false)
+    expect(r.factId).not.toBeNull()
+
+    const factRows = await handle.pg.query<{ id: string; text: string; deleted_at: string | null }>(
+      `SELECT id, text, deleted_at FROM facts WHERE id = $1`,
+      [r.factId],
+    )
+    expect(factRows.rows.length).toBe(1)
+    expect(factRows.rows[0]?.text).toBe('user prefers Aave on Arbitrum')
+    expect(factRows.rows[0]?.deleted_at).toBeNull()
+
+    const hist = await handle.pg.query<{ event: string; new_text: string }>(
+      `SELECT event, new_text FROM fact_history WHERE fact_id = $1`,
+      [r.factId],
+    )
+    expect(hist.rows.length).toBe(1)
+    expect(hist.rows[0]?.event).toBe('ADD')
+    expect(hist.rows[0]?.new_text).toBe('user prefers Aave on Arbitrum')
+  })
+
+  it('ADD is hash-idempotent within scope (skipped on duplicate)', async () => {
+    const first = await applyFactOps(handle.db, SCOPE, [
+      { kind: 'ADD', text: 'main wallet 0xABCD', embedding: fakeEmbedding(2) },
+    ])
+    const second = await applyFactOps(handle.db, SCOPE, [
+      { kind: 'ADD', text: 'main  wallet  0xABCD', embedding: fakeEmbedding(2) },
+    ])
+
+    expect(first[0]?.skipped).toBe(false)
+    expect(second[0]?.skipped).toBe(true)
+    expect(second[0]?.factId).toBe(first[0]?.factId)
+
+    const hist = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM fact_history WHERE fact_id = $1`,
+      [first[0]?.factId],
+    )
+    expect(hist.rows[0]?.count).toBe('1')
+  })
+
+  it('UPDATE inserts a replacement, sets supersede pointer, writes history(UPDATE)', async () => {
+    const add = await applyFactOps(handle.db, SCOPE, [
+      { kind: 'ADD', text: 'user uses Compound', embedding: fakeEmbedding(3) },
+    ])
+    const oldId = add[0]?.factId
+    expect(oldId).toBeDefined()
+    if (!oldId) return
+
+    const upd = await applyFactOps(handle.db, SCOPE, [
+      {
+        kind: 'UPDATE',
+        targetId: oldId,
+        text: 'user prefers Aave over Compound',
+        embedding: fakeEmbedding(4),
+      },
+    ])
+    const newId = upd[0]?.factId
+    expect(newId).toBeDefined()
+    expect(newId).not.toBe(oldId)
+
+    const oldRow = await handle.pg.query<{ superseded_by: string | null }>(
+      `SELECT superseded_by FROM facts WHERE id = $1`,
+      [oldId],
+    )
+    expect(oldRow.rows[0]?.superseded_by).toBe(newId)
+
+    const hist = await handle.pg.query<{ event: string; old_text: string; new_text: string }>(
+      `SELECT event, old_text, new_text FROM fact_history WHERE fact_id = $1`,
+      [newId],
+    )
+    expect(hist.rows[0]?.event).toBe('UPDATE')
+    expect(hist.rows[0]?.old_text).toBe('user uses Compound')
+    expect(hist.rows[0]?.new_text).toBe('user prefers Aave over Compound')
+  })
+
+  it('UPDATE on missing target throws', async () => {
+    await expect(
+      applyFactOps(handle.db, SCOPE, [
+        {
+          kind: 'UPDATE',
+          targetId: '00000000-0000-0000-0000-000000000000',
+          text: 'noop',
+          embedding: fakeEmbedding(5),
+        },
+      ]),
+    ).rejects.toThrow(/UPDATE target .* not found/)
+  })
+
+  it('DELETE soft-deletes + writes history(DELETE)', async () => {
+    const add = await applyFactOps(handle.db, SCOPE, [
+      { kind: 'ADD', text: 'user holds USDC on mainnet', embedding: fakeEmbedding(6) },
+    ])
+    const id = add[0]?.factId
+    expect(id).toBeDefined()
+    if (!id) return
+
+    await applyFactOps(handle.db, SCOPE, [{ kind: 'DELETE', targetId: id }])
+
+    const row = await handle.pg.query<{ deleted_at: string | null; text: string }>(
+      `SELECT deleted_at, text FROM facts WHERE id = $1`,
+      [id],
+    )
+    expect(row.rows[0]?.deleted_at).not.toBeNull()
+    expect(row.rows[0]?.text).toBe('user holds USDC on mainnet')
+
+    const hist = await handle.pg.query<{
+      event: string
+      old_text: string
+      new_text: string | null
+    }>(
+      `SELECT event, old_text, new_text FROM fact_history
+       WHERE fact_id = $1 AND event = 'DELETE'`,
+      [id],
+    )
+    expect(hist.rows[0]?.event).toBe('DELETE')
+    expect(hist.rows[0]?.old_text).toBe('user holds USDC on mainnet')
+    expect(hist.rows[0]?.new_text).toBeNull()
+  })
+
+  it('NONE op writes nothing', async () => {
+    const result = await applyFactOps(handle.db, SCOPE, [{ kind: 'NONE' }])
+    expect(result[0]?.skipped).toBe(true)
+    const all = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM fact_history`,
+    )
+    expect(all.rows[0]?.count).toBe('0')
+  })
+
+  it('rejects wrong-dim embeddings before opening transaction', async () => {
+    await expect(
+      applyFactOps(handle.db, SCOPE, [{ kind: 'ADD', text: 'bad', embedding: [1, 2, 3] }]),
+    ).rejects.toThrow(/embedding must be 1536/)
+  })
+})
+
+describe('facts — recallFacts', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+
+    const seedScope: FactScope = { agentId: 'talos-eth', channel: 'cli', threadId: 't-recall' }
+    await applyFactOps(handle.db, seedScope, [
+      { kind: 'ADD', text: 'user prefers Aave on Arbitrum', embedding: fakeEmbedding(1) },
+      { kind: 'ADD', text: 'user holds 5 ETH on mainnet', embedding: fakeEmbedding(50) },
+      { kind: 'ADD', text: 'user uses Uniswap for swaps', embedding: fakeEmbedding(100) },
+    ])
+    // channel-wide fact (thread_id = null)
+    await applyFactOps(handle.db, { agentId: 'talos-eth', channel: 'cli', threadId: null }, [
+      { kind: 'ADD', text: "user's main wallet 0xCAFE", embedding: fakeEmbedding(1) },
+    ])
+    // unrelated scope (different channel) — must not leak
+    await applyFactOps(handle.db, { agentId: 'talos-eth', channel: 'tg', threadId: 't-recall' }, [
+      { kind: 'ADD', text: 'should never appear in cli recall', embedding: fakeEmbedding(1) },
+    ])
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('returns hits ordered by hybrid score, scoped per (agent, channel)', async () => {
+    const hits = await recallFacts(
+      handle.db,
+      { agentId: 'talos-eth', channel: 'cli', threadId: 't-recall' },
+      fakeEmbedding(1),
+      'aave arbitrum',
+      { topK: 5, includeChannelWide: true },
+    )
+
+    expect(hits.length).toBeGreaterThan(0)
+    for (let i = 1; i < hits.length; i++) {
+      const prev = hits[i - 1]
+      const curr = hits[i]
+      if (prev && curr) expect(prev.score).toBeGreaterThanOrEqual(curr.score)
+    }
+    expect(hits.some((h) => h.text.toLowerCase().includes('aave'))).toBe(true)
+    expect(hits.some((h) => h.text.includes('cli recall'))).toBe(false)
+  })
+
+  it('excludes channel-wide facts when includeChannelWide=false', async () => {
+    const hits = await recallFacts(
+      handle.db,
+      { agentId: 'talos-eth', channel: 'cli', threadId: 't-recall' },
+      fakeEmbedding(1),
+      'wallet',
+      { topK: 10, includeChannelWide: false },
+    )
+    expect(hits.some((h) => h.text.includes('main wallet'))).toBe(false)
+  })
+
+  it('skips superseded + deleted facts', async () => {
+    const scope: FactScope = { agentId: 'talos-eth', channel: 'cli', threadId: 't-recall' }
+    const live = await recallFacts(handle.db, scope, fakeEmbedding(1), 'aave', { topK: 10 })
+    const aave = live.find((h) => h.text.toLowerCase().includes('aave'))
+    expect(aave).toBeDefined()
+    if (!aave) return
+
+    await applyFactOps(handle.db, scope, [
+      {
+        kind: 'UPDATE',
+        targetId: aave.id,
+        text: 'user prefers Compound after all',
+        embedding: fakeEmbedding(200),
+      },
+    ])
+
+    const after = await recallFacts(handle.db, scope, fakeEmbedding(1), 'aave', { topK: 10 })
+    expect(after.find((h) => h.id === aave.id)).toBeUndefined()
+    expect(after.some((h) => h.text.includes('Compound after all'))).toBe(true)
+
+    const compound = after.find((h) => h.text.includes('Compound after all'))
+    if (compound) {
+      await applyFactOps(handle.db, scope, [{ kind: 'DELETE', targetId: compound.id }])
+      const final = await recallFacts(handle.db, scope, fakeEmbedding(1), 'aave', { topK: 10 })
+      expect(final.find((h) => h.id === compound.id)).toBeUndefined()
+    }
+  })
+
+  it('rejects wrong-dim query embeddings', async () => {
+    await expect(recallFacts(handle.db, SCOPE, [1, 2, 3], 'q')).rejects.toThrow(
+      /queryEmbedding must be 1536/,
+    )
+  })
+})
+
+describe('facts — reconcileAndApplyFacts (pipeline)', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('runs extract → reconcile → apply with mocked deps', async () => {
+    const scope: FactScope = { agentId: 'talos-eth', channel: 'cli', threadId: 't-pipe' }
+
+    const candidates: ExtractedFact[] = [
+      { text: 'user prefers Aave on Arbitrum', embedding: fakeEmbedding(1) },
+      { text: 'user holds 5 ETH on mainnet', embedding: fakeEmbedding(50) },
+    ]
+
+    const extract: FactExtractor = async () => candidates
+    const reconcile: FactReconciler = async ({ candidates: cands }) =>
+      cands.map<FactOp>((c) => ({ kind: 'ADD', text: c.text, embedding: c.embedding }))
+
+    const ops = await reconcileAndApplyFacts(
+      handle.db,
+      scope,
+      [{ role: 'user', content: 'I usually use Aave on Arbitrum and hold ~5 ETH on mainnet' }],
+      { extract, reconcile, runId: null },
+    )
+
+    expect(ops.length).toBe(2)
+    expect(ops.every((o) => o.kind === 'ADD')).toBe(true)
+
+    const hits = await recallFacts(handle.db, scope, fakeEmbedding(1), 'aave', { topK: 5 })
+    expect(hits.some((h) => h.text.includes('Aave on Arbitrum'))).toBe(true)
+  })
+
+  it('reconciler can return UPDATE based on existing facts', async () => {
+    const scope: FactScope = { agentId: 'talos-eth', channel: 'cli', threadId: 't-pipe2' }
+
+    await applyFactOps(handle.db, scope, [
+      { kind: 'ADD', text: 'user uses Compound', embedding: fakeEmbedding(3) },
+    ])
+
+    const extract: FactExtractor = async () => [
+      { text: 'user prefers Aave over Compound now', embedding: fakeEmbedding(4) },
+    ]
+
+    const reconcile: FactReconciler = async ({ existing, candidates: cands }) => {
+      const target = existing[0]
+      const cand = cands[0]
+      if (!target || !cand) return []
+      return [{ kind: 'UPDATE', targetId: target.id, text: cand.text, embedding: cand.embedding }]
+    }
+
+    const ops = await reconcileAndApplyFacts(
+      handle.db,
+      scope,
+      [{ role: 'user', content: 'switching from Compound to Aave' }],
+      { extract, reconcile },
+    )
+
+    expect(ops[0]?.kind).toBe('UPDATE')
+    const hits = await recallFacts(handle.db, scope, fakeEmbedding(4), 'aave', { topK: 5 })
+    expect(hits.some((h) => h.text.includes('prefers Aave over Compound now'))).toBe(true)
+  })
+
+  it('returns empty when extractor returns no candidates', async () => {
+    const scope: FactScope = { agentId: 'talos-eth', channel: 'cli', threadId: 't-empty' }
+    const ops = await reconcileAndApplyFacts(handle.db, scope, [], {
+      extract: async () => [],
+      reconcile: async () => {
+        throw new Error('reconcile should not be called')
+      },
+    })
+    expect(ops).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #17.

## Summary

Adds the Mem0-style fact tier on top of `message_embeddings`. Vector-searching raw chat smears preference signal; distilled facts are the right primitive for "user prefers Aave" or "main wallet 0x...".

This is **additive** to the locked schema. `message_embeddings` stays the home of episodic recall ("what did we say last Tuesday"). `facts` is the new home of distilled state. Two stores, two retrieval intents.

## Schema

```ts
fact_event = ENUM('ADD', 'UPDATE', 'DELETE')

facts(
  id uuid pk,
  agent_id text not null,
  channel text not null,
  thread_id text,                    -- null = channel-wide
  text text not null,
  embedding vector(1536) not null,
  hash text not null,                -- md5 of normalized text
  attributed_to_run_id uuid fk runs,
  created_at, updated_at,
  superseded_by uuid fk facts,       -- supersede pointer for UPDATE
  deleted_at,                        -- soft delete
)
+ btree(agent_id, channel, thread_id)
+ partial btree(agent_id, channel, hash) WHERE deleted_at IS NULL AND superseded_by IS NULL
+ HNSW(embedding)

fact_history(
  id uuid pk,
  fact_id uuid fk facts cascade,
  event fact_event,
  old_text, new_text,
  run_id uuid fk runs,
  created_at,
)  -- append-only audit log
```

`thread_id IS NULL` means "applies to all threads in (agent, channel)" (e.g. "user's main wallet"). Per-thread facts override channel-wide on tie.

## Pipeline

`src/persistence/facts.ts` ships the **data plane**. The LLM-backed extractor + reconciler live in the runtime (#7) and pass in as injected dependencies, so tests use deterministic stubs.

```
extract(messages) -> ExtractedFact[]
                        |
                        v
recallFacts(scope, candidate.embedding, candidate.text) -> ExistingFact[]
                        |
                        v
reconcile({ scope, candidates, existing }) -> FactOp[]
                        |
                        v
applyFactOps(scope, ops) -> [{ op, factId, skipped }]
```

**Op semantics:**
- `ADD`: insert new live fact + history(ADD). Hash-idempotent within (agent, channel) scope.
- `UPDATE`: insert replacement, set old.superseded_by = new.id, history(UPDATE).
- `DELETE`: set deleted_at = now(), history(DELETE).
- `NONE`: no-op.

All ops in a single transaction.

## Recall

`recallFacts(db, scope, queryEmbedding, queryText, opts)` runs the same hybrid scoring as `searchMessages`:

```
score = (1 - cosine_distance) * 0.7 + ts_rank(...) * 0.3
```

over a top-N vector pool, filtered to live (deleted_at IS NULL, superseded_by IS NULL) facts in scope. Channel-wide facts can be included via `includeChannelWide: true` (default).

## Verification

- `pnpm typecheck` green
- `pnpm lint` green
- `pnpm test` green (38 passed, 1 todo)
- `pnpm build` green

## Tests (16 new cases)

- normalizeFactText / hashFactText
- ADD: writes fact + history; hash-idempotent on dup
- UPDATE: supersede pointer set, history captures old + new text; missing target throws
- DELETE: soft-delete + history; new_text null
- NONE: writes nothing
- dim validation rejected before transaction opens
- recallFacts: scope filter (different channel does not leak), channel-wide toggle, hides superseded + deleted, dim validation
- pipeline: ADD path, UPDATE path with existing facts surfaced via recall, empty extractor short-circuits

## Out of scope (future PRs)

- LLM-backed FactExtractor + FactReconciler implementations - belong in #7 runtime
- Entity extraction + entity_facts junction (Mem0's `{collection}_entities`)
- Fact pruning / TTL
- Cross-channel preference recall ranking with recency boost
- pg_trgm-backed lemmatization (relies on #15)