### PR TITLE
feat(keeperhub): OAuth + audit-by-default middleware

### DIFF
--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -17,6 +17,7 @@ export const paths = {
   pidPath: path.join(configDir, 'daemon.pid'),
   channelsConfigPath: path.join(configDir, 'channels.yaml'),
   logPath: path.join(dataDir, 'talos.log'),
+  keeperhubTokenPath: path.join(configDir, 'keeperhub.token'),
 } as const
 
 export type Paths = typeof paths

--- a/src/keeperhub/client.ts
+++ b/src/keeperhub/client.ts
@@ -1,0 +1,214 @@
+import { createMCPClient, type MCPClient, type MCPTransport } from '@ai-sdk/mcp'
+import type { Tool } from 'ai'
+import { flattenToolResult } from '@/mcp-host/registry'
+import { TalosAuthError } from '@/shared/errors'
+import { child } from '@/shared/logger'
+import {
+  type AuthServerMetadata,
+  discoverAuthServer,
+  refreshToken as refreshTokenRpc,
+} from './oauth'
+import { EXPIRY_BUFFER_MS, isExpired, loadSession, saveSession, sessionFromResponse } from './token'
+
+const log = child({ module: 'keeperhub' })
+const DEFAULT_KEEPERHUB_MCP_URL = 'https://app.keeperhub.com/mcp'
+
+export type KeeperHubClientOpts = {
+  /** Path to the persisted session file. */
+  tokenPath: string
+  /** Override for tests / self-hosted deployments. Default `https://app.keeperhub.com/mcp`. */
+  mcpUrl?: string
+  /** Override for tests. Default global `fetch`. */
+  fetch?: typeof fetch
+  /** Override for tests; if set, used instead of fetching `.well-known/oauth-authorization-server`. */
+  authServerMetadata?: AuthServerMetadata
+}
+
+/** Direct on-chain action — used by #10's protocol-tool wiring. */
+export type ContractCallInput = {
+  network: string
+  contract_address: string
+  function_name: string
+  function_args?: unknown[]
+  abi?: unknown
+}
+
+export type TransferInput = {
+  network: string
+  recipient_address: string
+  amount: string
+  token_address?: string
+}
+
+export type WorkflowExecutionStatus = 'pending' | 'running' | 'success' | 'failed' | 'cancelled'
+
+export type ExecutionResult = {
+  executionId: string
+  status: WorkflowExecutionStatus
+  txHash?: string
+  output?: unknown
+  error?: string
+}
+
+export interface KeeperHubClient {
+  /** Resolve a valid bearer token; refreshes if expired. */
+  ensureToken(): Promise<string>
+  /** List available KeeperHub tools (proxied through `@ai-sdk/mcp`). */
+  listTools(): Promise<Record<string, Tool>>
+  /** Call a KeeperHub MCP tool by name. */
+  callTool(name: string, args: Record<string, unknown>): Promise<unknown>
+  /** Execute a contract call directly (no workflow envelope). */
+  executeContractCall(input: ContractCallInput): Promise<ExecutionResult>
+  /** Execute a token / native transfer directly. */
+  executeTransfer(input: TransferInput): Promise<ExecutionResult>
+  /** Poll execution status; returns the latest snapshot. */
+  getExecutionStatus(executionId: string): Promise<ExecutionResult>
+  /** Disconnect the underlying MCP client. */
+  close(): Promise<void>
+}
+
+/**
+ * Build a KeeperHub MCP client that auto-refreshes the access token and
+ * exposes typed methods for the few MCP tools the audit middleware needs.
+ *
+ * NOTE: this DOES NOT perform first-time browser auth — that flow lives
+ * in the `talos init` wizard (#14). If no session is on disk, every method
+ * throws `TalosAuthError`. Callers must run init first.
+ */
+export async function createKeeperHubClient(opts: KeeperHubClientOpts): Promise<KeeperHubClient> {
+  const fetchImpl = opts.fetch ?? fetch
+  const mcpUrl = opts.mcpUrl ?? DEFAULT_KEEPERHUB_MCP_URL
+
+  let session = await loadSession(opts.tokenPath)
+  if (!session) {
+    throw new TalosAuthError(`no KeeperHub session at ${opts.tokenPath} — run \`talos init\` first`)
+  }
+
+  let metadata: AuthServerMetadata | null = opts.authServerMetadata ?? null
+  let mcp: MCPClient | null = null
+  let mcpToken: string | null = null
+
+  async function authMetadata(): Promise<AuthServerMetadata> {
+    if (metadata) return metadata
+    metadata = await discoverAuthServer({ fetch: fetchImpl })
+    return metadata
+  }
+
+  async function ensureToken(): Promise<string> {
+    if (!session) throw new TalosAuthError('KeeperHub session missing')
+    if (!isExpired(session)) return session.accessToken
+    if (!session.refreshToken) {
+      throw new TalosAuthError(
+        'KeeperHub access token expired and no refresh_token present — re-run `talos init`',
+      )
+    }
+    const meta = await authMetadata()
+    log.info({ msUntilExpiry: session.expiresAt - Date.now() }, 'refreshing KeeperHub token')
+    const tokenRes = await refreshTokenRpc({
+      fetch: fetchImpl,
+      meta,
+      clientId: session.client.client_id,
+      ...(session.client.client_secret !== undefined
+        ? { clientSecret: session.client.client_secret }
+        : {}),
+      refreshToken: session.refreshToken,
+    })
+    session = sessionFromResponse(session.client, tokenRes)
+    await saveSession(opts.tokenPath, session)
+    return session.accessToken
+  }
+
+  async function ensureMcp(): Promise<MCPClient> {
+    const token = await ensureToken()
+    if (mcp && mcpToken === token) return mcp
+    if (mcp) await mcp.close().catch(() => undefined)
+    mcpToken = token
+    mcp = await createMCPClient({
+      transport: {
+        type: 'http',
+        url: mcpUrl,
+        headers: { Authorization: `Bearer ${token}` },
+      } as unknown as MCPTransport,
+      name: 'talos-keeperhub',
+      onUncaughtError: (err) => log.error({ err }, 'KeeperHub MCP uncaught error'),
+    })
+    return mcp
+  }
+
+  async function callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+    const client = await ensureMcp()
+    const tools = await client.tools()
+    const tool = tools[name]
+    if (!tool?.execute) {
+      throw new Error(`KeeperHub tool "${name}" unavailable or has no execute`)
+    }
+    const raw = await tool.execute(args, {
+      toolCallId: `keeperhub-${name}-${Date.now()}`,
+      messages: [],
+    })
+    return flattenToolResult(raw)
+  }
+
+  function asExecutionResult(raw: unknown): ExecutionResult {
+    if (typeof raw !== 'object' || raw === null) {
+      return { executionId: '', status: 'pending', output: raw }
+    }
+    const r = raw as Record<string, unknown>
+    const executionId =
+      typeof r.execution_id === 'string'
+        ? r.execution_id
+        : typeof r.executionId === 'string'
+          ? r.executionId
+          : ''
+    const statusRaw = (r.status ?? r.state) as string | undefined
+    const status = (
+      ['pending', 'running', 'success', 'failed', 'cancelled'].includes(statusRaw ?? '')
+        ? statusRaw
+        : 'pending'
+    ) as WorkflowExecutionStatus
+    const txHash =
+      typeof r.tx_hash === 'string'
+        ? r.tx_hash
+        : typeof r.txHash === 'string'
+          ? r.txHash
+          : undefined
+    const error = typeof r.error === 'string' ? r.error : undefined
+    return {
+      executionId,
+      status,
+      ...(txHash !== undefined ? { txHash } : {}),
+      ...(error !== undefined ? { error } : {}),
+      output: r,
+    }
+  }
+
+  return {
+    ensureToken,
+    async listTools(): Promise<Record<string, Tool>> {
+      const client = await ensureMcp()
+      return (await client.tools()) as Record<string, Tool>
+    },
+    callTool,
+    async executeContractCall(input) {
+      return asExecutionResult(await callTool('execute_contract_call', input))
+    },
+    async executeTransfer(input) {
+      return asExecutionResult(await callTool('execute_transfer', input))
+    },
+    async getExecutionStatus(executionId) {
+      return asExecutionResult(
+        await callTool('get_direct_execution_status', { execution_id: executionId }),
+      )
+    },
+    async close() {
+      if (mcp) {
+        await mcp.close().catch(() => undefined)
+        mcp = null
+        mcpToken = null
+      }
+    },
+  }
+}
+
+/** Re-exported for tests + future callers. */
+export { EXPIRY_BUFFER_MS }

--- a/src/keeperhub/index.ts
+++ b/src/keeperhub/index.ts
@@ -1,19 +1,45 @@
-import { TalosNotImplementedError } from '@/shared/errors'
-
-export const KNOWN_READONLY: readonly RegExp[] = [
-  /_get_/,
-  /_quote$/,
-  /_status$/,
-  /_balance$/,
-  /_position$/,
-  /_search/,
-  /^blockscout_/,
-] as const
-
-export function shouldAudit(_toolName: string, _annotations?: { mutates?: boolean }): never {
-  throw new TalosNotImplementedError('keeperhub.shouldAudit')
-}
-
-export function createKeeperHubMiddleware(): never {
-  throw new TalosNotImplementedError('keeperhub.createKeeperHubMiddleware')
-}
+export {
+  type ContractCallInput,
+  createKeeperHubClient,
+  type ExecutionResult,
+  type KeeperHubClient,
+  type KeeperHubClientOpts,
+  type TransferInput,
+  type WorkflowExecutionStatus,
+} from './client'
+export {
+  type AnnotationLookup,
+  createKeeperHubMiddleware,
+  type KeeperHubMiddlewareDeps,
+  KNOWN_READONLY,
+  type RunContext,
+  type RunContextProvider,
+  type ShouldAuditDecision,
+  shouldAudit,
+  type ToolMiddleware,
+} from './middleware'
+export {
+  type AuthServerMetadata,
+  buildAuthorizeUrl,
+  discoverAuthServer,
+  type ExchangeCodeOpts,
+  exchangeCode,
+  generatePkce,
+  generateState,
+  type PkcePair,
+  type RefreshTokenOpts,
+  type RegisterClientOpts,
+  type RegisteredClient,
+  refreshToken,
+  registerClient,
+  type TokenResponse,
+} from './oauth'
+export {
+  clearSession,
+  EXPIRY_BUFFER_MS,
+  isExpired,
+  loadSession,
+  type StoredSession,
+  saveSession,
+  sessionFromResponse,
+} from './token'

--- a/src/keeperhub/middleware.ts
+++ b/src/keeperhub/middleware.ts
@@ -1,0 +1,153 @@
+import type { Tool } from 'ai'
+import type { ToolAnnotations } from '@/mcp-host/registry'
+import { appendToolCallAudit, type Db, type ToolAuditMeta } from '@/persistence/queries'
+import { child } from '@/shared/logger'
+
+const log = child({ module: 'keeperhub-middleware' })
+
+/**
+ * Regex allowlist for tools that bypass KeeperHub workflow routing.
+ * Sourced from `docs/spec.md` F5.11 + extended for known read-only patterns
+ * surfaced by Blockscout / quote / balance / position queries.
+ */
+export const KNOWN_READONLY: readonly RegExp[] = [
+  /_get_/,
+  /_quote$/,
+  /_status$/,
+  /_balance$/,
+  /_position$/,
+  /_search/,
+  /^blockscout_/,
+] as const
+
+export type ShouldAuditDecision = {
+  shouldAudit: boolean
+  reason: 'KNOWN_READONLY' | 'annotation_readOnly' | 'annotation_mutates' | 'audit_default'
+}
+
+/**
+ * Audit-by-default policy.
+ * 1. Tool name matches `KNOWN_READONLY` regex → bypass.
+ * 2. Tool's MCP annotation `readOnly === true` → bypass.
+ * 3. Tool's MCP annotation `mutates === true` → audit (explicit).
+ * 4. Otherwise → audit (default; the audit-by-default decision).
+ */
+export function shouldAudit(toolName: string, annotations?: ToolAnnotations): ShouldAuditDecision {
+  if (KNOWN_READONLY.some((re) => re.test(toolName))) {
+    return { shouldAudit: false, reason: 'KNOWN_READONLY' }
+  }
+  if (annotations?.readOnly === true) {
+    return { shouldAudit: false, reason: 'annotation_readOnly' }
+  }
+  if (annotations?.mutates === true) {
+    return { shouldAudit: true, reason: 'annotation_mutates' }
+  }
+  return { shouldAudit: true, reason: 'audit_default' }
+}
+
+/** Per-call run context that the runtime threads in (one per agent run). */
+export type RunContext = {
+  runId: string
+  stepId?: string | null
+}
+
+export type RunContextProvider = () => RunContext | null
+
+export type AnnotationLookup = (toolName: string) => ToolAnnotations | undefined
+
+export type KeeperHubMiddlewareDeps = {
+  db: Db
+  /**
+   * Returns the current run context, or `null` if no run is active.
+   * The runtime (#7 / #10 follow-up) sets and clears this around `streamText`.
+   * Without a run context, the middleware logs decisions to pino and skips
+   * the DB write — useful for ad-hoc tool calls outside the agent loop.
+   */
+  runContext: RunContextProvider
+  /**
+   * Optional lookup for MCP-side tool annotations. The runtime gets only
+   * `Record<string, Tool>` from the AI SDK, which has no annotations field —
+   * this getter lets the middleware consult `McpHost.listTools()` per tool name.
+   * Returns `undefined` for tools that have no annotations (defaults apply).
+   */
+  annotations?: AnnotationLookup
+}
+
+export type ToolMiddleware = (tools: Record<string, Tool>) => Record<string, Tool>
+
+/**
+ * Build an audit-by-default middleware that wraps each tool's `execute`,
+ * applies `shouldAudit`, runs the original tool, and persists a tool-call
+ * row with structured audit metadata.
+ *
+ * For #8 the middleware always passes through to the original tool (no
+ * workflow envelope). #10 will plug in `KeeperHubClient.executeContractCall`
+ * for tools whose decision is `shouldAudit=true`.
+ */
+export function createKeeperHubMiddleware(deps: KeeperHubMiddlewareDeps): ToolMiddleware {
+  return (tools) => {
+    const wrapped: Record<string, Tool> = {}
+    for (const [name, tool] of Object.entries(tools)) {
+      wrapped[name] = wrapTool(name, tool, deps)
+    }
+    return wrapped
+  }
+}
+
+function wrapTool(name: string, original: Tool, deps: KeeperHubMiddlewareDeps): Tool {
+  const annotations = deps.annotations?.(name)
+  const decision = shouldAudit(name, annotations)
+
+  const originalExecute = original.execute
+  if (!originalExecute) return original
+
+  const wrappedTool: Tool = {
+    ...original,
+    execute: async (args, ctx) => {
+      const startedAt = new Date()
+      const runCtx = deps.runContext()
+      let result: unknown
+      let error: string | undefined
+      try {
+        result = await originalExecute(args, ctx)
+        return result
+      } catch (e) {
+        error = e instanceof Error ? e.message : String(e)
+        throw e
+      } finally {
+        const finishedAt = new Date()
+        const auditMeta: ToolAuditMeta = {
+          shouldAudit: decision.shouldAudit,
+          reason: decision.reason,
+          details: {
+            elapsedMs: finishedAt.getTime() - startedAt.getTime(),
+          },
+        }
+        if (runCtx) {
+          try {
+            await appendToolCallAudit(deps.db, {
+              runId: runCtx.runId,
+              stepId: runCtx.stepId ?? null,
+              toolCallId: ctx.toolCallId,
+              toolName: name,
+              args: args as unknown,
+              ...(result !== undefined ? { result } : {}),
+              ...(error !== undefined ? { error } : {}),
+              audit: auditMeta,
+              startedAt,
+              finishedAt,
+            })
+          } catch (writeErr) {
+            log.warn({ err: writeErr, toolName: name }, 'failed to write tool-call audit row')
+          }
+        } else {
+          log.info(
+            { toolName: name, decision, toolCallId: ctx.toolCallId, error },
+            'tool audit (no run context)',
+          )
+        }
+      }
+    },
+  }
+  return wrappedTool
+}

--- a/src/keeperhub/oauth.ts
+++ b/src/keeperhub/oauth.ts
@@ -1,0 +1,214 @@
+import crypto from 'node:crypto'
+import { TalosAuthError } from '@/shared/errors'
+
+const KEEPERHUB_BASE = 'https://app.keeperhub.com'
+const DEFAULT_SCOPES = ['mcp:read', 'mcp:write']
+const DEFAULT_CLIENT_NAME = 'talos'
+
+/** OAuth Authorization Server metadata (RFC 8414) — only fields we actually use. */
+export type AuthServerMetadata = {
+  issuer: string
+  authorization_endpoint: string
+  token_endpoint: string
+  registration_endpoint?: string
+  scopes_supported?: string[]
+  code_challenge_methods_supported?: string[]
+  grant_types_supported?: string[]
+}
+
+export type RegisteredClient = {
+  client_id: string
+  client_secret?: string
+  client_id_issued_at?: number
+  registration_access_token?: string
+  registration_client_uri?: string
+}
+
+export type PkcePair = {
+  verifier: string
+  challenge: string
+  method: 'S256'
+}
+
+export type TokenResponse = {
+  access_token: string
+  token_type: string
+  expires_in: number
+  refresh_token?: string
+  scope?: string
+}
+
+export type DiscoveryOpts = { fetch?: typeof fetch; baseUrl?: string }
+
+/**
+ * Discover the KeeperHub authorization server metadata.
+ * Hits `${baseUrl}/.well-known/oauth-authorization-server`.
+ */
+export async function discoverAuthServer(opts: DiscoveryOpts = {}): Promise<AuthServerMetadata> {
+  const fetchImpl = opts.fetch ?? fetch
+  const url = `${opts.baseUrl ?? KEEPERHUB_BASE}/.well-known/oauth-authorization-server`
+  const res = await fetchImpl(url)
+  if (!res.ok) {
+    throw new TalosAuthError(
+      `KeeperHub auth-server discovery failed: ${res.status} ${res.statusText}`,
+    )
+  }
+  const meta = (await res.json()) as AuthServerMetadata
+  if (!meta.authorization_endpoint || !meta.token_endpoint) {
+    throw new TalosAuthError('KeeperHub auth-server metadata missing required endpoints')
+  }
+  return meta
+}
+
+/**
+ * Generate a PKCE verifier + S256 challenge.
+ * Verifier: 43-128 unreserved chars; challenge: BASE64URL(SHA256(verifier)).
+ */
+export function generatePkce(): PkcePair {
+  const verifier = base64UrlEncode(crypto.randomBytes(32))
+  const challenge = base64UrlEncode(crypto.createHash('sha256').update(verifier).digest())
+  return { verifier, challenge, method: 'S256' }
+}
+
+/** Random hex state for CSRF defense on the auth-code redirect. */
+export function generateState(): string {
+  return crypto.randomBytes(16).toString('hex')
+}
+
+export type RegisterClientOpts = {
+  fetch?: typeof fetch
+  meta: AuthServerMetadata
+  clientName?: string
+  redirectUri: string
+  scopes?: string[]
+}
+
+/**
+ * Dynamic Client Registration (RFC 7591). Registers a public PKCE client
+ * with KeeperHub and returns the issued client_id.
+ */
+export async function registerClient(opts: RegisterClientOpts): Promise<RegisteredClient> {
+  const fetchImpl = opts.fetch ?? fetch
+  if (!opts.meta.registration_endpoint) {
+    throw new TalosAuthError(
+      'KeeperHub auth-server does not advertise registration_endpoint (DCR unsupported)',
+    )
+  }
+
+  const body = {
+    client_name: opts.clientName ?? DEFAULT_CLIENT_NAME,
+    redirect_uris: [opts.redirectUri],
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+    scope: (opts.scopes ?? DEFAULT_SCOPES).join(' '),
+  }
+
+  const res = await fetchImpl(opts.meta.registration_endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new TalosAuthError(`KeeperHub DCR failed: ${res.status} ${res.statusText} ${text}`.trim())
+  }
+
+  return (await res.json()) as RegisteredClient
+}
+
+export type BuildAuthUrlOpts = {
+  meta: AuthServerMetadata
+  clientId: string
+  redirectUri: string
+  scopes?: string[]
+  pkce: PkcePair
+  state: string
+}
+
+/** Build the redirect URL the user opens in their browser to grant access. */
+export function buildAuthorizeUrl(opts: BuildAuthUrlOpts): string {
+  const u = new URL(opts.meta.authorization_endpoint)
+  u.searchParams.set('response_type', 'code')
+  u.searchParams.set('client_id', opts.clientId)
+  u.searchParams.set('redirect_uri', opts.redirectUri)
+  u.searchParams.set('scope', (opts.scopes ?? DEFAULT_SCOPES).join(' '))
+  u.searchParams.set('state', opts.state)
+  u.searchParams.set('code_challenge', opts.pkce.challenge)
+  u.searchParams.set('code_challenge_method', opts.pkce.method)
+  return u.toString()
+}
+
+export type ExchangeCodeOpts = {
+  fetch?: typeof fetch
+  meta: AuthServerMetadata
+  clientId: string
+  clientSecret?: string
+  redirectUri: string
+  code: string
+  pkceVerifier: string
+}
+
+/** Exchange the authorization code for an access + refresh token. */
+export async function exchangeCode(opts: ExchangeCodeOpts): Promise<TokenResponse> {
+  const fetchImpl = opts.fetch ?? fetch
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: opts.code,
+    redirect_uri: opts.redirectUri,
+    client_id: opts.clientId,
+    code_verifier: opts.pkceVerifier,
+  })
+  if (opts.clientSecret) body.set('client_secret', opts.clientSecret)
+
+  return postTokenRequest(fetchImpl, opts.meta.token_endpoint, body)
+}
+
+export type RefreshTokenOpts = {
+  fetch?: typeof fetch
+  meta: AuthServerMetadata
+  clientId: string
+  clientSecret?: string
+  refreshToken: string
+}
+
+/** Use the refresh_token grant to mint a new access token. */
+export async function refreshToken(opts: RefreshTokenOpts): Promise<TokenResponse> {
+  const fetchImpl = opts.fetch ?? fetch
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: opts.refreshToken,
+    client_id: opts.clientId,
+  })
+  if (opts.clientSecret) body.set('client_secret', opts.clientSecret)
+
+  return postTokenRequest(fetchImpl, opts.meta.token_endpoint, body)
+}
+
+async function postTokenRequest(
+  fetchImpl: typeof fetch,
+  endpoint: string,
+  body: URLSearchParams,
+): Promise<TokenResponse> {
+  const res = await fetchImpl(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new TalosAuthError(
+      `KeeperHub token request failed: ${res.status} ${res.statusText} ${text}`.trim(),
+    )
+  }
+  const json = (await res.json()) as TokenResponse
+  if (!json.access_token || typeof json.expires_in !== 'number') {
+    throw new TalosAuthError('KeeperHub token response missing access_token or expires_in')
+  }
+  return json
+}
+
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}

--- a/src/keeperhub/token.ts
+++ b/src/keeperhub/token.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { TalosAuthError } from '@/shared/errors'
+import type { RegisteredClient, TokenResponse } from './oauth'
+
+/** Persisted KeeperHub session — token + the client we registered to obtain it. */
+export type StoredSession = {
+  client: RegisteredClient
+  accessToken: string
+  refreshToken?: string
+  /** Wall-clock millis when access_token becomes invalid. */
+  expiresAt: number
+  scope?: string
+  tokenType: string
+}
+
+/** Refresh proactively if expiry is within this many ms. */
+export const EXPIRY_BUFFER_MS = 60_000
+
+export async function saveSession(filePath: string, session: StoredSession): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  const payload = JSON.stringify(session, null, 2)
+  await fs.writeFile(filePath, payload, { encoding: 'utf8', mode: 0o600 })
+  // mkdir + writeFile may race on umask; explicitly chmod to be sure.
+  await fs.chmod(filePath, 0o600).catch(() => undefined)
+}
+
+export async function loadSession(filePath: string): Promise<StoredSession | null> {
+  let raw: string
+  try {
+    raw = await fs.readFile(filePath, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+  try {
+    const parsed = JSON.parse(raw) as StoredSession
+    if (!parsed.accessToken || !parsed.client?.client_id || typeof parsed.expiresAt !== 'number') {
+      throw new TalosAuthError('KeeperHub token file is malformed')
+    }
+    return parsed
+  } catch (err) {
+    if (err instanceof TalosAuthError) throw err
+    throw new TalosAuthError('KeeperHub token file is not valid JSON', err)
+  }
+}
+
+export async function clearSession(filePath: string): Promise<void> {
+  await fs.rm(filePath, { force: true })
+}
+
+/** True if the access token is expired or within the refresh buffer. */
+export function isExpired(session: StoredSession, now: number = Date.now()): boolean {
+  return session.expiresAt - now <= EXPIRY_BUFFER_MS
+}
+
+/** Build a session from a fresh token response + the client that obtained it. */
+export function sessionFromResponse(
+  client: RegisteredClient,
+  res: TokenResponse,
+  now: number = Date.now(),
+): StoredSession {
+  return {
+    client,
+    accessToken: res.access_token,
+    ...(res.refresh_token !== undefined ? { refreshToken: res.refresh_token } : {}),
+    expiresAt: now + res.expires_in * 1000,
+    ...(res.scope !== undefined ? { scope: res.scope } : {}),
+    tokenType: res.token_type,
+  }
+}

--- a/src/mcp-host/index.ts
+++ b/src/mcp-host/index.ts
@@ -13,6 +13,8 @@ export interface McpServerConfig {
   command?: string
   args?: string[]
   url?: string
+  /** Extra headers for HTTP transport (e.g. `Authorization: Bearer ...`). */
+  headers?: Record<string, string>
 }
 
 /**

--- a/src/mcp-host/transports.ts
+++ b/src/mcp-host/transports.ts
@@ -37,6 +37,7 @@ export function buildTransport(
     return {
       type: 'http' as const,
       url: config.url,
+      ...(config.headers ? { headers: config.headers } : {}),
     }
   }
 

--- a/src/persistence/queries.ts
+++ b/src/persistence/queries.ts
@@ -69,6 +69,52 @@ export async function recordToolCall(db: Db, input: NewToolCall) {
   return row
 }
 
+export type ToolAuditMeta = {
+  /** True if KeeperHub middleware would route this through workflow audit. */
+  shouldAudit: boolean
+  /** Why the decision was made (e.g. KNOWN_READONLY, annotation_readOnly, audit_default). */
+  reason: string
+  /** KeeperHub workflow / execution / tx wiring (populated by #10's protocol-tool routing). */
+  workflowId?: string
+  executionId?: string
+  txHash?: string
+  /** Free-form details passed by the middleware (e.g. timing, route taken). */
+  details?: Record<string, unknown>
+}
+
+export type ToolCallAuditInput = {
+  runId: string
+  stepId?: string | null
+  toolCallId: string
+  toolName: string
+  args?: unknown
+  result?: unknown
+  error?: string | null
+  audit: ToolAuditMeta
+  startedAt?: Date
+  finishedAt?: Date
+}
+
+/**
+ * Append a tool-call row with structured audit metadata. Used by the
+ * KeeperHub middleware on every tool invocation; never throws on
+ * malformed audit metadata — failures are surfaced to the caller.
+ */
+export async function appendToolCallAudit(db: Db, input: ToolCallAuditInput) {
+  return recordToolCall(db, {
+    runId: input.runId,
+    stepId: input.stepId ?? null,
+    toolCallId: input.toolCallId,
+    toolName: input.toolName,
+    args: input.args ?? null,
+    result: input.result ?? null,
+    error: input.error ?? null,
+    audit: input.audit,
+    ...(input.startedAt ? { startedAt: input.startedAt } : {}),
+    ...(input.finishedAt ? { finishedAt: input.finishedAt } : {}),
+  })
+}
+
 export async function insertMessageEmbedding(
   db: Db,
   input: Omit<NewMessageEmbedding, 'embedding'> & { embedding: number[] },

--- a/tests/integration/keeperhub.test.ts
+++ b/tests/integration/keeperhub.test.ts
@@ -1,0 +1,702 @@
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  type AuthServerMetadata,
+  buildAuthorizeUrl,
+  clearSession,
+  createKeeperHubClient,
+  createKeeperHubMiddleware,
+  discoverAuthServer,
+  exchangeCode,
+  generatePkce,
+  generateState,
+  isExpired,
+  KNOWN_READONLY,
+  loadSession,
+  type RegisteredClient,
+  refreshToken,
+  registerClient,
+  type StoredSession,
+  saveSession,
+  sessionFromResponse,
+  shouldAudit,
+  type TokenResponse,
+} from '@/keeperhub'
+import { createDb, type DbHandle, openRun, runMigrations, upsertThread } from '@/persistence'
+
+// ---------------------------------------------------------------------------
+// Mocks for @ai-sdk/mcp (only exercised by client.ts tests)
+// ---------------------------------------------------------------------------
+
+const { mockCreateMCPClient } = vi.hoisted(() => {
+  const mockCreateMCPClient = vi.fn()
+  return { mockCreateMCPClient }
+})
+
+vi.mock('@ai-sdk/mcp', () => ({
+  createMCPClient: mockCreateMCPClient,
+}))
+
+vi.mock('@/config/env', () => ({
+  loadEnv: () => ({
+    OPENAI_API_KEY: 'test-key',
+    TALOS_DAEMON_PORT: 7711,
+    TALOS_LOG_LEVEL: 'silent',
+    NODE_ENV: 'test',
+  }),
+  resetEnvCache: () => {},
+}))
+
+// ---------------------------------------------------------------------------
+// OAuth pure-function tests (fetch mocked)
+// ---------------------------------------------------------------------------
+
+const FAKE_META: AuthServerMetadata = {
+  issuer: 'https://app.keeperhub.com',
+  authorization_endpoint: 'https://app.keeperhub.com/oauth/authorize',
+  token_endpoint: 'https://app.keeperhub.com/api/oauth/token',
+  registration_endpoint: 'https://app.keeperhub.com/api/oauth/register',
+  scopes_supported: ['mcp:read', 'mcp:write', 'mcp:admin'],
+  code_challenge_methods_supported: ['S256'],
+  grant_types_supported: ['authorization_code', 'refresh_token'],
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init.headers ?? {}) },
+  })
+}
+
+describe('discoverAuthServer', () => {
+  it('parses metadata from .well-known endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(FAKE_META))
+    const meta = await discoverAuthServer({ fetch: fetchMock })
+    expect(meta.token_endpoint).toBe(FAKE_META.token_endpoint)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://app.keeperhub.com/.well-known/oauth-authorization-server',
+    )
+  })
+
+  it('throws TalosAuthError on 4xx', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('not found', { status: 404 }))
+    await expect(discoverAuthServer({ fetch: fetchMock })).rejects.toThrow(/discovery failed/)
+  })
+
+  it('throws when required endpoints missing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ issuer: 'https://x' }))
+    await expect(discoverAuthServer({ fetch: fetchMock })).rejects.toThrow(/missing required/)
+  })
+})
+
+describe('generatePkce', () => {
+  it('produces a 43+ char unreserved verifier', () => {
+    const { verifier } = generatePkce()
+    expect(verifier.length).toBeGreaterThanOrEqual(43)
+    expect(/^[A-Za-z0-9_-]+$/.test(verifier)).toBe(true)
+  })
+
+  it('challenge is BASE64URL(SHA256(verifier))', () => {
+    const { verifier, challenge, method } = generatePkce()
+    const expected = require('node:crypto')
+      .createHash('sha256')
+      .update(verifier)
+      .digest('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '')
+    expect(challenge).toBe(expected)
+    expect(method).toBe('S256')
+  })
+
+  it('two calls produce distinct verifiers', () => {
+    const a = generatePkce()
+    const b = generatePkce()
+    expect(a.verifier).not.toBe(b.verifier)
+  })
+})
+
+describe('generateState', () => {
+  it('returns 32-char hex string', () => {
+    const s = generateState()
+    expect(s.length).toBe(32)
+    expect(/^[0-9a-f]+$/.test(s)).toBe(true)
+  })
+})
+
+describe('registerClient (DCR)', () => {
+  it('posts the expected body and returns the issued client', async () => {
+    const fakeClient: RegisteredClient = { client_id: 'client-abc' }
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(fakeClient))
+    const out = await registerClient({
+      fetch: fetchMock,
+      meta: FAKE_META,
+      redirectUri: 'http://127.0.0.1:43210/callback',
+    })
+    expect(out.client_id).toBe('client-abc')
+    expect(fetchMock).toHaveBeenCalledWith(
+      FAKE_META.registration_endpoint,
+      expect.objectContaining({ method: 'POST' }),
+    )
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = JSON.parse((init as RequestInit).body as string) as Record<string, unknown>
+    expect(body.token_endpoint_auth_method).toBe('none')
+    expect(body.grant_types).toEqual(['authorization_code', 'refresh_token'])
+    expect(body.scope).toBe('mcp:read mcp:write')
+  })
+
+  it('throws when meta has no registration_endpoint', async () => {
+    await expect(
+      registerClient({
+        meta: { ...FAKE_META, registration_endpoint: undefined as unknown as string },
+        redirectUri: 'http://127.0.0.1:43210/callback',
+      }),
+    ).rejects.toThrow(/DCR unsupported/)
+  })
+
+  it('surfaces server error body in the thrown message', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('client_name required', { status: 400 }))
+    await expect(
+      registerClient({
+        fetch: fetchMock,
+        meta: FAKE_META,
+        redirectUri: 'http://127.0.0.1:43210/callback',
+      }),
+    ).rejects.toThrow(/DCR failed: 400/)
+  })
+})
+
+describe('buildAuthorizeUrl', () => {
+  it('includes every required PKCE/OAuth param', () => {
+    const url = buildAuthorizeUrl({
+      meta: FAKE_META,
+      clientId: 'client-abc',
+      redirectUri: 'http://127.0.0.1:43210/callback',
+      pkce: { verifier: 'v', challenge: 'c', method: 'S256' },
+      state: 'st',
+    })
+    const u = new URL(url)
+    expect(u.searchParams.get('response_type')).toBe('code')
+    expect(u.searchParams.get('client_id')).toBe('client-abc')
+    expect(u.searchParams.get('code_challenge')).toBe('c')
+    expect(u.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(u.searchParams.get('state')).toBe('st')
+    expect(u.searchParams.get('scope')).toBe('mcp:read mcp:write')
+  })
+})
+
+describe('exchangeCode + refreshToken', () => {
+  const tokenRes: TokenResponse = {
+    access_token: 'at-1',
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: 'rt-1',
+    scope: 'mcp:read mcp:write',
+  }
+
+  it('exchangeCode posts form body and parses response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(tokenRes))
+    const out = await exchangeCode({
+      fetch: fetchMock,
+      meta: FAKE_META,
+      clientId: 'client-abc',
+      redirectUri: 'http://127.0.0.1:43210/callback',
+      code: 'AUTH_CODE',
+      pkceVerifier: 'verif',
+    })
+    expect(out.access_token).toBe('at-1')
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = (init as RequestInit).body as string
+    expect(body).toContain('grant_type=authorization_code')
+    expect(body).toContain('code=AUTH_CODE')
+    expect(body).toContain('code_verifier=verif')
+  })
+
+  it('refreshToken posts grant_type=refresh_token', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(tokenRes))
+    await refreshToken({
+      fetch: fetchMock,
+      meta: FAKE_META,
+      clientId: 'client-abc',
+      refreshToken: 'rt-1',
+    })
+    const [, init] = fetchMock.mock.calls[0]!
+    const body = (init as RequestInit).body as string
+    expect(body).toContain('grant_type=refresh_token')
+    expect(body).toContain('refresh_token=rt-1')
+  })
+
+  it('throws on non-2xx response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('bad code', { status: 400 }))
+    await expect(
+      exchangeCode({
+        fetch: fetchMock,
+        meta: FAKE_META,
+        clientId: 'client-abc',
+        redirectUri: 'http://127.0.0.1:43210/callback',
+        code: 'AUTH_CODE',
+        pkceVerifier: 'verif',
+      }),
+    ).rejects.toThrow(/token request failed: 400/)
+  })
+
+  it('throws when access_token missing in response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ token_type: 'Bearer', expires_in: 3600 }))
+    await expect(
+      exchangeCode({
+        fetch: fetchMock,
+        meta: FAKE_META,
+        clientId: 'client-abc',
+        redirectUri: 'http://127.0.0.1:43210/callback',
+        code: 'AUTH_CODE',
+        pkceVerifier: 'verif',
+      }),
+    ).rejects.toThrow(/missing access_token/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Token persistence tests
+// ---------------------------------------------------------------------------
+
+describe('token persistence', () => {
+  let tmpDir: string
+  let tokenPath: string
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'talos-keeperhub-'))
+    tokenPath = path.join(tmpDir, 'keeperhub.token')
+  })
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  const sample: StoredSession = {
+    client: { client_id: 'client-abc' },
+    accessToken: 'at-1',
+    refreshToken: 'rt-1',
+    expiresAt: Date.now() + 3_600_000,
+    scope: 'mcp:read mcp:write',
+    tokenType: 'Bearer',
+  }
+
+  it('round-trips save + load', async () => {
+    await saveSession(tokenPath, sample)
+    const loaded = await loadSession(tokenPath)
+    expect(loaded).toEqual(sample)
+  })
+
+  it('writes file with 0600 perms', async () => {
+    await saveSession(tokenPath, sample)
+    const stat = fs.statSync(tokenPath)
+    // mask off file-type bits, compare permissions
+    expect(stat.mode & 0o777).toBe(0o600)
+  })
+
+  it('returns null when file is missing', async () => {
+    const loaded = await loadSession(path.join(tmpDir, 'nope'))
+    expect(loaded).toBeNull()
+  })
+
+  it('throws on malformed JSON', async () => {
+    await fsp.writeFile(tokenPath, '{not json', 'utf8')
+    await expect(loadSession(tokenPath)).rejects.toThrow(/not valid JSON/)
+  })
+
+  it('throws on missing required fields', async () => {
+    await fsp.writeFile(tokenPath, JSON.stringify({ accessToken: 'x' }), 'utf8')
+    await expect(loadSession(tokenPath)).rejects.toThrow(/malformed/)
+  })
+
+  it('clearSession removes file (idempotent)', async () => {
+    await saveSession(tokenPath, sample)
+    await clearSession(tokenPath)
+    expect(fs.existsSync(tokenPath)).toBe(false)
+    await clearSession(tokenPath) // second call shouldn't throw
+  })
+
+  it('isExpired returns true when within buffer (60s)', () => {
+    const fresh = { ...sample, expiresAt: Date.now() + 30_000 }
+    const future = { ...sample, expiresAt: Date.now() + 600_000 }
+    expect(isExpired(fresh)).toBe(true)
+    expect(isExpired(future)).toBe(false)
+  })
+
+  it('sessionFromResponse derives expiresAt = now + expires_in*1000', () => {
+    const now = 1_700_000_000_000
+    const session = sessionFromResponse(
+      { client_id: 'client-abc' },
+      {
+        access_token: 'at',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'rt',
+      },
+      now,
+    )
+    expect(session.expiresAt).toBe(now + 3_600_000)
+    expect(session.refreshToken).toBe('rt')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// shouldAudit decision tree
+// ---------------------------------------------------------------------------
+
+describe('shouldAudit', () => {
+  it('bypasses tools matching KNOWN_READONLY', () => {
+    expect(shouldAudit('blockscout_get_balance').shouldAudit).toBe(false)
+    expect(shouldAudit('aave_get_position').reason).toBe('KNOWN_READONLY')
+    expect(shouldAudit('uniswap_quote').reason).toBe('KNOWN_READONLY')
+  })
+
+  it('bypasses tools annotated readOnly', () => {
+    const d = shouldAudit('aave_supply', { readOnly: true })
+    expect(d.shouldAudit).toBe(false)
+    expect(d.reason).toBe('annotation_readOnly')
+  })
+
+  it('audits tools annotated mutates', () => {
+    const d = shouldAudit('aave_supply', { mutates: true })
+    expect(d.shouldAudit).toBe(true)
+    expect(d.reason).toBe('annotation_mutates')
+  })
+
+  it('audits tools without annotations (audit-by-default)', () => {
+    const d = shouldAudit('uniswap_swap')
+    expect(d.shouldAudit).toBe(true)
+    expect(d.reason).toBe('audit_default')
+  })
+
+  it('KNOWN_READONLY allowlist exposed for inspection', () => {
+    expect(KNOWN_READONLY.length).toBeGreaterThan(0)
+    expect(KNOWN_READONLY.every((r) => r instanceof RegExp)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createKeeperHubMiddleware
+// ---------------------------------------------------------------------------
+
+describe('createKeeperHubMiddleware', () => {
+  let handle: DbHandle
+  let runId: string
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+    await upsertThread(handle.db, { id: 't-1', channel: 'cli', agentId: 'talos-eth' })
+    const run = await openRun(handle.db, { threadId: 't-1', prompt: 'test' })
+    runId = run.id
+  })
+
+  afterEach(async () => {
+    await handle.close()
+  })
+
+  function makeTool(execute: (args: unknown) => Promise<unknown>) {
+    return {
+      description: 'test tool',
+      inputSchema: { type: 'object' as const, properties: {} },
+      execute: async (args: unknown, _ctx: unknown) => execute(args),
+    } as never
+  }
+
+  async function readToolCall(toolCallId: string) {
+    return handle.pg.query<{
+      tool_name: string
+      audit: { shouldAudit: boolean; reason: string }
+      result: unknown
+      error: string | null
+    }>(`SELECT tool_name, audit, result, error FROM tool_calls WHERE tool_call_id = $1`, [
+      toolCallId,
+    ])
+  }
+
+  it('wraps tools and writes audit row on success', async () => {
+    const middleware = createKeeperHubMiddleware({
+      db: handle.db,
+      runContext: () => ({ runId }),
+    })
+    const wrapped = middleware({
+      uniswap_swap: makeTool(async () => ({ ok: true })),
+    })
+
+    const result = await wrapped.uniswap_swap!.execute!(
+      { amount: 100 },
+      { toolCallId: 'tc-1', messages: [] },
+    )
+    expect(result).toEqual({ ok: true })
+
+    const rows = await readToolCall('tc-1')
+    expect(rows.rows).toHaveLength(1)
+    const row = rows.rows[0]!
+    expect(row.tool_name).toBe('uniswap_swap')
+    expect(row.audit.shouldAudit).toBe(true)
+    expect(row.audit.reason).toBe('audit_default')
+    expect(row.result).toEqual({ ok: true })
+  })
+
+  it('marks audit row with KNOWN_READONLY reason for read-only tool', async () => {
+    const middleware = createKeeperHubMiddleware({
+      db: handle.db,
+      runContext: () => ({ runId }),
+    })
+    const wrapped = middleware({
+      blockscout_get_balance: makeTool(async () => '0xff'),
+    })
+
+    await wrapped.blockscout_get_balance!.execute!(
+      { addr: '0x0' },
+      { toolCallId: 'tc-2', messages: [] },
+    )
+
+    const rows = await readToolCall('tc-2')
+    const row = rows.rows[0]!
+    expect(row.audit.shouldAudit).toBe(false)
+    expect(row.audit.reason).toBe('KNOWN_READONLY')
+  })
+
+  it('uses annotation lookup when provided', async () => {
+    const middleware = createKeeperHubMiddleware({
+      db: handle.db,
+      runContext: () => ({ runId }),
+      annotations: (name) => (name === 'aave_supply' ? { mutates: true } : undefined),
+    })
+    const wrapped = middleware({ aave_supply: makeTool(async () => 'ok') })
+    await wrapped.aave_supply!.execute!({}, { toolCallId: 'tc-3', messages: [] })
+    const rows = await readToolCall('tc-3')
+    expect(rows.rows[0]!.audit.reason).toBe('annotation_mutates')
+  })
+
+  it('records error and rethrows when tool throws', async () => {
+    const middleware = createKeeperHubMiddleware({
+      db: handle.db,
+      runContext: () => ({ runId }),
+    })
+    const wrapped = middleware({
+      uniswap_swap: makeTool(async () => {
+        throw new Error('insufficient liquidity')
+      }),
+    })
+
+    await expect(
+      wrapped.uniswap_swap!.execute!({}, { toolCallId: 'tc-4', messages: [] }),
+    ).rejects.toThrow(/insufficient liquidity/)
+
+    const rows = await readToolCall('tc-4')
+    expect(rows.rows[0]!.error).toContain('insufficient liquidity')
+    expect(rows.rows[0]!.audit.shouldAudit).toBe(true)
+  })
+
+  it('skips DB write when no run context is available', async () => {
+    const middleware = createKeeperHubMiddleware({
+      db: handle.db,
+      runContext: () => null,
+    })
+    const wrapped = middleware({ uniswap_swap: makeTool(async () => 'ok') })
+    await wrapped.uniswap_swap!.execute!({}, { toolCallId: 'tc-5', messages: [] })
+    const rows = await readToolCall('tc-5')
+    expect(rows.rows).toHaveLength(0)
+  })
+
+  it('passes through tools without an execute fn unchanged', () => {
+    const middleware = createKeeperHubMiddleware({
+      db: handle.db,
+      runContext: () => null,
+    })
+    const noExec = { description: 'meta', inputSchema: { type: 'object' as const } } as never
+    const wrapped = middleware({ meta: noExec })
+    expect(wrapped.meta).toBe(noExec)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createKeeperHubClient (auth + MCP integration, mocked)
+// ---------------------------------------------------------------------------
+
+describe('createKeeperHubClient', () => {
+  let tmpDir: string
+  let tokenPath: string
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'talos-keeperhub-client-'))
+    tokenPath = path.join(tmpDir, 'keeperhub.token')
+    mockCreateMCPClient.mockReset()
+  })
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('throws TalosAuthError when no session on disk', async () => {
+    await expect(createKeeperHubClient({ tokenPath })).rejects.toThrow(/no KeeperHub session/)
+  })
+
+  it('returns the existing access token when not expired', async () => {
+    await saveSession(tokenPath, {
+      client: { client_id: 'client-abc' },
+      accessToken: 'at-fresh',
+      refreshToken: 'rt-1',
+      expiresAt: Date.now() + 3_600_000,
+      tokenType: 'Bearer',
+    })
+    const client = await createKeeperHubClient({
+      tokenPath,
+      authServerMetadata: FAKE_META,
+    })
+    expect(await client.ensureToken()).toBe('at-fresh')
+    await client.close()
+  })
+
+  it('refreshes an expired token via fetch and re-persists the session', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        access_token: 'at-new',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'rt-new',
+      } satisfies TokenResponse),
+    )
+    await saveSession(tokenPath, {
+      client: { client_id: 'client-abc' },
+      accessToken: 'at-old',
+      refreshToken: 'rt-old',
+      expiresAt: Date.now() - 1000, // expired
+      tokenType: 'Bearer',
+    })
+    const client = await createKeeperHubClient({
+      tokenPath,
+      authServerMetadata: FAKE_META,
+      fetch: fetchMock as unknown as typeof fetch,
+    })
+    expect(await client.ensureToken()).toBe('at-new')
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const reloaded = await loadSession(tokenPath)
+    expect(reloaded?.accessToken).toBe('at-new')
+    expect(reloaded?.refreshToken).toBe('rt-new')
+    await client.close()
+  })
+
+  it('throws when expired and no refresh_token present', async () => {
+    await saveSession(tokenPath, {
+      client: { client_id: 'client-abc' },
+      accessToken: 'at-old',
+      expiresAt: Date.now() - 1000,
+      tokenType: 'Bearer',
+    })
+    const client = await createKeeperHubClient({
+      tokenPath,
+      authServerMetadata: FAKE_META,
+    })
+    await expect(client.ensureToken()).rejects.toThrow(/no refresh_token/)
+    await client.close()
+  })
+
+  it('passes Bearer token in Authorization header to MCP transport', async () => {
+    const mockMcp = {
+      tools: vi.fn().mockResolvedValue({}),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    mockCreateMCPClient.mockResolvedValue(mockMcp)
+
+    await saveSession(tokenPath, {
+      client: { client_id: 'client-abc' },
+      accessToken: 'at-fresh',
+      refreshToken: 'rt-1',
+      expiresAt: Date.now() + 3_600_000,
+      tokenType: 'Bearer',
+    })
+    const client = await createKeeperHubClient({
+      tokenPath,
+      authServerMetadata: FAKE_META,
+    })
+    await client.listTools()
+    const [opts] = mockCreateMCPClient.mock.calls[0]!
+    expect(opts.transport).toEqual(
+      expect.objectContaining({
+        type: 'http',
+        url: 'https://app.keeperhub.com/mcp',
+        headers: { Authorization: 'Bearer at-fresh' },
+      }),
+    )
+    await client.close()
+  })
+
+  it('executeContractCall maps response to ExecutionResult shape', async () => {
+    const mockMcp = {
+      tools: vi.fn().mockResolvedValue({
+        execute_contract_call: {
+          description: 'EVM call',
+          execute: vi.fn().mockResolvedValue({
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  execution_id: 'exec-1',
+                  status: 'success',
+                  tx_hash: '0xdead',
+                }),
+              },
+            ],
+          }),
+        },
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    mockCreateMCPClient.mockResolvedValue(mockMcp)
+
+    await saveSession(tokenPath, {
+      client: { client_id: 'client-abc' },
+      accessToken: 'at-fresh',
+      refreshToken: 'rt-1',
+      expiresAt: Date.now() + 3_600_000,
+      tokenType: 'Bearer',
+    })
+    const client = await createKeeperHubClient({
+      tokenPath,
+      authServerMetadata: FAKE_META,
+    })
+    const out = await client.executeContractCall({
+      network: 'base-sepolia',
+      contract_address: '0xaaa',
+      function_name: 'supply',
+    })
+    expect(out.executionId).toBe('exec-1')
+    expect(out.status).toBe('success')
+    expect(out.txHash).toBe('0xdead')
+    await client.close()
+  })
+
+  it('callTool throws when target tool is missing on the server', async () => {
+    const mockMcp = {
+      tools: vi.fn().mockResolvedValue({}),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    mockCreateMCPClient.mockResolvedValue(mockMcp)
+
+    await saveSession(tokenPath, {
+      client: { client_id: 'client-abc' },
+      accessToken: 'at-fresh',
+      refreshToken: 'rt-1',
+      expiresAt: Date.now() + 3_600_000,
+      tokenType: 'Bearer',
+    })
+    const client = await createKeeperHubClient({
+      tokenPath,
+      authServerMetadata: FAKE_META,
+    })
+    await expect(client.callTool('execute_contract_call', { foo: 1 })).rejects.toThrow(
+      /unavailable/,
+    )
+    await client.close()
+  })
+})


### PR DESCRIPTION
## Summary

Ships the KeeperHub MCP integration primitives for issue #8 — OAuth 2.1 + DCR + PKCE, persistent token, audited MCP client wrapper, and the audit-by-default middleware that wraps every tool's execute.

### Bundles

- **OAuth (`oauth.ts`)** — discoverAuthServer, generatePkce (S256), generateState, registerClient (DCR), buildAuthorizeUrl, exchangeCode, refreshToken. Fetch injected for testability.
- **Token (`token.ts`)** — saveSession / loadSession at `$configDir/keeperhub.token` with mode 0600, 60s expiry buffer, idempotent clear.
- **Client (`client.ts`)** — `createKeeperHubClient` wraps `@ai-sdk/mcp` HTTP transport with `Authorization: Bearer <token>`. Lazy refresh. Typed `executeContractCall` / `executeTransfer` / `getExecutionStatus` mapped to ExecutionResult.
- **Middleware (`middleware.ts`)** — `shouldAudit(name, annotations)` (KNOWN_READONLY > readOnly > mutates > default-audit). `createKeeperHubMiddleware({ db, runContext, annotations? })` wraps every tool's execute and persists a `tool_calls` row with structured audit metadata.

### Decisions taken (defaults confirmed in chat)

1. **Audit destination** — local DB now, KeeperHub workflow path activated in #10.
2. **Workflow blocking** — block-and-wait when wired (#10), per architecture decision #9.
3. **Token refresh** — lazy on next call with 60s buffer.
4. **`KNOWN_READONLY`** — hardcoded constant, security-sensitive.
5. **Workflow envelope** — skipped for #8 (no real protocol tools to route yet); will land in #10 via `executeContractCall`.

### Plumbing

- `McpServerConfig` gains optional `headers?: Record<string, string>` so the KeeperHub client can inject the bearer header via the http transport.
- `appendToolCallAudit` typed helper added to `src/persistence/queries.ts`.
- `paths.keeperhubTokenPath` added.

## What's NOT in this PR (deferred)

- Real workflow envelope for mutating tools (`createWorkflow` + `executeWorkflow`) -> **#10** when protocol tools land
- Browser flow for first-time OAuth -> **#14** init wizard
- Runtime `runContext` provider wiring -> follow-up (small)
- Workflow approval UX -> **#13** channels

## Test plan

- [x] `pnpm vitest run` — 123 passing + 1 todo (was 82 + 1; +41 new)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm biome check` — 0 errors, 19 warnings (all `noNonNullAssertion` in tests, severity `warn`, matches existing test patterns)
- [x] OAuth: discovery (success/4xx/missing-endpoints), PKCE (verifier shape, S256 challenge match, distinctness), state shape, DCR (body shape / missing-registration / 4xx), authorize URL params, exchangeCode (form body / 4xx / missing-token), refreshToken grant
- [x] Token: round-trip, 0600 perms, missing-file null, malformed JSON, missing fields, idempotent clear, 60s expiry buffer, sessionFromResponse derivation
- [x] shouldAudit truth table
- [x] Middleware: wraps + audit row, KNOWN_READONLY reason, annotation lookup, error rethrows + recorded, no run context = no DB write, no-execute tools passthrough
- [x] Client: throws without session, returns fresh token, refreshes expired + persists, throws when expired without refresh_token, passes Bearer header to MCP transport, maps execute_contract_call response to ExecutionResult, throws when target tool absent

Closes #8