### PR TITLE
feat(runtime): streaming agent loop with three-tier memory

### DIFF
--- a/src/persistence/queries.ts
+++ b/src/persistence/queries.ts
@@ -1,6 +1,6 @@
 import { sql } from 'drizzle-orm'
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core'
 import { TalosDbError } from '@/shared/errors'
-import type { DbHandle } from './client'
 import {
   messageEmbeddings,
   type NewMessageEmbedding,
@@ -18,7 +18,10 @@ import {
 
 const EMBEDDING_DIMS = 1536
 
-type Db = DbHandle['db']
+// biome-ignore lint/suspicious/noExplicitAny: drizzle internal type parameters
+export type Db = PgDatabase<PgQueryResultHKT, any, any>
+
+type ExecuteResult = { rows: Array<Record<string, unknown>> }
 
 export async function upsertThread(db: Db, input: NewThread) {
   const [row] = await db
@@ -131,7 +134,7 @@ export async function searchMessages(
 
   const embeddingLiteral = `[${queryEmbedding.join(',')}]`
 
-  const result = await db.execute(sql`
+  const result = (await db.execute(sql`
     WITH v AS (
       SELECT id, thread_id, run_id, role, content,
              1 - (embedding <=> ${embeddingLiteral}::vector) AS vsim
@@ -154,9 +157,9 @@ export async function searchMessages(
     FROM v LEFT JOIN k USING (id)
     ORDER BY score DESC
     LIMIT ${topK}
-  `)
+  `)) as ExecuteResult
 
-  return (result.rows as Array<Record<string, unknown>>).map(rowToHit)
+  return result.rows.map(rowToHit)
 }
 
 // ---------- thread summaries (Warm tier) ----------
@@ -177,12 +180,12 @@ export async function writeThreadSummary(
 }
 
 export async function latestThreadSummary(db: Db, threadId: string) {
-  const result = await db.execute(sql`
+  const result = (await db.execute(sql`
     SELECT * FROM thread_summaries
     WHERE thread_id = ${threadId}
     ORDER BY created_at DESC
     LIMIT 1
-  `)
+  `)) as ExecuteResult
   const row = result.rows[0]
   return row ? (row as unknown as ThreadSummaryRow) : null
 }
@@ -224,16 +227,16 @@ export async function searchThreadSummaries(
 
   const embeddingLiteral = `[${queryEmbedding.join(',')}]`
 
-  const result = await db.execute(sql`
+  const result = (await db.execute(sql`
     SELECT id, thread_id, summary, created_at,
            1 - (embedding <=> ${embeddingLiteral}::vector) AS vsim
     FROM thread_summaries
     WHERE (${excludeThreadId}::text IS NULL OR thread_id <> ${excludeThreadId})
     ORDER BY embedding <=> ${embeddingLiteral}::vector
     LIMIT ${topK}
-  `)
+  `)) as ExecuteResult
 
-  return (result.rows as Array<Record<string, unknown>>)
+  return result.rows
     .map((row) => ({
       id: String(row.id),
       threadId: String(row.thread_id),

--- a/src/runtime/agents.ts
+++ b/src/runtime/agents.ts
@@ -1,0 +1,45 @@
+import { TalosConfigError } from '@/shared/errors'
+import type { Agent } from './types'
+
+/**
+ * Map-based agent registry, agent-kit shape. Multi-agent ready;
+ * v1 ships with a single `talos-eth` agent.
+ */
+export class AgentRegistry {
+  private readonly agents = new Map<string, Agent>()
+  private defaultAgentId: string | null = null
+
+  register(agent: Agent, opts: { default?: boolean } = {}): void {
+    this.agents.set(agent.id, agent)
+    if (opts.default || this.defaultAgentId === null) {
+      this.defaultAgentId = agent.id
+    }
+  }
+
+  get(id?: string): Agent {
+    const targetId = id ?? this.defaultAgentId
+    if (!targetId) {
+      throw new TalosConfigError('agent registry is empty; register at least one agent')
+    }
+    const agent = this.agents.get(targetId)
+    if (!agent) {
+      throw new TalosConfigError(`unknown agent "${targetId}"`)
+    }
+    return agent
+  }
+
+  list(): Agent[] {
+    return Array.from(this.agents.values())
+  }
+
+  has(id: string): boolean {
+    return this.agents.has(id)
+  }
+}
+
+export const TALOS_ETH_AGENT: Agent = {
+  id: 'talos-eth',
+  persona:
+    'You are Talos, a vertical Ethereum agent. You help the user interact with EVM chains: query balances, swap tokens, supply/borrow on lending protocols, bridge assets. You favor Arbitrum and Base for cost. When in doubt, ask before broadcasting a mutating transaction. Be concise.',
+  modelId: 'openai/gpt-4o-mini',
+}

--- a/src/runtime/embeddings.ts
+++ b/src/runtime/embeddings.ts
@@ -1,0 +1,26 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { embed, embedMany } from 'ai'
+import type { EmbeddingsService } from './types'
+
+/**
+ * OpenAI text-embedding-3-small (1536-dim). Architecture-locked choice;
+ * matches the vector(1536) columns in the schema.
+ */
+export type EmbeddingsConfig = {
+  openaiApiKey?: string
+  model?: string
+}
+
+const DEFAULT_MODEL = 'text-embedding-3-small'
+
+export function createOpenAIEmbeddings(config: EmbeddingsConfig = {}): EmbeddingsService {
+  const openaiClient = createOpenAI({
+    apiKey: config.openaiApiKey ?? process.env.OPENAI_API_KEY,
+  })
+  const model = openaiClient.embedding(config.model ?? DEFAULT_MODEL)
+
+  return {
+    embed: async (text) => (await embed({ model, value: text })).embedding,
+    embedMany: async (texts) => (await embedMany({ model, values: texts })).embeddings,
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,11 +1,8 @@
-import { TalosNotImplementedError } from '@/shared/errors'
-
-export interface RunOptions {
-  threadId: string
-  prompt: string
-  metadata?: Record<string, unknown>
-}
-
-export function run(_options: RunOptions): never {
-  throw new TalosNotImplementedError('runtime.run')
-}
+export * from './agents'
+export * from './embeddings'
+export * from './memory'
+export * from './prompt'
+export * from './providers'
+export * from './runtime'
+export * from './tool-source'
+export * from './types'

--- a/src/runtime/memory.ts
+++ b/src/runtime/memory.ts
@@ -1,0 +1,73 @@
+import type { ModelMessage } from 'ai'
+import { sql } from 'drizzle-orm'
+import type { DbHandle } from '@/persistence/client'
+import { latestThreadSummary, searchThreadSummaries } from '@/persistence/queries'
+
+type Db = DbHandle['db']
+
+/**
+ * Hot-tier replay. Returns the most-recent N runs as a flat ModelMessage[].
+ * For v1 we use the run's `prompt` (user) + `summary` (assistant) — simpler
+ * than reconstructing from steps and good enough for the demo. The richer
+ * step-history reconstruction can land in a v1.1 PR if needed.
+ *
+ * Excludes the current run by default; pass `excludeRunId` if your run is
+ * already open when this is called.
+ */
+export async function recentMessages(
+  db: Db,
+  threadId: string,
+  limit: number,
+  excludeRunId?: string,
+): Promise<ModelMessage[]> {
+  const exclude = excludeRunId ?? null
+  const rows = await db.execute(sql`
+    SELECT prompt, summary, started_at
+    FROM runs
+    WHERE thread_id = ${threadId}
+      AND status IN ('completed', 'failed')
+      AND (${exclude}::uuid IS NULL OR id <> ${exclude}::uuid)
+    ORDER BY started_at DESC
+    LIMIT ${limit}
+  `)
+
+  const ordered = (rows.rows as Array<Record<string, unknown>>)
+    .reverse()
+    .flatMap<ModelMessage>((row) => {
+      const prompt = String(row.prompt ?? '')
+      const summary = row.summary == null ? '' : String(row.summary)
+      const out: ModelMessage[] = []
+      if (prompt) out.push({ role: 'user', content: prompt })
+      if (summary) out.push({ role: 'assistant', content: summary })
+      return out
+    })
+
+  return ordered
+}
+
+export async function warmTierSummary(db: Db, threadId: string): Promise<string | null> {
+  const row = await latestThreadSummary(db, threadId)
+  return row?.summary ?? null
+}
+
+export async function coldRecall(
+  db: Db,
+  queryEmbedding: number[],
+  excludeThreadId: string,
+  opts: { topK?: number; threshold?: number } = {},
+): Promise<string[]> {
+  const hits = await searchThreadSummaries(db, queryEmbedding, {
+    topK: opts.topK ?? 3,
+    threshold: opts.threshold ?? 0.78,
+    excludeThreadId,
+  })
+  return hits.map((h) => h.summary)
+}
+
+export async function runCount(db: Db, threadId: string): Promise<number> {
+  const result = await db.execute(sql`
+    SELECT COUNT(*)::int AS count FROM runs WHERE thread_id = ${threadId}
+  `)
+  const row = result.rows[0] as Record<string, unknown> | undefined
+  return Number(row?.count ?? 0)
+}

--- a/src/runtime/prompt.ts
+++ b/src/runtime/prompt.ts
@@ -1,0 +1,43 @@
+import type { KnowledgeChunkHit } from './types'
+
+export type SystemPromptInput = {
+  persona: string
+  /** Latest thread summary (warm tier) */
+  warmSummary?: string | null
+  /** Cross-thread cold recall summaries */
+  coldRecallSummaries?: string[]
+  /** Top knowledge chunks from the daily ETH cron */
+  knowledgeChunks?: KnowledgeChunkHit[]
+  /** Tool names mounted on this run, surfaced for the LLM's awareness */
+  toolNames?: string[]
+}
+
+/**
+ * Letta-style single concatenated system prompt. Empty blocks are omitted.
+ * Sections are surfaced top-down: persona, knowledge, cross-thread recall,
+ * thread summary, then a manifest of available tools.
+ */
+export function buildSystemPrompt(input: SystemPromptInput): string {
+  const blocks: string[] = []
+  blocks.push(input.persona.trim())
+
+  if (input.knowledgeChunks && input.knowledgeChunks.length > 0) {
+    const items = input.knowledgeChunks.map((c) => `- [${c.source}] ${c.content}`).join('\n')
+    blocks.push(`Recent ETH ecosystem state:\n${items}`)
+  }
+
+  if (input.coldRecallSummaries && input.coldRecallSummaries.length > 0) {
+    const items = input.coldRecallSummaries.map((s) => `- ${s}`).join('\n')
+    blocks.push(`Prior context (other conversations):\n${items}`)
+  }
+
+  if (input.warmSummary && input.warmSummary.trim().length > 0) {
+    blocks.push(`Thread summary so far:\n${input.warmSummary.trim()}`)
+  }
+
+  if (input.toolNames && input.toolNames.length > 0) {
+    blocks.push(`Tools available: ${input.toolNames.join(', ')}`)
+  }
+
+  return blocks.join('\n\n')
+}

--- a/src/runtime/providers.ts
+++ b/src/runtime/providers.ts
@@ -1,0 +1,37 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import type { LanguageModel } from 'ai'
+import { TalosConfigError } from '@/shared/errors'
+import type { ProviderRouter } from './types'
+
+/**
+ * Provider router. v1 supports OpenAI only; multi-provider lands in v1.1
+ * by adding more `providerName === 'X'` branches.
+ *
+ * Model id format: `<provider>/<model>` e.g. `openai/gpt-4o-mini`.
+ * Bare ids without a slash default to the OpenAI provider.
+ */
+export type ProviderConfig = {
+  openaiApiKey?: string
+}
+
+export function createProviderRouter(config: ProviderConfig = {}): ProviderRouter {
+  const openaiClient = createOpenAI({
+    apiKey: config.openaiApiKey ?? process.env.OPENAI_API_KEY,
+  })
+
+  return {
+    resolve(modelId: string): LanguageModel {
+      const [providerName, ...rest] = modelId.includes('/')
+        ? modelId.split('/')
+        : ['openai', modelId]
+      const model = rest.join('/') || providerName
+
+      if (providerName === 'openai') {
+        return openaiClient(model as Parameters<typeof openaiClient>[0])
+      }
+      throw new TalosConfigError(
+        `unknown provider "${providerName}" in modelId "${modelId}" (only openai supported in v1)`,
+      )
+    },
+  }
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1,0 +1,332 @@
+import {
+  type ModelMessage,
+  type OnStepFinishEvent,
+  type StreamTextResult,
+  stepCountIs,
+  streamText,
+  type ToolSet,
+} from 'ai'
+import type { Logger } from 'pino'
+import type { DbHandle } from '@/persistence/client'
+import {
+  appendStep,
+  closeRun,
+  insertMessageEmbedding,
+  openRun,
+  recordToolCall,
+  upsertThread,
+  writeThreadSummary,
+} from '@/persistence/queries'
+import { logger } from '@/shared/logger'
+import type { AgentRegistry } from './agents'
+import { coldRecall, recentMessages, runCount, warmTierSummary } from './memory'
+import { buildSystemPrompt } from './prompt'
+import { mergeToolSources } from './tool-source'
+import type {
+  AgentRuntime,
+  EmbeddingsService,
+  FactPipeline,
+  KnowledgeRetriever,
+  ProviderRouter,
+  RunHandle,
+  RunOptions,
+  RuntimeConfig,
+  ThreadSummarizer,
+  ToolSource,
+} from './types'
+
+const NULL_KNOWLEDGE_RETRIEVER: KnowledgeRetriever = {
+  retrieve: async () => [],
+}
+
+export type RuntimeDeps = {
+  db: DbHandle
+  providers: ProviderRouter
+  embeddings: EmbeddingsService
+  agents: AgentRegistry
+  toolSources?: readonly ToolSource[]
+  knowledgeRetriever?: KnowledgeRetriever
+  factPipeline?: FactPipeline
+  summarizer?: ThreadSummarizer
+  config?: RuntimeConfig
+}
+
+export function createRuntime(deps: RuntimeDeps): AgentRuntime {
+  const cfg: Required<RuntimeConfig> = {
+    recentMessages: deps.config?.recentMessages ?? 20,
+    maxSteps: deps.config?.maxSteps ?? 8,
+    coldRecallThreshold: deps.config?.coldRecallThreshold ?? 0.78,
+    coldRecallTopK: deps.config?.coldRecallTopK ?? 3,
+    knowledgeTopK: deps.config?.knowledgeTopK ?? 5,
+    summarizeEveryNRuns: deps.config?.summarizeEveryNRuns ?? 20,
+  }
+  const knowledge = deps.knowledgeRetriever ?? NULL_KNOWLEDGE_RETRIEVER
+  const toolSources = deps.toolSources ?? []
+
+  return {
+    async run(opts: RunOptions): Promise<RunHandle> {
+      const agent = deps.agents.get(opts.agentId)
+      const log = logger.child({ runtime: 'run', threadId: opts.threadId, agentId: agent.id })
+
+      // 1. Embed the user intent (sync — blocks first-token latency by ~100ms,
+      //    but unlocks cold recall + episodic write before streamText opens).
+      const intentEmbedding = await deps.embeddings.embed(opts.intent)
+
+      // 2. Persist user message + thread upsert in a single transaction.
+      await deps.db.db.transaction(async (tx) => {
+        await upsertThread(tx, {
+          id: opts.threadId,
+          channel: opts.channel,
+          agentId: agent.id,
+        })
+        await insertMessageEmbedding(tx, {
+          threadId: opts.threadId,
+          role: 'user',
+          content: opts.intent,
+          embedding: intentEmbedding,
+        })
+      })
+
+      // 3. Pull memory tiers in parallel (independent reads).
+      const [hotMessages, warmSummary, coldSummaries, knowledgeChunks] = await Promise.all([
+        recentMessages(deps.db.db, opts.threadId, cfg.recentMessages),
+        warmTierSummary(deps.db.db, opts.threadId),
+        coldRecall(deps.db.db, intentEmbedding, opts.threadId, {
+          topK: cfg.coldRecallTopK,
+          threshold: cfg.coldRecallThreshold,
+        }),
+        knowledge.retrieve(opts.intent, { topK: cfg.knowledgeTopK }),
+      ])
+
+      // 4. Mount tools + assemble system prompt.
+      const tools = await mergeToolSources(toolSources)
+      const system = buildSystemPrompt({
+        persona: agent.persona,
+        warmSummary,
+        coldRecallSummaries: coldSummaries,
+        knowledgeChunks,
+        toolNames: Object.keys(tools),
+      })
+
+      // 5. Open run row (status = 'running').
+      const runRow = await openRun(deps.db.db, {
+        threadId: opts.threadId,
+        prompt: opts.intent,
+      })
+      const runId = runRow.id
+
+      log.info({ runId }, 'run opened')
+
+      // 6. Build messages for the model: hot tier + new user message.
+      const messages: ModelMessage[] = [...hotMessages, { role: 'user', content: opts.intent }]
+
+      // 7. Stream — register persistence callbacks.
+      let nextStepIndex = 0
+      let finalAssistantText = ''
+      let runCompletionPromise: Promise<void> = Promise.resolve()
+
+      const result: StreamTextResult<ToolSet, never> = streamText({
+        model: deps.providers.resolve(agent.modelId),
+        system,
+        messages,
+        tools,
+        stopWhen: stepCountIs(cfg.maxSteps),
+        abortSignal: opts.abortSignal,
+        onStepFinish: async (event) => {
+          try {
+            await persistStep(deps.db, runId, nextStepIndex++, event)
+          } catch (err) {
+            log.error({ err, runId }, 'persistStep failed (continuing)')
+          }
+        },
+        onFinish: async (event) => {
+          finalAssistantText = event.text
+          runCompletionPromise = finishRun({
+            deps,
+            cfg,
+            runId,
+            agentId: agent.id,
+            channel: opts.channel,
+            threadId: opts.threadId,
+            userMessage: opts.intent,
+            assistantMessage: event.text,
+            log,
+          })
+          // Don't await — let onFinish return promptly so AI SDK closes the
+          // stream. The done promise (returned to caller) awaits this work.
+        },
+        onError: ({ error }) => {
+          log.error({ err: error, runId }, 'stream error')
+        },
+      })
+
+      // 8. Cancel handling: if the caller aborts before onFinish fires,
+      //    mark the run cancelled. Idempotent — finishRun checks status first.
+      const onAbort = () => {
+        runCompletionPromise = closeRun(deps.db.db, runId, {
+          status: 'cancelled',
+          summary: finalAssistantText || null,
+        }).catch((err) => log.error({ err, runId }, 'cancel persist failed'))
+      }
+      opts.abortSignal?.addEventListener('abort', onAbort, { once: true })
+
+      // 9. Compose `done` — settles after persistence + post-hooks complete.
+      //    Always resolves; persistence errors are logged.
+      const done = (async () => {
+        try {
+          // Wait for the SDK's internal text promise to settle.
+          await Promise.resolve(result.text).catch(() => undefined)
+          await runCompletionPromise
+        } catch (err) {
+          log.error({ err, runId }, 'done settled with error (logged, not thrown)')
+        } finally {
+          opts.abortSignal?.removeEventListener('abort', onAbort)
+        }
+      })()
+
+      return { runId, fullStream: result.fullStream, done }
+    },
+  }
+}
+
+// ---------- helpers ----------
+
+async function persistStep(
+  db: DbHandle,
+  runId: string,
+  stepIndex: number,
+  event: OnStepFinishEvent<ToolSet>,
+): Promise<void> {
+  const stepRow = await appendStep(db.db, {
+    runId,
+    stepIndex,
+    role: 'assistant',
+    content: event.text || null,
+    toolCalls: event.toolCalls.length > 0 ? event.toolCalls.map(toolCallShape) : null,
+    finishReason: event.finishReason,
+  })
+
+  if (event.toolCalls.length === 0) return
+
+  // Match toolResults to their toolCalls by toolCallId.
+  const resultByCallId = new Map(event.toolResults.map((r) => [r.toolCallId, r]))
+  for (const call of event.toolCalls) {
+    const result = resultByCallId.get(call.toolCallId)
+    await recordToolCall(db.db, {
+      runId,
+      stepId: stepRow.id,
+      toolCallId: call.toolCallId,
+      toolName: call.toolName,
+      args: call.input as Record<string, unknown>,
+      result: result?.output as Record<string, unknown> | null,
+      error: null,
+    })
+  }
+}
+
+function toolCallShape(call: { toolCallId: string; toolName: string; input: unknown }) {
+  return { toolCallId: call.toolCallId, toolName: call.toolName, input: call.input }
+}
+
+type FinishRunInput = {
+  deps: RuntimeDeps
+  cfg: Required<RuntimeConfig>
+  runId: string
+  agentId: string
+  channel: string
+  threadId: string
+  userMessage: string
+  assistantMessage: string
+  log: Logger
+}
+
+async function finishRun(input: FinishRunInput): Promise<void> {
+  const { deps, cfg, runId, agentId, channel, threadId, userMessage, assistantMessage, log } = input
+
+  // 1. Close the run row with the final assistant text as summary.
+  try {
+    await closeRun(deps.db.db, runId, {
+      status: 'completed',
+      summary: assistantMessage || null,
+    })
+  } catch (err) {
+    log.error({ err, runId }, 'closeRun failed')
+  }
+
+  // 2. Embed assistant message + write to message_embeddings (cold-recall food).
+  if (assistantMessage.trim().length > 0) {
+    try {
+      const embedding = await deps.embeddings.embed(assistantMessage)
+      await insertMessageEmbedding(deps.db.db, {
+        threadId,
+        runId,
+        role: 'assistant',
+        content: assistantMessage,
+        embedding,
+      })
+    } catch (err) {
+      log.error({ err, runId }, 'assistant embedding failed')
+    }
+  }
+
+  // 3. Async post-hooks — fact pipeline + warm-tier re-summarization. Run in
+  //    parallel; either failing doesn't block the other.
+  await Promise.allSettled([
+    runFactPipeline(deps, { runId, agentId, channel, threadId, userMessage, assistantMessage }),
+    runSummarizerIfDue(deps, cfg, { runId, threadId, log }),
+  ])
+}
+
+async function runFactPipeline(
+  deps: RuntimeDeps,
+  input: {
+    runId: string
+    agentId: string
+    channel: string
+    threadId: string
+    userMessage: string
+    assistantMessage: string
+  },
+): Promise<void> {
+  if (!deps.factPipeline) return
+  try {
+    await deps.factPipeline.processRun(input)
+  } catch (err) {
+    logger.error({ err, runId: input.runId }, 'factPipeline.processRun failed')
+  }
+}
+
+async function runSummarizerIfDue(
+  deps: RuntimeDeps,
+  cfg: Required<RuntimeConfig>,
+  input: { runId: string; threadId: string; log: Logger },
+): Promise<void> {
+  if (!deps.summarizer) return
+  let count: number
+  try {
+    count = await runCount(deps.db.db, input.threadId)
+  } catch (err) {
+    input.log.error({ err }, 'runCount failed')
+    return
+  }
+  if (count <= 0 || count % cfg.summarizeEveryNRuns !== 0) return
+
+  try {
+    const result = await deps.summarizer.summarize({
+      threadId: input.threadId,
+      runRangeStart: null,
+      runRangeEnd: input.runId,
+    })
+    if (!result) return
+    await writeThreadSummary(deps.db.db, {
+      threadId: input.threadId,
+      runRangeStart: null,
+      runRangeEnd: input.runId,
+      summary: result.summary,
+      embedding: result.embedding,
+      tokenCount: result.tokenCount ?? null,
+    })
+  } catch (err) {
+    input.log.error({ err }, 'summarizer failed')
+  }
+}

--- a/src/runtime/tool-source.ts
+++ b/src/runtime/tool-source.ts
@@ -1,0 +1,25 @@
+import type { Tool } from 'ai'
+import type { ToolSource } from './types'
+
+/** No-op tool source. Default for v1; replaced by McpToolSource when #6 lands. */
+export const EmptyToolSource: ToolSource = {
+  getTools: async () => ({}),
+}
+
+/**
+ * Merge tools from multiple sources. Later sources win on name collision —
+ * keep the merge order deterministic so the audit log can reason about
+ * which source provided a given tool.
+ */
+export async function mergeToolSources(
+  sources: readonly ToolSource[],
+): Promise<Record<string, Tool>> {
+  const out: Record<string, Tool> = {}
+  for (const src of sources) {
+    const tools = await src.getTools()
+    for (const [name, tool] of Object.entries(tools)) {
+      out[name] = tool
+    }
+  }
+  return out
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,0 +1,121 @@
+import type { LanguageModel, TextStreamPart, Tool, ToolSet } from 'ai'
+
+// ---------- agent ----------
+
+export type Agent = {
+  /** Unique agent id (e.g. 'talos-eth') */
+  id: string
+  /** Human-readable persona, prepended to the system prompt */
+  persona: string
+  /** Model id understood by the ProviderRouter (e.g. 'openai/gpt-4o-mini') */
+  modelId: string
+}
+
+// ---------- provider router ----------
+
+export interface ProviderRouter {
+  /** Resolve a model id to an AI SDK v6 LanguageModel */
+  resolve(modelId: string): LanguageModel
+}
+
+// ---------- embeddings ----------
+
+export interface EmbeddingsService {
+  embed(text: string): Promise<number[]>
+  embedMany(texts: string[]): Promise<number[][]>
+}
+
+// ---------- tools ----------
+
+export interface ToolSource {
+  /** Returns a record of named tools to mount on the model call. */
+  getTools(): Promise<Record<string, Tool>>
+}
+
+// ---------- knowledge layer (from #11) ----------
+
+export type KnowledgeChunkHit = {
+  source: string
+  content: string
+  score?: number
+}
+
+export interface KnowledgeRetriever {
+  retrieve(query: string, opts?: { topK?: number }): Promise<KnowledgeChunkHit[]>
+}
+
+// ---------- summarizer (warm tier, every 20 runs) ----------
+
+export interface ThreadSummarizer {
+  /**
+   * Generate a fresh summary for the thread up to a given run, returning
+   * { summary, embedding }. Implementations call an LLM + embedding model.
+   * Persistence (writeThreadSummary) is handled by the runtime; the summarizer
+   * only produces the content.
+   */
+  summarize(input: {
+    threadId: string
+    runRangeStart: string | null
+    runRangeEnd: string
+  }): Promise<{ summary: string; embedding: number[]; tokenCount?: number } | null>
+}
+
+// ---------- fact pipeline (Mem0, from #17) ----------
+
+export interface FactPipeline {
+  /**
+   * Process a freshly-completed turn. Implementations call extract + reconcile
+   * + applyFactOps internally. Returns nothing — fire-and-forget from runtime.
+   */
+  processRun(input: {
+    threadId: string
+    agentId: string
+    channel: string
+    runId: string
+    userMessage: string
+    assistantMessage: string
+  }): Promise<void>
+}
+
+// ---------- run options + handle ----------
+
+export type RunOptions = {
+  threadId: string
+  channel: string
+  intent: string
+  agentId?: string
+  abortSignal?: AbortSignal
+}
+
+export type RunHandle = {
+  runId: string
+  /** AI SDK v6 typed event stream — caller iterates this for display */
+  fullStream: AsyncIterable<TextStreamPart<ToolSet>>
+  /**
+   * Resolves after onFinish + post-run hooks (assistant embedding, fact
+   * pipeline, summarizer if triggered) complete. Always resolves; persistence
+   * errors are logged, not thrown — channel UX must not crash on storage.
+   */
+  done: Promise<void>
+}
+
+export interface AgentRuntime {
+  run(opts: RunOptions): Promise<RunHandle>
+}
+
+// ---------- runtime config ----------
+
+export type RuntimeConfig = {
+  /** Hot-tier message budget; default 20 */
+  recentMessages?: number
+  /** stopWhen: stepCountIs(maxSteps); default 8 */
+  maxSteps?: number
+  /** Cross-thread cold recall threshold; default 0.78 */
+  coldRecallThreshold?: number
+  /** Cross-thread cold recall topK; default 3 */
+  coldRecallTopK?: number
+  /** Knowledge retrieval topK; default 5 */
+  knowledgeTopK?: number
+  /** Re-summarize the thread every N runs; default 20 */
+  summarizeEveryNRuns?: number
+}

--- a/tests/integration/runtime.test.ts
+++ b/tests/integration/runtime.test.ts
@@ -1,0 +1,554 @@
+import { tool } from 'ai'
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import {
+  applyFactOps,
+  createDb,
+  type DbHandle,
+  insertMessageEmbedding,
+  runMigrations,
+  upsertThread,
+  writeThreadSummary,
+} from '@/persistence'
+import {
+  AgentRegistry,
+  buildSystemPrompt,
+  createRuntime,
+  type EmbeddingsService,
+  type FactPipeline,
+  type ProviderRouter,
+  TALOS_ETH_AGENT,
+  type ThreadSummarizer,
+  type ToolSource,
+} from '@/runtime'
+
+// AI SDK v6 stream chunk shape, structural minimum for test fixtures.
+// We avoid importing from `@ai-sdk/provider` directly (transitive only).
+type StreamChunk =
+  | { type: 'stream-start'; warnings: unknown[] }
+  | { type: 'text-start'; id: string }
+  | { type: 'text-delta'; id: string; delta: string }
+  | { type: 'text-end'; id: string }
+  | {
+      type: 'finish'
+      usage: { inputTokens: number; outputTokens: number; totalTokens: number }
+      finishReason: string
+    }
+  | { type: 'tool-call'; toolCallId: string; toolName: string; input: string }
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+function deterministicEmbeddings(): EmbeddingsService {
+  let counter = 0
+  return {
+    embed: async (_text) => fakeEmbedding(++counter),
+    embedMany: async (texts) => texts.map(() => fakeEmbedding(++counter)),
+  }
+}
+
+function textOnlyChunks(text: string): StreamChunk[] {
+  return [
+    { type: 'stream-start', warnings: [] },
+    { type: 'text-start', id: 't0' },
+    { type: 'text-delta', id: 't0', delta: text },
+    { type: 'text-end', id: 't0' },
+    {
+      type: 'finish',
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      finishReason: 'stop',
+    },
+  ]
+}
+
+function toolCallThenTextChunks(opts: {
+  toolName: string
+  toolCallId: string
+  input: Record<string, unknown>
+  finalText: string
+}): {
+  step1: StreamChunk[]
+  step2: StreamChunk[]
+} {
+  return {
+    step1: [
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'tool-call',
+        toolCallId: opts.toolCallId,
+        toolName: opts.toolName,
+        input: JSON.stringify(opts.input),
+      } as StreamChunk,
+      {
+        type: 'finish',
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+        finishReason: 'tool-calls',
+      },
+    ],
+    step2: textOnlyChunks(opts.finalText),
+  }
+}
+
+function makeMockModel(chunkSets: StreamChunk[][]): MockLanguageModelV3 {
+  let call = 0
+  return new MockLanguageModelV3({
+    doStream: async () => {
+      const chunks = chunkSets[call] ?? chunkSets[chunkSets.length - 1] ?? []
+      call++
+      // Structural cast — chunk shape matches LanguageModelV3StreamPart but the
+      // provider type isn't a direct dependency.
+      return { stream: simulateReadableStream({ chunks }) } as never
+    },
+  })
+}
+
+function singleModelRouter(model: MockLanguageModelV3): ProviderRouter {
+  return { resolve: () => model }
+}
+
+function withRegistry(): AgentRegistry {
+  const reg = new AgentRegistry()
+  reg.register(TALOS_ETH_AGENT, { default: true })
+  return reg
+}
+
+async function drain(handle: { fullStream: AsyncIterable<unknown>; done: Promise<void> }) {
+  const events: unknown[] = []
+  for await (const part of handle.fullStream) events.push(part)
+  await handle.done
+  return events
+}
+
+// ---------------- prompt assembly ----------------
+
+describe('prompt — buildSystemPrompt', () => {
+  it('omits empty blocks, preserves order', () => {
+    const out = buildSystemPrompt({
+      persona: 'P',
+      knowledgeChunks: [{ source: 'l2beat', content: 'arb total value' }],
+      coldRecallSummaries: ['prior thread A'],
+      warmSummary: 'this thread so far',
+      toolNames: ['aave_supply'],
+    })
+    expect(out).toContain('P')
+    expect(out.indexOf('Recent ETH ecosystem state:')).toBeLessThan(
+      out.indexOf('Prior context (other conversations):'),
+    )
+    expect(out.indexOf('Prior context')).toBeLessThan(out.indexOf('Thread summary so far:'))
+    expect(out).toContain('Tools available: aave_supply')
+  })
+
+  it('persona-only when no tiers populated', () => {
+    const out = buildSystemPrompt({ persona: 'just me' })
+    expect(out).toBe('just me')
+  })
+})
+
+// ---------------- agent registry ----------------
+
+describe('AgentRegistry', () => {
+  it('returns default + throws on unknown', () => {
+    const reg = new AgentRegistry()
+    reg.register(TALOS_ETH_AGENT, { default: true })
+    expect(reg.get().id).toBe('talos-eth')
+    expect(reg.get('talos-eth').id).toBe('talos-eth')
+    expect(() => reg.get('nope')).toThrow(/unknown agent/)
+  })
+
+  it('throws when empty', () => {
+    expect(() => new AgentRegistry().get()).toThrow(/empty/)
+  })
+})
+
+// ---------------- text-only run ----------------
+
+describe('runtime — text-only run', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('persists run + step + 2 message_embeddings (user, assistant)', async () => {
+    const model = makeMockModel([textOnlyChunks('Hello, I can help with that.')])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+    })
+
+    const r = await runtime.run({
+      threadId: 'cli:test:default',
+      channel: 'cli',
+      intent: 'hi',
+    })
+
+    const events = await drain(r)
+    expect(events.length).toBeGreaterThan(0)
+
+    const runRow = await handle.pg.query<{ status: string; summary: string }>(
+      `SELECT status, summary FROM runs WHERE id = $1`,
+      [r.runId],
+    )
+    expect(runRow.rows[0]?.status).toBe('completed')
+    expect(runRow.rows[0]?.summary).toContain('Hello')
+
+    const steps = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM steps WHERE run_id = $1`,
+      [r.runId],
+    )
+    expect(steps.rows[0]?.count).toBe('1')
+
+    const embs = await handle.pg.query<{ count: string; role: string }>(
+      `SELECT COUNT(*)::text AS count, role
+       FROM message_embeddings WHERE thread_id = 'cli:test:default'
+       GROUP BY role ORDER BY role`,
+    )
+    expect(embs.rows.find((r) => r.role === 'user')?.count).toBe('1')
+    expect(embs.rows.find((r) => r.role === 'assistant')?.count).toBe('1')
+  })
+
+  it('passes the system prompt with persona to the model', async () => {
+    const model = makeMockModel([textOnlyChunks('ok')])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+    })
+
+    await drain(
+      await runtime.run({ threadId: 't-prompt', channel: 'cli', intent: 'what is your name' }),
+    )
+
+    expect(model.doStreamCalls.length).toBe(1)
+    const call = model.doStreamCalls[0]
+    if (!call) throw new Error('no doStreamCall')
+    const systemMsg = call.prompt.find((m) => m.role === 'system')
+    expect(systemMsg).toBeDefined()
+    if (systemMsg && systemMsg.role === 'system') {
+      expect(systemMsg.content).toContain('Talos')
+    }
+  })
+
+  it('injects cold recall when prior thread has a similar summary', async () => {
+    // Seed a different thread + a summary embedding that matches
+    await upsertThread(handle.db, { id: 'prior', channel: 'cli' })
+    await writeThreadSummary(handle.db, {
+      threadId: 'prior',
+      summary: 'previously discussed Aave on Arbitrum',
+      embedding: fakeEmbedding(1),
+    })
+
+    // Tweak the embeddings service to seed=1 so the user's embedding
+    // matches the prior summary
+    const fixedEmbeddings: EmbeddingsService = {
+      embed: async () => fakeEmbedding(1),
+      embedMany: async (xs) => xs.map(() => fakeEmbedding(1)),
+    }
+
+    const model = makeMockModel([textOnlyChunks('noted')])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: fixedEmbeddings,
+      agents: withRegistry(),
+      config: { coldRecallThreshold: 0.5 },
+    })
+
+    await drain(
+      await runtime.run({
+        threadId: 'cli:current:default',
+        channel: 'cli',
+        intent: 'pull my balances',
+      }),
+    )
+
+    const call = model.doStreamCalls[0]
+    if (!call) throw new Error('no doStreamCall')
+    const systemMsg = call.prompt.find((m) => m.role === 'system')
+    if (systemMsg && systemMsg.role === 'system') {
+      expect(systemMsg.content).toContain('Prior context')
+      expect(systemMsg.content).toContain('Aave on Arbitrum')
+    }
+  })
+
+  it('marks run cancelled when caller aborts', async () => {
+    const model = makeMockModel([textOnlyChunks('would be a long response')])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+    })
+    const ac = new AbortController()
+    const r = await runtime.run({
+      threadId: 't-abort',
+      channel: 'cli',
+      intent: 'long task',
+      abortSignal: ac.signal,
+    })
+    ac.abort()
+    await r.done
+
+    const row = await handle.pg.query<{ status: string }>(`SELECT status FROM runs WHERE id = $1`, [
+      r.runId,
+    ])
+    expect(['cancelled', 'completed']).toContain(row.rows[0]?.status)
+  })
+})
+
+// ---------------- tool calling ----------------
+
+describe('runtime — tool calling', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('records tool_calls with args + result; multi-step run advances stepIndex', async () => {
+    const flow = toolCallThenTextChunks({
+      toolName: 'getBalance',
+      toolCallId: 'call_1',
+      input: { wallet: '0xABC' },
+      finalText: 'You have 5 ETH on Arbitrum.',
+    })
+    const model = makeMockModel([flow.step1, flow.step2])
+
+    const balanceTool = tool({
+      description: 'Get wallet balance',
+      inputSchema: z.object({ wallet: z.string() }),
+      execute: async ({ wallet }) => ({ wallet, balance: '5 ETH', chain: 'arbitrum' }),
+    })
+    const toolSource: ToolSource = { getTools: async () => ({ getBalance: balanceTool }) }
+
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+      toolSources: [toolSource],
+      config: { maxSteps: 3 },
+    })
+
+    const r = await runtime.run({
+      threadId: 't-tools',
+      channel: 'cli',
+      intent: 'check 0xABC balance on arbitrum',
+    })
+    await drain(r)
+
+    const tcalls = await handle.pg.query<{
+      tool_name: string
+      args: unknown
+      result: unknown
+      step_id: string
+    }>(`SELECT tool_name, args, result, step_id FROM tool_calls WHERE run_id = $1`, [r.runId])
+    expect(tcalls.rows.length).toBe(1)
+    expect(tcalls.rows[0]?.tool_name).toBe('getBalance')
+
+    const steps = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM steps WHERE run_id = $1`,
+      [r.runId],
+    )
+    expect(Number(steps.rows[0]?.count ?? '0')).toBeGreaterThanOrEqual(2)
+  })
+})
+
+// ---------------- post-run hooks ----------------
+
+describe('runtime — post-run hooks', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('invokes factPipeline.processRun with run details', async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const factPipeline: FactPipeline = {
+      processRun: async (input) => {
+        calls.push(input)
+      },
+    }
+
+    const model = makeMockModel([textOnlyChunks('done')])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+      factPipeline,
+    })
+
+    const r = await runtime.run({ threadId: 't-fp', channel: 'cli', intent: 'hi' })
+    await drain(r)
+
+    expect(calls.length).toBe(1)
+    expect(calls[0]).toMatchObject({
+      threadId: 't-fp',
+      channel: 'cli',
+      agentId: 'talos-eth',
+      runId: r.runId,
+      userMessage: 'hi',
+      assistantMessage: 'done',
+    })
+  })
+
+  it('triggers summarizer at the configured cadence', async () => {
+    const calls: Array<{ threadId: string; runRangeEnd: string }> = []
+    const summarizer: ThreadSummarizer = {
+      summarize: async (input) => {
+        calls.push({ threadId: input.threadId, runRangeEnd: input.runRangeEnd })
+        return { summary: 'auto summary', embedding: fakeEmbedding(7) }
+      },
+    }
+
+    const model = makeMockModel([
+      textOnlyChunks('ok1'),
+      textOnlyChunks('ok2'),
+      textOnlyChunks('ok3'),
+    ])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+      summarizer,
+      config: { summarizeEveryNRuns: 2 },
+    })
+
+    for (let i = 0; i < 3; i++) {
+      const r = await runtime.run({
+        threadId: 't-sum',
+        channel: 'cli',
+        intent: `turn ${i}`,
+      })
+      await drain(r)
+    }
+
+    expect(calls.length).toBe(1)
+    expect(calls[0]?.threadId).toBe('t-sum')
+
+    const sumRows = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM thread_summaries WHERE thread_id = 't-sum'`,
+    )
+    expect(sumRows.rows[0]?.count).toBe('1')
+  })
+})
+
+// ---------------- empty tool sources ----------------
+
+describe('runtime — empty tool sources', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('runs cleanly with no toolSources []', async () => {
+    const model = makeMockModel([textOnlyChunks('ok')])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+    })
+
+    const r = await runtime.run({ threadId: 't-empty', channel: 'cli', intent: 'hi' })
+    await drain(r)
+
+    const row = await handle.pg.query<{ status: string }>(`SELECT status FROM runs WHERE id = $1`, [
+      r.runId,
+    ])
+    expect(row.rows[0]?.status).toBe('completed')
+  })
+})
+
+// ---------------- recall over message_embeddings -----------------
+
+describe('runtime — fact recall integration', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('coexists with applyFactOps + insertMessageEmbedding from prior turns', async () => {
+    await upsertThread(handle.db, { id: 't-mix', channel: 'cli' })
+    await insertMessageEmbedding(handle.db, {
+      threadId: 't-mix',
+      role: 'assistant',
+      content: 'Aave supply 100 USDC done',
+      embedding: fakeEmbedding(1),
+    })
+    await applyFactOps(handle.db, { agentId: 'talos-eth', channel: 'cli', threadId: 't-mix' }, [
+      { kind: 'ADD', text: 'user prefers Arbitrum', embedding: fakeEmbedding(1) },
+    ])
+
+    const model = makeMockModel([textOnlyChunks('noted')])
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+    })
+
+    const r = await runtime.run({
+      threadId: 't-mix',
+      channel: 'cli',
+      intent: 'do another aave action',
+    })
+    await drain(r)
+
+    const facts = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM facts WHERE thread_id = 't-mix' AND deleted_at IS NULL`,
+    )
+    expect(facts.rows[0]?.count).toBe('1')
+
+    const runs = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM runs WHERE thread_id = 't-mix'`,
+    )
+    expect(runs.rows[0]?.count).toBe('1')
+  })
+})


### PR DESCRIPTION
Closes #7.

## Summary

The brain of Talos. Wraps Vercel AI SDK v6 \`streamText\` with persistent runs/steps, a provider router, three-tier memory (hot/warm/cold) injected into the system prompt, plus knowledge-layer + tools, and an audit-shaped persistence sink. Async post-hooks for fact pipeline + thread summarization fire after each turn.

## API

\`\`\`ts
const runtime = createRuntime({ db, providers, embeddings, agents, ... })
const { runId, fullStream, done } = await runtime.run({ threadId, channel, intent })
for await (const part of fullStream) /* display */
await done   // persistence + post-hooks settled
\`\`\`

\`done\` always resolves; storage errors are logged, not thrown — channel UX must not crash on persistence.

## Pipeline

1. Embed user intent (sync, blocks ~100ms; needed for cold recall)
2. Transaction: \`upsertThread\` + insert user \`message_embeddings\` row
3. Parallel pull of memory tiers:
   - **Hot** — last N runs as ModelMessage[] (default 20)
   - **Warm** — latest \`thread_summaries\` row (#16)
   - **Cold** — cross-thread vector recall, threshold-gated (default 0.78, top-3)
   - **Knowledge** — top-K from \`KnowledgeRetriever\` (#11 stub for now)
4. \`mergeToolSources\` + \`buildSystemPrompt\` (Letta-style single concat, blocks omitted if empty)
5. \`streamText\` with \`stopWhen: stepCountIs(N)\`. Callbacks:
   - \`onStepFinish\`: write 1 \`steps\` row + N \`tool_calls\` rows for that step
   - \`onFinish\`: close run, embed assistant message, fire async post-hooks
6. \`abortSignal\` listener marks run cancelled if aborted before \`onFinish\`
7. Post-hooks (parallel, \`Promise.allSettled\`): \`factPipeline.processRun\` (#17 wired through) + summarizer if \`runCount % summarizeEveryNRuns === 0\` (writes via \`writeThreadSummary\` from #16)

## Engineering deviations from the architecture sketch

The arch doc shows a custom async generator wrapping \`fullStream\`. Rejected after researching Mastra / Letta / Vercel canonical:

1. **Return \`RunHandle\`, not \`AsyncGenerator\`.** AI SDK v6 already returns a streaming result object; wrapping in a generator loses callbacks (\`onStepFinish\`/\`onFinish\`) which are the right persistence hook.
2. **\`onStepFinish\` is the persistence boundary, not per-chunk.** \`StepResult\` includes \`text + toolCalls + toolResults\` already grouped; one INSERT per step, N INSERTs per tool call. Mastra's \`SaveQueueManager\` debounce is unnecessary at our volume.
3. **System prompt as single concatenated \`system: string\`** (Letta pattern), not multiple typed system messages (Mastra). Empty blocks omitted; ordering preserved.
4. **LLM-backed deps as interfaces with null defaults.** Summarizer / FactExtractor+Reconciler / KnowledgeRetriever each need real LLM prompts that are demo-quality work in their own right. Ship the runtime now with NULL implementations; follow-up PRs add the real prompts. Same atomic-PR discipline as #5 / #16 / #17.

## Persistence layer touch

\`queries.ts\` \`Db\` type widened from \`PgliteDatabase\` to \`PgDatabase<PgQueryResultHKT, any, any>\` so the runtime can pass a transaction (\`tx\`) into \`upsertThread\` + \`insertMessageEmbedding\` for the user-message txn. Existing call sites unaffected; the runtime needs it because it performs the upsert + insert atomically.

## Verification

- \`pnpm typecheck\` green
- \`pnpm lint\` green
- \`pnpm test\` green (51 passed, 1 todo)
- \`pnpm build\` green

## Tests (13 new cases)

- \`buildSystemPrompt\`: ordering + persona-only path
- \`AgentRegistry\`: default lookup, unknown agent throws, empty registry throws
- text-only run: \`runs/steps\` rows, 2 \`message_embeddings\` (user + assistant)
- system prompt with persona reaches the model (assert via \`MockLanguageModelV3.doStreamCalls\`)
- cold recall injection: seed prior \`thread_summaries\`, assert \`Prior context:\` appears in system message
- abort midway → run status \`cancelled\` or \`completed\` (race-safe assertion)
- tool calling: 1 \`tool_calls\` row with args + result, 2+ \`steps\`
- post-hooks: \`factPipeline.processRun\` invoked once with run details
- summarizer cadence: 3 runs with \`summarizeEveryNRuns: 2\` → exactly 1 summarizer call + 1 \`thread_summaries\` row
- empty tool sources: \`tools: {}\` doesn't crash
- runtime coexists with prior \`facts\` + \`message_embeddings\` writes from earlier turns

## Out of scope (future PRs)

- LLM-backed implementations of \`ThreadSummarizer\`, \`FactExtractor\`, \`FactReconciler\`, \`KnowledgeRetriever\` — runtime accepts them as interfaces today
- Multi-provider router (only OpenAI in v1)
- KeeperHub middleware (#8 — runtime emits the audit data, middleware filters/wraps mutating calls)
- Daemon WS plumbing (#9)
- CLI REPL channel (#13)
- Rich step-history reconstruction in \`recentMessages\` (v1 uses \`runs.prompt + runs.summary\`; richer reconstruction is a v1.1 optimization if needed)