### PR TITLE
fix(mcp-host): address review follow-ups from #6

### DIFF
--- a/src/mcp-host/host.ts
+++ b/src/mcp-host/host.ts
@@ -1,5 +1,5 @@
 import { createMCPClient, type MCPClient, type MCPTransport } from '@ai-sdk/mcp'
-import type { Tool } from 'ai'
+import type { ModelMessage, Tool } from 'ai'
 import { child } from '@/shared/logger'
 import type { McpServerConfig } from './index'
 import {
@@ -26,10 +26,36 @@ type ServerEntry = {
   tools: Map<string, NamespacedToolEntry>
   healthy: boolean
   retries: number
+  lastError?: string
 }
 
-const MAX_RETRIES = 3
-const BASE_DELAY_MS = 1000
+/** Health snapshot exposed via getServerHealth() */
+export type ServerHealth = {
+  healthy: boolean
+  retries: number
+  lastError?: string
+}
+
+/** Options for `callTool` ad-hoc invocations. */
+export type CallToolOptions = {
+  /** Conversation context for tools that need it. Defaults to []. */
+  messages?: ModelMessage[]
+  /** Override the host-level default timeout. */
+  timeoutMs?: number
+}
+
+export type McpHostOptions = {
+  /** Per tool-call timeout in ms. Default 30000. */
+  toolCallTimeoutMs?: number
+  /** Total connect attempts (1 initial + N-1 retries). Default 3. */
+  maxAttempts?: number
+  /** Base backoff between attempts; doubles each retry. Default 1000. */
+  baseDelayMs?: number
+}
+
+const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30_000
+const DEFAULT_MAX_ATTEMPTS = 3
+const DEFAULT_BASE_DELAY_MS = 1000
 
 /**
  * McpHost — manages connections to N MCP servers and exposes their tools
@@ -37,12 +63,23 @@ const BASE_DELAY_MS = 1000
  */
 export class McpHost {
   private servers = new Map<string, ServerEntry>()
+  /** Reverse lookup: namespaced tool name → owning server entry. */
+  private toolIndex = new Map<string, ServerEntry>()
   private started = false
+  private readonly toolCallTimeoutMs: number
+  private readonly maxAttempts: number
+  private readonly baseDelayMs: number
+
+  constructor(opts: McpHostOptions = {}) {
+    this.toolCallTimeoutMs = opts.toolCallTimeoutMs ?? DEFAULT_TOOL_CALL_TIMEOUT_MS
+    this.maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
+    this.baseDelayMs = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
+  }
 
   /**
    * Connect to all configured servers. Retries with exponential backoff
-   * on failure. Does not throw on individual server failures — logs and
-   * marks unhealthy.
+   * on failure. Throws only if every server fails; otherwise unhealthy
+   * servers are reported via `getServerHealth()`.
    */
   async start(configs: McpServerConfig[]): Promise<void> {
     if (this.started) {
@@ -93,6 +130,7 @@ export class McpHost {
     }
     await Promise.allSettled(closers)
     this.servers.clear()
+    this.toolIndex.clear()
     this.started = false
     log.info('McpHost stopped')
   }
@@ -123,45 +161,48 @@ export class McpHost {
   }
 
   /**
-   * Call a namespaced tool on the appropriate server.
-   * Tool name format: `${serverName}_${toolName}`
+   * Ad-hoc tool invocation by namespaced name. Looks up via the host's
+   * tool index, so server names containing underscores work correctly.
+   *
+   * NOTE: the runtime should obtain tools via `getToolRecord()` and let
+   * `streamText` invoke them with full conversation context. Use this
+   * method only for ad-hoc / admin invocations. Tools that depend on
+   * conversation context will receive whatever is passed via
+   * `opts.messages` (default `[]`).
    */
   async callTool(
     name: string,
     args: Record<string, unknown>,
+    opts: CallToolOptions = {},
   ): Promise<string | Record<string, unknown>> {
-    const underscoreIdx = name.indexOf('_')
-    if (underscoreIdx === -1) {
-      throw new Error(`tool name "${name}" missing server prefix (expected "server_tool")`)
+    const owner = this.toolIndex.get(name)
+    if (!owner) {
+      throw new Error(`tool "${name}" not found in any connected server`)
+    }
+    if (!owner.healthy || !owner.client) {
+      throw new Error(`MCP server "${owner.config.name}" is not connected`)
     }
 
-    const serverName = name.slice(0, underscoreIdx)
-    const toolName = name.slice(underscoreIdx + 1)
-
-    const entry = this.servers.get(serverName)
-    if (!entry) {
-      throw new Error(`unknown MCP server "${serverName}"`)
-    }
-    if (!entry.healthy || !entry.client) {
-      throw new Error(`MCP server "${serverName}" is not connected`)
-    }
-
-    const namespacedName = namespaceToolName(serverName, toolName)
-    const toolEntry = entry.tools.get(namespacedName)
+    const toolEntry = owner.tools.get(name)
     if (!toolEntry) {
-      throw new Error(`tool "${namespacedName}" not found on server "${serverName}"`)
+      throw new Error(`tool "${name}" missing from server "${owner.config.name}" registry`)
+    }
+    if (!toolEntry.tool.execute) {
+      throw new Error(`tool "${name}" has no execute function`)
     }
 
-    // AI SDK tool execution — call the tool's execute function
-    if (toolEntry.tool.execute) {
-      const result = await toolEntry.tool.execute(args, {
-        toolCallId: `${serverName}-${toolName}-${Date.now()}`,
-        messages: [],
-      })
-      return flattenToolResult(result)
-    }
+    const timeoutMs = opts.timeoutMs ?? this.toolCallTimeoutMs
+    const messages = opts.messages ?? []
 
-    throw new Error(`tool "${namespacedName}" has no execute function`)
+    const result = await this.withTimeout(
+      toolEntry.tool.execute(args, {
+        toolCallId: `${owner.config.name}-${toolEntry.originalName}-${Date.now()}`,
+        messages,
+      }),
+      timeoutMs,
+      `tool "${name}"`,
+    )
+    return flattenToolResult(result)
   }
 
   /**
@@ -172,17 +213,40 @@ export class McpHost {
   }
 
   /**
-   * Get health status of all servers.
+   * Get health status of all servers, including retry counts and last error.
    */
-  getServerHealth(): Record<string, boolean> {
-    const out: Record<string, boolean> = {}
+  getServerHealth(): Record<string, ServerHealth> {
+    const out: Record<string, ServerHealth> = {}
     for (const [name, entry] of this.servers) {
-      out[name] = entry.healthy
+      out[name] = {
+        healthy: entry.healthy,
+        retries: entry.retries,
+        ...(entry.lastError ? { lastError: entry.lastError } : {}),
+      }
     }
     return out
   }
 
   // --- internal ---
+
+  private async withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+    let timer: NodeJS.Timeout | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    })
+    try {
+      return await Promise.race([p, timeout])
+    } finally {
+      if (timer) clearTimeout(timer)
+    }
+  }
+
+  private markUnhealthy(name: string, reason: string): void {
+    const entry = this.servers.get(name)
+    if (!entry) return
+    entry.healthy = false
+    entry.lastError = reason
+  }
 
   private async connectServer(name: string): Promise<void> {
     const entry = this.servers.get(name)
@@ -191,18 +255,18 @@ export class McpHost {
     const { config } = entry
     log.info({ server: name, transport: config.transport }, 'connecting to MCP server')
 
-    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
       try {
         const transport = buildTransport(config)
         const client = await createMCPClient({
           transport: transport as MCPTransport | HttpTransportConfig,
           name: `talos-${config.name}`,
           onUncaughtError: (err) => {
-            log.error({ err, server: name }, 'uncaught MCP error')
+            log.error({ err, server: name }, 'uncaught MCP error — marking unhealthy')
+            this.markUnhealthy(name, err instanceof Error ? err.message : String(err))
           },
         })
 
-        // Fetch tools and namespace them
         const mcpTools = await client.tools()
         const toolMap = new Map<string, NamespacedToolEntry>()
 
@@ -210,37 +274,41 @@ export class McpHost {
           const namespaced = namespaceToolName(config.name, originalName)
           const annotations = parseToolAnnotations(tool as Record<string, unknown>)
 
-          toolMap.set(namespaced, {
+          const namespacedEntry: NamespacedToolEntry = {
             namespacedName: namespaced,
             originalName,
             serverName: config.name,
             annotations,
             tool: tool as Tool,
-          })
+          }
+          toolMap.set(namespaced, namespacedEntry)
+          this.toolIndex.set(namespaced, entry)
         }
 
         entry.client = client
         entry.tools = toolMap
         entry.healthy = true
         entry.retries = 0
+        entry.lastError = undefined
 
         log.info({ server: name, tools: toolMap.size }, 'MCP server connected')
         return
       } catch (err) {
-        entry.retries = attempt + 1
+        entry.retries = attempt
+        entry.lastError = err instanceof Error ? err.message : String(err)
 
-        if (attempt < MAX_RETRIES) {
-          const delay = BASE_DELAY_MS * 2 ** attempt
+        if (attempt < this.maxAttempts) {
+          const delay = this.baseDelayMs * 2 ** (attempt - 1)
           log.warn(
-            { err, server: name, attempt: attempt + 1, retryInMs: delay },
+            { err, server: name, attempt, retryInMs: delay },
             'MCP server connection failed, retrying',
           )
           await new Promise((r) => setTimeout(r, delay))
         } else {
           entry.healthy = false
           log.error(
-            { err, server: name, retries: MAX_RETRIES },
-            'MCP server connection failed after retries',
+            { err, server: name, attempts: this.maxAttempts },
+            'MCP server connection failed after all attempts',
           )
           throw err
         }

--- a/src/mcp-host/registry.ts
+++ b/src/mcp-host/registry.ts
@@ -49,33 +49,33 @@ export function parseToolAnnotations(tool: Record<string, unknown>): ToolAnnotat
 }
 
 /**
- * Flatten MCP tool result to a single string or parsed JSON.
+ * Flatten MCP tool result to a single string or parsed JSON object.
  *
  * MCP returns: { content: [{ type: 'text', text: '{"foo":1}' }] }
  * This function flattens to:
- *   - single text item → string
- *   - single text item that's valid JSON → parsed object
- *   - multiple text items → joined with \n\n
+ *   - single text item that looks like a JSON object (`{...}`) → parsed object
+ *   - single text item otherwise → string
+ *   - multiple text items → joined with \n\n (object-parse on the join only if it starts with `{`)
  *   - error → wrapped in <error> tag
+ *
+ * JSON parsing is gated on `text.trim().startsWith('{')` so the return type
+ * stays honest: `string | Record<string, unknown>`. Scalars like `"42"` /
+ * `"true"` and arrays like `"[1,2]"` pass through as text — callers that need
+ * those should JSON.parse themselves.
  */
 export function flattenToolResult(result: unknown): string | Record<string, unknown> {
   if (result == null) return ''
 
-  // If it's already a string, return as-is
   if (typeof result === 'string') return result
-
-  // If it's not an object, stringify
   if (typeof result !== 'object') return String(result)
 
   const obj = result as Record<string, unknown>
 
-  // Handle MCP content array
   if (Array.isArray(obj.content)) {
     const items = obj.content as Array<{ type: string; text?: string; isError?: boolean }>
 
     if (items.length === 0) return ''
 
-    // Check for error
     if (items.some((i) => i.isError)) {
       const errorTexts = items
         .filter((i) => i.type === 'text')
@@ -84,31 +84,29 @@ export function flattenToolResult(result: unknown): string | Record<string, unkn
       return `<error>${errorTexts}</error>`
     }
 
-    // Single text item — try JSON parse
-    const first = items[0]
-    if (items.length === 1 && first?.type === 'text' && first.text) {
-      const text = first.text
-      try {
-        return JSON.parse(text) as Record<string, unknown>
-      } catch {
-        return text
-      }
+    const texts = items.filter((i) => i.type === 'text').map((i) => i.text ?? '')
+
+    if (texts.length === 1) {
+      const text = texts[0] ?? ''
+      return tryParseJsonObject(text) ?? text
     }
 
-    // Multiple text items — join
-    const texts = items
-      .filter((i) => i.type === 'text')
-      .map((i) => i.text ?? '')
-      .join('\n\n')
-
-    // Try JSON parse on joined text
-    try {
-      return JSON.parse(texts) as Record<string, unknown>
-    } catch {
-      return texts
-    }
+    const joined = texts.join('\n\n')
+    return tryParseJsonObject(joined) ?? joined
   }
 
-  // Not MCP format — return as-is (might already be flat)
   return obj as unknown as Record<string, unknown>
+}
+
+function tryParseJsonObject(text: string): Record<string, unknown> | null {
+  if (!text.trim().startsWith('{')) return null
+  try {
+    const parsed = JSON.parse(text)
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+    return null
+  } catch {
+    return null
+  }
 }

--- a/tests/integration/mcp-host.test.ts
+++ b/tests/integration/mcp-host.test.ts
@@ -21,6 +21,10 @@ describe('namespaceToolName', () => {
       'blockscout_get_token_balance',
     )
   })
+
+  it('handles server names containing underscores', () => {
+    expect(namespaceToolName('aave_v3', 'supply')).toBe('aave_v3_supply')
+  })
 })
 
 describe('parseToolAnnotations', () => {
@@ -85,9 +89,24 @@ describe('flattenToolResult', () => {
     expect(flattenToolResult(result)).toBe('hello world')
   })
 
-  it('parses JSON from single text content item', () => {
+  it('parses JSON object from single text content item', () => {
     const result = { content: [{ type: 'text', text: '{"balance":"100"}' }] }
     expect(flattenToolResult(result)).toEqual({ balance: '100' })
+  })
+
+  it('does not parse scalar JSON values (returns as text)', () => {
+    expect(flattenToolResult({ content: [{ type: 'text', text: '42' }] })).toBe('42')
+    expect(flattenToolResult({ content: [{ type: 'text', text: 'true' }] })).toBe('true')
+    expect(flattenToolResult({ content: [{ type: 'text', text: 'null' }] })).toBe('null')
+  })
+
+  it('does not parse JSON arrays (returns as text)', () => {
+    expect(flattenToolResult({ content: [{ type: 'text', text: '[1,2,3]' }] })).toBe('[1,2,3]')
+  })
+
+  it('returns text when JSON parse fails on object-shaped string', () => {
+    const result = { content: [{ type: 'text', text: '{not valid json' }] }
+    expect(flattenToolResult(result)).toBe('{not valid json')
   })
 
   it('joins multiple text items with newline', () => {
@@ -117,33 +136,40 @@ describe('flattenToolResult', () => {
 // McpHost integration tests (mocked MCP client)
 // ---------------------------------------------------------------------------
 
+type CreateMcpClientOpts = { onUncaughtError?: (err: unknown) => void }
+
 const { mockCreateMCPClient, MockStdioTransport } = vi.hoisted(() => {
-  const mockClose = vi.fn().mockResolvedValue(undefined)
-  const mockTools = vi.fn().mockResolvedValue({
-    supply: {
-      description: 'Supply tokens to Aave',
-      inputSchema: { type: 'object', properties: { amount: { type: 'string' } } },
-      execute: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"tx":"0xabc"}' }] }),
-    },
-    borrow: {
-      description: 'Borrow from Aave',
-      inputSchema: { type: 'object', properties: { amount: { type: 'string' } } },
-      execute: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'borrowed' }] }),
-    },
-  })
-  const mockCreateMCPClient = vi.fn().mockResolvedValue({
-    tools: mockTools,
+  const defaultClient = {
+    tools: vi.fn().mockResolvedValue({
+      supply: {
+        description: 'Supply tokens to Aave',
+        inputSchema: { type: 'object', properties: { amount: { type: 'string' } } },
+        execute: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '{"tx":"0xabc"}' }] }),
+      },
+      borrow: {
+        description: 'Borrow from Aave',
+        inputSchema: { type: 'object', properties: { amount: { type: 'string' } } },
+        execute: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'borrowed' }] }),
+      },
+    }),
     listTools: vi.fn().mockResolvedValue({ tools: [] }),
-    close: mockClose,
+    close: vi.fn().mockResolvedValue(undefined),
     serverInfo: { name: 'test-server', version: '1.0.0' },
-  })
+  }
+  const mockCreateMCPClient = vi.fn().mockResolvedValue(defaultClient)
   const MockStdioTransport = vi.fn().mockImplementation(() => ({
     start: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
     send: vi.fn().mockResolvedValue(undefined),
   }))
-  return { mockClose, mockTools, mockCreateMCPClient, MockStdioTransport }
+  return { mockCreateMCPClient, MockStdioTransport }
 })
+
+/** Pull the onUncaughtError handler the host registered on its most recent createMCPClient call. */
+function lastOnUncaughtError(): ((err: unknown) => void) | undefined {
+  const calls = mockCreateMCPClient.mock.calls as Array<[CreateMcpClientOpts]>
+  return calls[calls.length - 1]?.[0]?.onUncaughtError
+}
 
 vi.mock('@ai-sdk/mcp', () => ({
   createMCPClient: mockCreateMCPClient,
@@ -189,6 +215,20 @@ describe('McpHost', () => {
     await host.stop()
   })
 
+  it('routes calls correctly when server name contains an underscore', async () => {
+    const host = new McpHost()
+    await host.start([{ name: 'aave_v3', transport: 'http', url: 'https://mcp.aave.com' }])
+
+    const record = host.getToolRecord()
+    expect(record).toHaveProperty('aave_v3_supply')
+    expect(record).toHaveProperty('aave_v3_borrow')
+
+    const result = await host.callTool('aave_v3_supply', { amount: '100' })
+    expect(result).toEqual({ tx: '0xabc' })
+
+    await host.stop()
+  })
+
   it('calls tool with namespaced name', async () => {
     const host = new McpHost()
     await host.start([{ name: 'aave', transport: 'http', url: 'https://mcp.aave.com' }])
@@ -199,22 +239,16 @@ describe('McpHost', () => {
     await host.stop()
   })
 
-  it('throws on unknown server', async () => {
+  it('throws when calling an unknown tool', async () => {
     const host = new McpHost()
     await host.start([{ name: 'aave', transport: 'http', url: 'https://mcp.aave.com' }])
 
     await expect(host.callTool('unknown_supply', {})).rejects.toThrow(
-      'unknown MCP server "unknown"',
+      'tool "unknown_supply" not found in any connected server',
     )
-
-    await host.stop()
-  })
-
-  it('throws on missing server prefix', async () => {
-    const host = new McpHost()
-    await host.start([{ name: 'aave', transport: 'http', url: 'https://mcp.aave.com' }])
-
-    await expect(host.callTool('supply', {})).rejects.toThrow('missing server prefix')
+    await expect(host.callTool('supply', {})).rejects.toThrow(
+      'tool "supply" not found in any connected server',
+    )
 
     await host.stop()
   })
@@ -230,11 +264,11 @@ describe('McpHost', () => {
     await host.stop()
   })
 
-  it('reports server health', async () => {
+  it('reports server health with retries and last error', async () => {
     const host = new McpHost()
     await host.start([{ name: 'aave', transport: 'http', url: 'https://mcp.aave.com' }])
 
-    expect(host.getServerHealth()).toEqual({ aave: true })
+    expect(host.getServerHealth()).toEqual({ aave: { healthy: true, retries: 0 } })
     expect(host.isServerHealthy('aave')).toBe(true)
     expect(host.isServerHealthy('nonexistent')).toBe(false)
 
@@ -248,6 +282,60 @@ describe('McpHost', () => {
     await host.stop()
     expect(host.listTools()).toHaveLength(0)
     expect(host.getServerHealth()).toEqual({})
+  })
+
+  it('flips healthy=false when onUncaughtError fires after connect', async () => {
+    const host = new McpHost()
+    await host.start([{ name: 'aave', transport: 'http', url: 'https://mcp.aave.com' }])
+    expect(host.isServerHealthy('aave')).toBe(true)
+
+    const handler = lastOnUncaughtError()
+    expect(handler).toBeDefined()
+    handler?.(new Error('connection dropped'))
+
+    expect(host.isServerHealthy('aave')).toBe(false)
+    const health = host.getServerHealth()
+    expect(health.aave?.healthy).toBe(false)
+    expect(health.aave?.lastError).toBe('connection dropped')
+
+    await host.stop()
+  })
+
+  it('aborts a tool call that exceeds the timeout', async () => {
+    mockCreateMCPClient.mockResolvedValueOnce({
+      tools: vi.fn().mockResolvedValue({
+        slow: {
+          description: 'slow tool',
+          execute: vi.fn(() => new Promise(() => {})),
+        },
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    })
+
+    const host = new McpHost({ toolCallTimeoutMs: 50 })
+    await host.start([{ name: 'aave', transport: 'http', url: 'https://mcp.aave.com' }])
+
+    await expect(host.callTool('aave_slow', {})).rejects.toThrow(
+      'tool "aave_slow" timed out after 50ms',
+    )
+
+    await host.stop()
+  })
+
+  it('records retries and lastError when a server fails to connect', async () => {
+    mockCreateMCPClient.mockRejectedValueOnce(new Error('connect refused'))
+    mockCreateMCPClient.mockRejectedValueOnce(new Error('connect refused'))
+    mockCreateMCPClient.mockRejectedValueOnce(new Error('connect refused'))
+
+    const host = new McpHost({ maxAttempts: 3, baseDelayMs: 1 })
+    await expect(
+      host.start([{ name: 'aave', transport: 'http', url: 'https://mcp.aave.com' }]),
+    ).rejects.toThrow('all servers failed to connect')
+
+    const health = host.getServerHealth()
+    expect(health.aave?.healthy).toBe(false)
+    expect(health.aave?.retries).toBe(3)
+    expect(health.aave?.lastError).toBe('connect refused')
   })
 })
 


### PR DESCRIPTION
## Summary

Addresses every item from issue #23 (post-merge review of #6 / PR #22).

### Bug fixes

- **A. Underscore-in-server-name routing.** `host.callTool` now looks up via a `toolIndex: Map<namespacedName, ServerEntry>` instead of parsing `name` on the first underscore. Servers like `aave_v3` resolve correctly.
- **B. Off-by-one retry counter.** `MAX_ATTEMPTS = 3` means 3 total tries (1 initial + 2 retries), matching the public claim. Configurable via `new McpHost({ maxAttempts })`.
- **C. `flattenToolResult` JSON-parse.** Only parses when text starts with `{` AND the parsed value is a plain object. Arrays, scalars, and malformed JSON pass through as text — `string | Record<string, unknown>` is no longer a runtime lie.

### Improvements

- **D.** `onUncaughtError` flips `entry.healthy = false` and records `lastError` (was log-only).
- **E.** Tool-call timeout via `withTimeout` helper; default 30s, override via `new McpHost({ toolCallTimeoutMs })` or per-call `callTool(name, args, { timeoutMs })`.
- **F.** `callTool(name, args, opts?)` accepts `{ messages?, timeoutMs? }`. JSDoc warns runtime callers to use `getToolRecord()` instead.
- **G.** `getServerHealth()` returns `Record<string, { healthy: boolean; retries: number; lastError?: string }>` (was `Record<string, boolean>`).

## Test plan

- [x] `pnpm vitest run` — 82 passing + 1 todo (was 75 + 1 todo, +7 new)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm biome check src/mcp-host tests/integration/mcp-host.test.ts` — clean
- [x] New tests cover: underscore-in-server-name routing, JSON-parse heuristic edges (`'42'`, `'true'`, `'null'`, `'[1,2,3]'`, malformed `{`), tool-call timeout, `onUncaughtError` flip, retry counter visible in health snapshot

Closes #23