### PR TITLE
feat(daemon): talosd WS control plane (closes #9)

### DIFF
--- a/bin/talos.ts
+++ b/bin/talos.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
+import path from 'node:path'
 import { Command } from 'commander'
 import { paths } from '@/config/paths'
+import {
+  formatDiagnostics,
+  renderServiceArtifact,
+  runDiagnostics,
+  writeServiceArtifact,
+} from '@/daemon'
 import { assertNoLiveDaemon, createDb, runMigrations } from '@/persistence'
 import { TalosNotImplementedError } from '@/shared/errors'
 import { logger } from '@/shared/logger'
@@ -20,18 +27,29 @@ program
 
 program
   .command('install-service')
-  .description('Install talosd as launchd or systemd user service')
-  .action(() => {
-    logger.info('install-service: not implemented')
-    throw new TalosNotImplementedError('talos install-service')
+  .description('Install talosd as launchd (macOS) or systemd user service (Linux)')
+  .option('--print', 'render the service file to stdout without writing')
+  .option('--bin <path>', 'override talosd binary path (default: resolve from this script)')
+  .action((opts: { print?: boolean; bin?: string }) => {
+    const binPath = opts.bin ?? path.resolve(path.dirname(process.argv[1] ?? ''), 'talosd.js')
+    const artifact = renderServiceArtifact({ binPath })
+    if (opts.print) {
+      process.stdout.write(artifact.body)
+      return
+    }
+    writeServiceArtifact(artifact)
+    logger.info({ servicePath: artifact.servicePath }, 'service file written')
+    process.stdout.write(`\nNext steps:\n${artifact.followups.map((c) => `  ${c}`).join('\n')}\n`)
   })
 
 program
   .command('doctor')
   .description('Diagnose the current Talos installation')
-  .action(() => {
-    logger.info('doctor: not implemented')
-    throw new TalosNotImplementedError('talos doctor')
+  .action(async () => {
+    const results = await runDiagnostics()
+    process.stdout.write(`${formatDiagnostics(results)}\n`)
+    const allPass = results.every((r) => r.pass)
+    process.exit(allPass ? 0 : 1)
   })
 
 program

--- a/bin/talosd.ts
+++ b/bin/talosd.ts
@@ -1,19 +1,10 @@
 #!/usr/bin/env node
-import { loadEnv } from '@/config/env'
-import { paths } from '@/config/paths'
+import { startDaemon } from '@/daemon'
 import { logger } from '@/shared/logger'
 
 async function main(): Promise<void> {
-  const env = loadEnv()
-  logger.info(
-    {
-      port: env.TALOS_DAEMON_PORT,
-      configDir: paths.configDir,
-      dataDir: paths.dataDir,
-    },
-    'talosd booting',
-  )
-  logger.warn('talosd: control plane not yet implemented')
+  const handle = await startDaemon()
+  await handle.done
   process.exit(0)
 }
 

--- a/src/daemon/doctor.ts
+++ b/src/daemon/doctor.ts
@@ -1,0 +1,179 @@
+import fs from 'node:fs'
+import { WebSocket } from 'ws'
+import { paths } from '@/config/paths'
+import { ensureToken } from '@/config/token'
+import { isExpired, loadSession } from '@/keeperhub/token'
+import { createDb, runMigrations } from '@/persistence'
+import {
+  type ClientFrame,
+  type ServerFrame,
+  ServerFrame as ServerFrameSchema,
+} from '@/protocol/frames'
+
+export type DiagnosticResult = {
+  name: string
+  pass: boolean
+  detail: string
+}
+
+export type RunDiagnosticsOpts = {
+  /** Override the daemon address — defaults to `ws://127.0.0.1:${port}`. */
+  daemonUrl?: string
+  /** Daemon port; defaults to env or 7711. */
+  port?: number
+  /** Bound timeout for the daemon-responding probe. */
+  daemonTimeoutMs?: number
+}
+
+const DEFAULT_DAEMON_TIMEOUT_MS = 3_000
+
+export async function runDiagnostics(opts: RunDiagnosticsOpts = {}): Promise<DiagnosticResult[]> {
+  const port = opts.port ?? Number(process.env.TALOS_DAEMON_PORT ?? 7711)
+  const daemonUrl = opts.daemonUrl ?? `ws://127.0.0.1:${port}`
+  const daemonTimeoutMs = opts.daemonTimeoutMs ?? DEFAULT_DAEMON_TIMEOUT_MS
+
+  const results: DiagnosticResult[] = []
+  results.push(await checkDb())
+  results.push(await checkDaemon(daemonUrl, daemonTimeoutMs))
+  results.push(await checkKeeperHub())
+  return results
+}
+
+async function checkDb(): Promise<DiagnosticResult> {
+  const dbPath = paths.dbPath
+  if (!fs.existsSync(dbPath)) {
+    return {
+      name: 'db',
+      pass: false,
+      detail: `db not initialized at ${dbPath}; run \`talos migrate\``,
+    }
+  }
+  try {
+    // Daemon owns the file-backed DB at runtime — touching it would fight that.
+    // Probe with a brief ephemeral connection running the (idempotent) migrator.
+    const handle = await createDb({ ephemeral: true })
+    try {
+      await runMigrations(handle)
+      return {
+        name: 'db',
+        pass: true,
+        detail: `migrations replay clean (probed via ephemeral PGLite)`,
+      }
+    } finally {
+      await handle.close()
+    }
+  } catch (err) {
+    return {
+      name: 'db',
+      pass: false,
+      detail: `db probe failed: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+}
+
+async function checkDaemon(url: string, timeoutMs: number): Promise<DiagnosticResult> {
+  let token: string
+  try {
+    token = await ensureToken()
+  } catch (err) {
+    return {
+      name: 'daemon',
+      pass: false,
+      detail: `token unreadable: ${err instanceof Error ? err.message : String(err)}`,
+    }
+  }
+
+  return new Promise<DiagnosticResult>((resolve) => {
+    const ws = new WebSocket(url)
+    const timer = setTimeout(() => {
+      ws.terminate()
+      resolve({ name: 'daemon', pass: false, detail: `no response from ${url} in ${timeoutMs}ms` })
+    }, timeoutMs)
+
+    ws.on('error', (err) => {
+      clearTimeout(timer)
+      resolve({
+        name: 'daemon',
+        pass: false,
+        detail: `${url} unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      })
+    })
+
+    ws.on('open', () => {
+      const hello: ClientFrame = { type: 'hello', version: '0.1.0', client: 'talos-doctor' }
+      ws.send(JSON.stringify(hello))
+      const auth: ClientFrame = { type: 'auth', token }
+      ws.send(JSON.stringify(auth))
+    })
+
+    ws.on('message', (raw) => {
+      const text = typeof raw === 'string' ? raw : (raw as Buffer).toString('utf8')
+      let parsed: ServerFrame | null = null
+      try {
+        const json = JSON.parse(text)
+        const result = ServerFrameSchema.safeParse(json)
+        parsed = result.success ? result.data : null
+      } catch {
+        parsed = null
+      }
+      if (parsed && parsed.type === 'hello-ack') {
+        clearTimeout(timer)
+        ws.close()
+        resolve({
+          name: 'daemon',
+          pass: true,
+          detail: `hello-ack from ${url} (server ${parsed.version})`,
+        })
+      }
+    })
+  })
+}
+
+async function checkKeeperHub(): Promise<DiagnosticResult> {
+  const tokenPath = paths.keeperhubTokenPath
+  if (!fs.existsSync(tokenPath)) {
+    return {
+      name: 'keeperhub',
+      pass: false,
+      detail: `no session at ${tokenPath}; run \`talos init\` to authorize`,
+    }
+  }
+  try {
+    const session = await loadSession(tokenPath)
+    if (!session) {
+      return {
+        name: 'keeperhub',
+        pass: false,
+        detail: 'session file present but empty',
+      }
+    }
+    if (isExpired(session) && !session.refreshToken) {
+      return {
+        name: 'keeperhub',
+        pass: false,
+        detail: 'access token expired and no refresh_token — re-run `talos init`',
+      }
+    }
+    return {
+      name: 'keeperhub',
+      pass: true,
+      detail: `session for client ${session.client.client_id} (expires ${new Date(session.expiresAt).toISOString()})`,
+    }
+  } catch (err) {
+    return {
+      name: 'keeperhub',
+      pass: false,
+      detail: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+/** Pretty-print diagnostic results as a fixed-width table for console output. */
+export function formatDiagnostics(results: DiagnosticResult[]): string {
+  const nameW = Math.max(4, ...results.map((r) => r.name.length))
+  const lines = results.map((r) => {
+    const mark = r.pass ? 'PASS' : 'FAIL'
+    return `${mark}  ${r.name.padEnd(nameW)}  ${r.detail}`
+  })
+  return lines.join('\n')
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,20 @@
-import { TalosNotImplementedError } from '@/shared/errors'
-
-export function startDaemon(): never {
-  throw new TalosNotImplementedError('daemon.startDaemon')
-}
+export {
+  type DiagnosticResult,
+  formatDiagnostics,
+  type RunDiagnosticsOpts,
+  runDiagnostics,
+} from './doctor'
+export {
+  type RenderServiceOpts,
+  renderServiceArtifact,
+  type ServiceArtifact,
+  type ServicePlatform,
+  writeServiceArtifact,
+} from './install-service'
+export { type DaemonHandle, type StartDaemonOpts, startDaemon } from './lifecycle'
+export { type StreamRunOpts, streamRunToWs } from './runs'
+export {
+  type ControlPlane,
+  type ControlPlaneOpts,
+  createControlPlane,
+} from './server'

--- a/src/daemon/install-service.ts
+++ b/src/daemon/install-service.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export type ServicePlatform = 'darwin' | 'linux'
+export type ServiceArtifact = {
+  platform: ServicePlatform
+  /** Absolute path the service file should be written to. */
+  servicePath: string
+  /** Rendered service definition (plist or unit). */
+  body: string
+  /** Commands the user should run after writing the file. */
+  followups: string[]
+}
+
+export type RenderServiceOpts = {
+  /** Absolute path to the talosd executable. */
+  binPath: string
+  /** Override $HOME — tests + non-default-home installs. */
+  home?: string
+  /** Override platform — tests. */
+  platform?: NodeJS.Platform
+  /** Custom log dir for service stdout/stderr. */
+  logDir?: string
+}
+
+const LABEL = 'com.talos.daemon'
+
+/**
+ * Render a launchd plist (macOS) or systemd user unit (Linux) for `talosd`.
+ * Throws on unsupported platforms; install-service is a v1-only feature
+ * scoped to the two platforms we ship to (per spec F11.5).
+ */
+export function renderServiceArtifact(opts: RenderServiceOpts): ServiceArtifact {
+  const platform = opts.platform ?? process.platform
+  const home = opts.home ?? os.homedir()
+  const logDir = opts.logDir ?? path.join(home, '.local', 'share', 'talos')
+
+  if (platform === 'darwin') {
+    const servicePath = path.join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`)
+    const body = renderLaunchdPlist({ binPath: opts.binPath, logDir })
+    return {
+      platform: 'darwin',
+      servicePath,
+      body,
+      followups: [`launchctl load -w "${servicePath}"`, 'launchctl list | grep talos'],
+    }
+  }
+
+  if (platform === 'linux') {
+    const servicePath = path.join(home, '.config', 'systemd', 'user', 'talosd.service')
+    const body = renderSystemdUnit({ binPath: opts.binPath, logDir })
+    return {
+      platform: 'linux',
+      servicePath,
+      body,
+      followups: [
+        'systemctl --user daemon-reload',
+        'systemctl --user enable --now talosd.service',
+        'systemctl --user status talosd.service',
+      ],
+    }
+  }
+
+  throw new Error(
+    `unsupported platform "${platform}" — install-service supports darwin and linux only`,
+  )
+}
+
+/** Write the rendered service file. Creates the parent dir if missing. */
+export function writeServiceArtifact(artifact: ServiceArtifact): void {
+  fs.mkdirSync(path.dirname(artifact.servicePath), { recursive: true })
+  fs.writeFileSync(artifact.servicePath, artifact.body, { encoding: 'utf8', mode: 0o644 })
+}
+
+function renderLaunchdPlist(opts: { binPath: string; logDir: string }): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyLists-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${opts.binPath}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${opts.logDir}/talosd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>${opts.logDir}/talosd.err.log</string>
+  <key>WorkingDirectory</key>
+  <string>${opts.logDir}</string>
+</dict>
+</plist>
+`
+}
+
+function renderSystemdUnit(opts: { binPath: string; logDir: string }): string {
+  return `[Unit]
+Description=Talos vertical Ethereum agent daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${opts.binPath}
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:${opts.logDir}/talosd.out.log
+StandardError=append:${opts.logDir}/talosd.err.log
+WorkingDirectory=${opts.logDir}
+
+[Install]
+WantedBy=default.target
+`
+}

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs'
+import { loadEnv, resetEnvCache } from '@/config/env'
+import { paths } from '@/config/paths'
+import { ensureToken } from '@/config/token'
+import {
+  assertNoLiveDaemon,
+  createDb,
+  type DbHandle,
+  removePidFile,
+  runMigrations,
+  writePidFile,
+} from '@/persistence'
+import { AgentRegistry, TALOS_ETH_AGENT } from '@/runtime/agents'
+import { createOpenAIEmbeddings } from '@/runtime/embeddings'
+import { createProviderRouter } from '@/runtime/providers'
+import { createRuntime } from '@/runtime/runtime'
+import { logger } from '@/shared/logger'
+import { type ControlPlane, createControlPlane } from './server'
+
+export type DaemonHandle = {
+  /** Wait for shutdown — resolves on SIGTERM/SIGINT or explicit `stop()`. */
+  done: Promise<void>
+  /** Trigger graceful shutdown. */
+  stop(): Promise<void>
+  /** Bound port (useful when env var TALOS_DAEMON_PORT was 0 in tests). */
+  port: number
+  controlPlane: ControlPlane
+}
+
+export type StartDaemonOpts = {
+  /** Override port; otherwise from env TALOS_DAEMON_PORT. */
+  port?: number
+  /** Override host; default 127.0.0.1. */
+  host?: string
+  /** Disable signal handlers — useful for tests where vitest manages process lifecycle. */
+  installSignalHandlers?: boolean
+  /** Use ephemeral PGLite (no on-disk file). Tests only. */
+  ephemeralDb?: boolean
+}
+
+export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<DaemonHandle> {
+  const installSignals = startOpts.installSignalHandlers ?? true
+
+  // Refresh env cache in case the file changed since last call.
+  resetEnvCache()
+  const env = loadEnv()
+
+  // Refuse to boot if another daemon is already running.
+  assertNoLiveDaemon()
+
+  fs.mkdirSync(paths.dataDir, { recursive: true })
+  fs.mkdirSync(paths.configDir, { recursive: true })
+
+  // Bootstrap the bearer token. First-time generation is logged ONCE so the
+  // user can copy it into client config (channels, MCP server, etc).
+  const tokenExisted = fs.existsSync(paths.tokenPath)
+  const token = await ensureToken()
+  if (!tokenExisted) {
+    logger.info(
+      { tokenPath: paths.tokenPath },
+      'generated new daemon bearer token (saved 0600); copy from the file path above',
+    )
+  }
+
+  // Open DB + run migrations. PGLite ephemeral mode for tests.
+  const dbHandle: DbHandle = startOpts.ephemeralDb
+    ? await createDb({ ephemeral: true })
+    : await createDb({ path: paths.dbPath })
+  await runMigrations(dbHandle)
+
+  // Build runtime deps. Tools / KH middleware / knowledge / summarizer / fact
+  // pipeline are deferred to follow-up issues (#10/#11/#16/#17 LLM impls).
+  const agents = new AgentRegistry()
+  agents.register(TALOS_ETH_AGENT, { default: true })
+  const providers = createProviderRouter()
+  const embeddings = createOpenAIEmbeddings()
+  const runtime = createRuntime({
+    db: dbHandle,
+    providers,
+    embeddings,
+    agents,
+    toolSources: [],
+  })
+
+  // Boot control plane.
+  const controlPlane = createControlPlane({
+    runtime,
+    token,
+    port: startOpts.port ?? env.TALOS_DAEMON_PORT,
+    ...(startOpts.host !== undefined ? { host: startOpts.host } : {}),
+  })
+  const { port, host } = await controlPlane.start()
+
+  // Write the PID file only after we've successfully bound — avoids leaking
+  // a stale PID if start fails.
+  writePidFile()
+
+  if (!env.OPENAI_API_KEY) {
+    logger.warn(
+      'OPENAI_API_KEY not set — control plane up, but run-start frames will fail until configured',
+    )
+  }
+
+  logger.info({ port, host, pidPath: paths.pidPath }, 'talosd ready')
+
+  let stopping: Promise<void> | null = null
+  let resolveDone: (() => void) | undefined
+  const done = new Promise<void>((res) => {
+    resolveDone = res
+  })
+
+  async function stop(): Promise<void> {
+    if (stopping) return stopping
+    stopping = (async () => {
+      logger.info('talosd shutting down')
+      try {
+        await controlPlane.stop()
+      } catch (err) {
+        logger.warn({ err }, 'error stopping control plane')
+      }
+      try {
+        await dbHandle.close()
+      } catch (err) {
+        logger.warn({ err }, 'error closing db')
+      }
+      removePidFile()
+      logger.info('talosd stopped')
+      resolveDone?.()
+    })()
+    return stopping
+  }
+
+  if (installSignals) {
+    const onSig = (sig: NodeJS.Signals) => {
+      logger.info({ sig }, 'signal received')
+      void stop()
+    }
+    process.once('SIGTERM', onSig)
+    process.once('SIGINT', onSig)
+  }
+
+  return { done, stop, port, controlPlane }
+}

--- a/src/daemon/runs.ts
+++ b/src/daemon/runs.ts
@@ -1,0 +1,52 @@
+import type { ServerFrame } from '@/protocol/frames'
+import type { RunHandle } from '@/runtime/types'
+
+export type StreamRunOpts = {
+  handle: RunHandle
+  send: (frame: ServerFrame) => void
+}
+
+/**
+ * Pipe a runtime `RunHandle.fullStream` into `run-event` frames, then send
+ * a final `run-done` frame after `handle.done` resolves. The runtime swallows
+ * post-run persistence errors itself, so `handle.done` always resolves; we
+ * only need to handle errors thrown inside the stream iteration.
+ */
+export async function streamRunToWs(opts: StreamRunOpts): Promise<void> {
+  let finishReason: string | undefined
+  let usage: { inputTokens?: number; outputTokens?: number } | undefined
+
+  try {
+    for await (const event of opts.handle.fullStream) {
+      // AI SDK v6 emits a `finish` step at the end of every run carrying
+      // both finishReason and usage. Snapshot for the run-done frame.
+      if (event.type === 'finish') {
+        const e = event as { finishReason?: string; totalUsage?: unknown; usage?: unknown }
+        if (typeof e.finishReason === 'string') finishReason = e.finishReason
+        const usageSrc = (e.totalUsage ?? e.usage) as
+          | { inputTokens?: number; outputTokens?: number }
+          | undefined
+        if (usageSrc) {
+          const next: { inputTokens?: number; outputTokens?: number } = {}
+          if (typeof usageSrc.inputTokens === 'number') next.inputTokens = usageSrc.inputTokens
+          if (typeof usageSrc.outputTokens === 'number') next.outputTokens = usageSrc.outputTokens
+          usage = next
+        }
+      }
+      opts.send({ type: 'run-event', runId: opts.handle.runId, event })
+    }
+  } finally {
+    // `done` resolves regardless of stream success — the runtime catches
+    // post-run hook failures internally.
+    await opts.handle.done.catch(() => undefined)
+    const done: ServerFrame =
+      usage !== undefined && finishReason !== undefined
+        ? { type: 'run-done', runId: opts.handle.runId, finishReason, usage }
+        : finishReason !== undefined
+          ? { type: 'run-done', runId: opts.handle.runId, finishReason }
+          : usage !== undefined
+            ? { type: 'run-done', runId: opts.handle.runId, usage }
+            : { type: 'run-done', runId: opts.handle.runId }
+    opts.send(done)
+  }
+}

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -1,0 +1,285 @@
+import type { AddressInfo } from 'node:net'
+import { WebSocket, WebSocketServer } from 'ws'
+import {
+  type ClientFrame,
+  ClientFrame as ClientFrameSchema,
+  PROTOCOL_VERSION,
+  type ServerFrame,
+} from '@/protocol/frames'
+import type { AgentRuntime } from '@/runtime/types'
+import { child } from '@/shared/logger'
+import { streamRunToWs } from './runs'
+
+const log = child({ module: 'daemon-server' })
+
+const DEFAULT_HOST = '127.0.0.1'
+
+export type ControlPlaneOpts = {
+  runtime: AgentRuntime
+  /** Bearer token clients must present in the auth frame. */
+  token: string
+  /** TCP port; pass 0 for an ephemeral port (tests). */
+  port: number
+  /** Host to bind to. Default 127.0.0.1 — refuse to listen elsewhere by default. */
+  host?: string
+  /** Default channel id reported to the runtime when a client doesn't supply one. */
+  defaultChannel?: string
+}
+
+export type ControlPlane = {
+  /** Bind the WS server. Resolves to the actual port (useful when port=0). */
+  start(): Promise<{ port: number; host: string }>
+  /** Stop accepting connections, abort inflight runs, close server. */
+  stop(opts?: { drainTimeoutMs?: number }): Promise<void>
+  /** Number of currently-open connections. Useful for tests. */
+  connectionCount(): number
+  /** Total inflight runs across all connections. Useful for tests. */
+  inflightRunCount(): number
+}
+
+type Connection = {
+  ws: WebSocket
+  helloed: boolean
+  authenticated: boolean
+  inflight: Map<string, AbortController>
+  pending: Set<Promise<void>>
+}
+
+const DEFAULT_DRAIN_MS = 30_000
+
+export function createControlPlane(opts: ControlPlaneOpts): ControlPlane {
+  const host = opts.host ?? DEFAULT_HOST
+  const defaultChannel = opts.defaultChannel ?? 'ws'
+  const wss = new WebSocketServer({ port: opts.port, host })
+  const conns = new Set<Connection>()
+
+  wss.on('connection', (ws) => {
+    const conn: Connection = {
+      ws,
+      helloed: false,
+      authenticated: false,
+      inflight: new Map(),
+      pending: new Set(),
+    }
+    conns.add(conn)
+
+    ws.on('message', (raw) => {
+      void handleMessage(conn, raw)
+    })
+    ws.on('close', () => {
+      // Abort any runs still in flight for this connection.
+      for (const ac of conn.inflight.values()) ac.abort()
+      conn.inflight.clear()
+      conns.delete(conn)
+    })
+    ws.on('error', (err) => {
+      log.warn({ err }, 'connection error')
+    })
+  })
+
+  async function handleMessage(conn: Connection, raw: WebSocket.RawData): Promise<void> {
+    const parsed = parseClientFrame(raw)
+    if (!parsed.ok) {
+      sendError(conn, 'INVALID_FRAME', parsed.error)
+      return
+    }
+    const frame = parsed.frame
+
+    if (frame.type === 'hello') {
+      if (conn.helloed) {
+        sendError(conn, 'HELLO_REPEAT', 'hello already received')
+        return
+      }
+      conn.helloed = true
+      send(conn, {
+        type: 'hello-ack',
+        version: PROTOCOL_VERSION,
+        serverTime: new Date().toISOString(),
+      })
+      return
+    }
+
+    if (frame.type === 'auth') {
+      if (!conn.helloed) {
+        sendError(conn, 'AUTH_BEFORE_HELLO', 'send hello first')
+        return
+      }
+      if (conn.authenticated) {
+        sendError(conn, 'AUTH_REPEAT', 'already authenticated')
+        return
+      }
+      if (!constantTimeEqual(frame.token, opts.token)) {
+        sendError(conn, 'AUTH_FAILED', 'invalid token')
+        conn.ws.close(4401, 'auth failed')
+        return
+      }
+      conn.authenticated = true
+      return
+    }
+
+    if (!conn.authenticated) {
+      sendError(conn, 'NOT_AUTHENTICATED', 'auth before issuing runs')
+      conn.ws.close(4401, 'unauthenticated')
+      return
+    }
+
+    if (frame.type === 'run-start') {
+      await startRun(conn, frame)
+      return
+    }
+
+    if (frame.type === 'run-cancel') {
+      const ac = conn.inflight.get(frame.runId)
+      if (!ac) {
+        sendError(conn, 'UNKNOWN_RUN', `no inflight run ${frame.runId}`, frame.runId)
+        return
+      }
+      ac.abort()
+      return
+    }
+  }
+
+  async function startRun(
+    conn: Connection,
+    frame: Extract<ClientFrame, { type: 'run-start' }>,
+  ): Promise<void> {
+    const ac = new AbortController()
+    let handle: Awaited<ReturnType<AgentRuntime['run']>>
+    try {
+      handle = await opts.runtime.run({
+        threadId: frame.threadId,
+        channel: defaultChannel,
+        intent: frame.prompt,
+        abortSignal: ac.signal,
+      })
+    } catch (err) {
+      sendError(conn, 'RUN_START_FAILED', err instanceof Error ? err.message : String(err))
+      return
+    }
+
+    conn.inflight.set(handle.runId, ac)
+    const task = streamRunToWs({
+      handle,
+      send: (f) => send(conn, f),
+    })
+      .catch((err) => {
+        log.warn({ err, runId: handle.runId }, 'run streamer failed')
+        sendError(
+          conn,
+          'RUN_FAILED',
+          err instanceof Error ? err.message : String(err),
+          handle.runId,
+        )
+      })
+      .finally(() => {
+        conn.inflight.delete(handle.runId)
+      })
+    conn.pending.add(task)
+    task.finally(() => conn.pending.delete(task))
+  }
+
+  function send(conn: Connection, frame: ServerFrame): void {
+    if (conn.ws.readyState !== WebSocket.OPEN) return
+    try {
+      conn.ws.send(JSON.stringify(frame))
+    } catch (err) {
+      log.warn({ err }, 'failed to send frame')
+    }
+  }
+
+  function sendError(conn: Connection, code: string, message: string, runId?: string): void {
+    send(conn, runId ? { type: 'error', code, message, runId } : { type: 'error', code, message })
+  }
+
+  return {
+    async start(): Promise<{ port: number; host: string }> {
+      if (wss.address()) {
+        const addr = wss.address() as AddressInfo
+        return { port: addr.port, host: addr.address }
+      }
+      return new Promise((resolve, reject) => {
+        const onError = (err: unknown) => {
+          wss.off('listening', onListening)
+          reject(err instanceof Error ? err : new Error(String(err)))
+        }
+        const onListening = () => {
+          wss.off('error', onError)
+          const addr = wss.address() as AddressInfo
+          log.info({ port: addr.port, host: addr.address }, 'control plane listening')
+          resolve({ port: addr.port, host: addr.address })
+        }
+        wss.once('error', onError)
+        wss.once('listening', onListening)
+      })
+    },
+
+    async stop(stopOpts: { drainTimeoutMs?: number } = {}): Promise<void> {
+      const timeoutMs = stopOpts.drainTimeoutMs ?? DEFAULT_DRAIN_MS
+      // Stop accepting new connections immediately.
+      wss.close()
+
+      // Abort all inflight runs across all connections.
+      for (const conn of conns) {
+        for (const ac of conn.inflight.values()) ac.abort()
+      }
+
+      // Drain pending streamer tasks with a hard deadline.
+      const allPending = Array.from(conns).flatMap((c) => Array.from(c.pending))
+      await Promise.race([
+        Promise.allSettled(allPending),
+        new Promise<void>((resolve) => setTimeout(resolve, timeoutMs)),
+      ])
+
+      // Close any still-open sockets.
+      for (const conn of conns) {
+        try {
+          conn.ws.close(1001, 'shutdown')
+        } catch {
+          /* ignore */
+        }
+      }
+      conns.clear()
+    },
+
+    connectionCount(): number {
+      return conns.size
+    },
+
+    inflightRunCount(): number {
+      let total = 0
+      for (const conn of conns) total += conn.inflight.size
+      return total
+    },
+  }
+}
+
+type ParseResult = { ok: true; frame: ClientFrame } | { ok: false; error: string }
+
+function parseClientFrame(raw: WebSocket.RawData): ParseResult {
+  let text: string
+  try {
+    text = typeof raw === 'string' ? raw : Buffer.isBuffer(raw) ? raw.toString('utf8') : String(raw)
+  } catch {
+    return { ok: false, error: 'frame decode failed' }
+  }
+  let json: unknown
+  try {
+    json = JSON.parse(text)
+  } catch {
+    return { ok: false, error: 'frame is not JSON' }
+  }
+  const result = ClientFrameSchema.safeParse(json)
+  if (!result.success) {
+    return { ok: false, error: result.error.issues.map((i) => i.message).join('; ') }
+  }
+  return { ok: true, frame: result.data }
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}

--- a/src/persistence/ownership.ts
+++ b/src/persistence/ownership.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import { paths as defaultPaths, type Paths } from '@/config/paths'
 import { TalosDbError } from '@/shared/errors'
 
@@ -56,4 +57,22 @@ function isAlive(pid: number): boolean {
     if (code === 'EPERM') return true
     throw err
   }
+}
+
+/**
+ * Write the current process pid to `paths.pidPath`. Creates the parent
+ * directory if missing. Atomic-ish via fs.writeFileSync (PGLite ownership
+ * model only ever has one writer; race is not a real concern).
+ */
+export function writePidFile(opts: { paths?: Pick<Paths, 'pidPath'>; pid?: number } = {}): void {
+  const target = (opts.paths ?? defaultPaths).pidPath
+  const pid = opts.pid ?? process.pid
+  fs.mkdirSync(path.dirname(target), { recursive: true })
+  fs.writeFileSync(target, `${pid}\n`, { mode: 0o644 })
+}
+
+/** Remove the pidfile if present. Idempotent — safe to call from cleanup paths. */
+export function removePidFile(opts: { paths?: Pick<Paths, 'pidPath'> } = {}): void {
+  const target = (opts.paths ?? defaultPaths).pidPath
+  fs.rmSync(target, { force: true })
 }

--- a/tests/integration/daemon.test.ts
+++ b/tests/integration/daemon.test.ts
@@ -1,0 +1,653 @@
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebSocket } from 'ws'
+import {
+  type ControlPlane,
+  createControlPlane,
+  formatDiagnostics,
+  renderServiceArtifact,
+  streamRunToWs,
+  writeServiceArtifact,
+} from '@/daemon'
+import { type ClientFrame, PROTOCOL_VERSION, type ServerFrame } from '@/protocol/frames'
+import type { AgentRuntime, RunHandle, RunOptions } from '@/runtime/types'
+
+vi.mock('@/config/env', () => ({
+  loadEnv: () => ({
+    OPENAI_API_KEY: 'test-key',
+    TALOS_DAEMON_PORT: 0,
+    TALOS_LOG_LEVEL: 'silent',
+    NODE_ENV: 'test',
+  }),
+  resetEnvCache: () => {},
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TOKEN = 'test-token-1234'
+
+type FakeRunSpec = {
+  runId?: string
+  events?: Array<Record<string, unknown>>
+  /** Resolves the `done` promise — keeps tests deterministic. */
+  doneAfterMs?: number
+  /** If set, throws this error after streaming events, instead of resolving. */
+  throwAfterEvents?: Error
+}
+
+/**
+ * Build a tiny AgentRuntime test double whose `run` returns a hand-rolled
+ * RunHandle. The latest call's AbortController-tracking signal is exposed on
+ * the returned object so tests can assert abort behaviour.
+ */
+function createFakeRuntime(
+  opts: { spec?: FakeRunSpec | ((opts: RunOptions) => FakeRunSpec) } = {},
+) {
+  const calls: Array<{ opts: RunOptions; aborted: () => boolean; runId: string }> = []
+  let runCounter = 0
+
+  const runtime: AgentRuntime = {
+    async run(runOpts: RunOptions): Promise<RunHandle> {
+      const spec = typeof opts.spec === 'function' ? opts.spec(runOpts) : (opts.spec ?? {})
+      const runId = spec.runId ?? `run-${++runCounter}`
+      const aborted = () => runOpts.abortSignal?.aborted ?? false
+      calls.push({ opts: runOpts, aborted, runId })
+
+      const events = spec.events ?? [
+        { type: 'text-start', id: 'm1' },
+        { type: 'text-delta', id: 'm1', text: 'hello' },
+        { type: 'text-end', id: 'm1' },
+        {
+          type: 'finish',
+          finishReason: 'stop',
+          totalUsage: { inputTokens: 5, outputTokens: 1 },
+        },
+      ]
+
+      const fullStream = (async function* () {
+        for (const ev of events) {
+          // Yield to the event loop so abort can be observed mid-stream.
+          await new Promise((r) => setImmediate(r))
+          if (aborted()) {
+            yield { type: 'abort', reason: 'aborted' } as never
+            return
+          }
+          yield ev as never
+        }
+        if (spec.throwAfterEvents) throw spec.throwAfterEvents
+      })()
+
+      const done = spec.doneAfterMs
+        ? new Promise<void>((res) => setTimeout(res, spec.doneAfterMs))
+        : Promise.resolve()
+
+      return { runId, fullStream, done }
+    },
+  }
+
+  return { runtime, calls }
+}
+
+async function startPlane(
+  runtime: AgentRuntime,
+  token: string = TOKEN,
+): Promise<{
+  plane: ControlPlane
+  url: string
+}> {
+  const plane = createControlPlane({ runtime, token, port: 0 })
+  const { port, host } = await plane.start()
+  return { plane, url: `ws://${host}:${port}` }
+}
+
+type FrameReader = {
+  next(timeoutMs?: number): Promise<ServerFrame>
+  collectUntil(predicate: (f: ServerFrame) => boolean, timeoutMs?: number): Promise<ServerFrame[]>
+}
+
+/**
+ * Persistent frame reader — buffers frames as they arrive so callers never
+ * miss messages between listener attach/detach windows.
+ */
+function makeReader(ws: WebSocket): FrameReader {
+  const queue: ServerFrame[] = []
+  const waiters: Array<{ resolve: (f: ServerFrame) => void; timer: NodeJS.Timeout }> = []
+
+  ws.on('message', (raw: WebSocket.RawData) => {
+    const text = typeof raw === 'string' ? raw : (raw as Buffer).toString('utf8')
+    let frame: ServerFrame
+    try {
+      frame = JSON.parse(text) as ServerFrame
+    } catch {
+      return
+    }
+    const waiter = waiters.shift()
+    if (waiter) {
+      clearTimeout(waiter.timer)
+      waiter.resolve(frame)
+    } else {
+      queue.push(frame)
+    }
+  })
+
+  return {
+    next(timeoutMs = 1500): Promise<ServerFrame> {
+      const queued = queue.shift()
+      if (queued) return Promise.resolve(queued)
+      return new Promise<ServerFrame>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const idx = waiters.findIndex((w) => w.timer === timer)
+          if (idx !== -1) waiters.splice(idx, 1)
+          reject(new Error(`no frame received within ${timeoutMs}ms`))
+        }, timeoutMs)
+        waiters.push({ resolve, timer })
+      })
+    },
+    async collectUntil(predicate, timeoutMs = 3000): Promise<ServerFrame[]> {
+      const out: ServerFrame[] = []
+      while (true) {
+        const f = await this.next(timeoutMs)
+        out.push(f)
+        if (predicate(f)) return out
+      }
+    },
+  }
+}
+
+function connectClient(url: string): Promise<{ ws: WebSocket; reader: FrameReader }> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url)
+    ws.once('open', () => resolve({ ws, reader: makeReader(ws) }))
+    ws.once('error', reject)
+  })
+}
+
+function send(ws: WebSocket, frame: ClientFrame): void {
+  ws.send(JSON.stringify(frame))
+}
+
+async function helloAndAuth(
+  ws: WebSocket,
+  reader: FrameReader,
+  token: string = TOKEN,
+): Promise<void> {
+  send(ws, { type: 'hello', version: PROTOCOL_VERSION, client: 'test' })
+  const ack = await reader.next()
+  expect(ack.type).toBe('hello-ack')
+  send(ws, { type: 'auth', token })
+}
+
+// ---------------------------------------------------------------------------
+// Control plane lifecycle
+// ---------------------------------------------------------------------------
+
+describe('createControlPlane — lifecycle', () => {
+  it('binds an ephemeral port and reports it', async () => {
+    const { runtime } = createFakeRuntime()
+    const plane = createControlPlane({ runtime, token: TOKEN, port: 0 })
+    const { port, host } = await plane.start()
+    expect(port).toBeGreaterThan(0)
+    expect(host).toBe('127.0.0.1')
+    await plane.stop()
+  })
+
+  it('connectionCount reflects open clients', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    expect(plane.connectionCount()).toBe(0)
+    const { ws } = await connectClient(url)
+    await new Promise((r) => setTimeout(r, 30))
+    expect(plane.connectionCount()).toBe(1)
+    ws.close()
+    await new Promise((r) => setTimeout(r, 50))
+    expect(plane.connectionCount()).toBe(0)
+    await plane.stop()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Frame protocol — hello / auth state machine
+// ---------------------------------------------------------------------------
+
+describe('frame protocol — hello + auth', () => {
+  it('hello -> hello-ack with version + serverTime', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    send(ws, { type: 'hello', version: '0.1.0' })
+    const ack = await reader.next()
+    expect(ack.type).toBe('hello-ack')
+    if (ack.type === 'hello-ack') {
+      expect(ack.version).toBe(PROTOCOL_VERSION)
+      expect(typeof ack.serverTime).toBe('string')
+    }
+    ws.close()
+    await plane.stop()
+  })
+
+  it('rejects malformed JSON with INVALID_FRAME', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    ws.send('not json{')
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') expect(err.code).toBe('INVALID_FRAME')
+    ws.close()
+    await plane.stop()
+  })
+
+  it('rejects unknown frame shapes with INVALID_FRAME', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    ws.send(JSON.stringify({ type: 'nope' }))
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') expect(err.code).toBe('INVALID_FRAME')
+    ws.close()
+    await plane.stop()
+  })
+
+  it('hello twice -> HELLO_REPEAT', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    send(ws, { type: 'hello', version: '0.1.0' })
+    await reader.next() // ack
+    send(ws, { type: 'hello', version: '0.1.0' })
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') expect(err.code).toBe('HELLO_REPEAT')
+    ws.close()
+    await plane.stop()
+  })
+
+  it('auth before hello -> AUTH_BEFORE_HELLO', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    send(ws, { type: 'auth', token: TOKEN })
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') expect(err.code).toBe('AUTH_BEFORE_HELLO')
+    ws.close()
+    await plane.stop()
+  })
+
+  it('auth with wrong token -> AUTH_FAILED + connection closed', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    send(ws, { type: 'hello', version: '0.1.0' })
+    await reader.next()
+    send(ws, { type: 'auth', token: 'WRONG' })
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') expect(err.code).toBe('AUTH_FAILED')
+    await new Promise((r) => setTimeout(r, 50))
+    expect([WebSocket.CLOSED, WebSocket.CLOSING]).toContain(ws.readyState)
+    await plane.stop()
+  })
+
+  it('auth twice -> AUTH_REPEAT', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'auth', token: TOKEN })
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') expect(err.code).toBe('AUTH_REPEAT')
+    ws.close()
+    await plane.stop()
+  })
+
+  it('run-start before auth -> NOT_AUTHENTICATED + closed', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    send(ws, { type: 'hello', version: '0.1.0' })
+    await reader.next() // ack — auth not sent
+    send(ws, { type: 'run-start', threadId: 't', prompt: 'hi' })
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') expect(err.code).toBe('NOT_AUTHENTICATED')
+    await new Promise((r) => setTimeout(r, 50))
+    expect([WebSocket.CLOSED, WebSocket.CLOSING]).toContain(ws.readyState)
+    await plane.stop()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Run lifecycle: run-start -> run-event -> run-done
+// ---------------------------------------------------------------------------
+
+describe('run lifecycle', () => {
+  it('streams run-event frames followed by run-done', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-start', threadId: 't1', prompt: 'hi' })
+
+    const frames = await reader.collectUntil((f) => f.type === 'run-done')
+    const eventFrames = frames.filter((f) => f.type === 'run-event')
+    const done = frames.find((f) => f.type === 'run-done')
+    expect(eventFrames.length).toBeGreaterThan(0)
+    expect(done).toBeDefined()
+    if (done?.type === 'run-done') {
+      expect(done.runId).toBe('run-1')
+      expect(done.finishReason).toBe('stop')
+      expect(done.usage).toEqual({ inputTokens: 5, outputTokens: 1 })
+    }
+
+    ws.close()
+    await plane.stop()
+  })
+
+  it('reports inflight count during a run, then drops to zero', async () => {
+    const { runtime } = createFakeRuntime({
+      spec: {
+        events: Array.from({ length: 8 }, (_, i) => ({
+          type: 'text-delta',
+          id: 'm',
+          text: `${i}`,
+        })),
+        doneAfterMs: 50,
+      },
+    })
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-start', threadId: 't1', prompt: 'hi' })
+    // Wait for at least one run-event then sample
+    await reader.next() // first run-event
+    expect(plane.inflightRunCount()).toBe(1)
+
+    await reader.collectUntil((f) => f.type === 'run-done')
+    expect(plane.inflightRunCount()).toBe(0)
+
+    ws.close()
+    await plane.stop()
+  })
+
+  it('run-cancel for unknown runId -> UNKNOWN_RUN', async () => {
+    const { runtime } = createFakeRuntime()
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-cancel', runId: 'nonexistent' })
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') {
+      expect(err.code).toBe('UNKNOWN_RUN')
+      expect(err.runId).toBe('nonexistent')
+    }
+    ws.close()
+    await plane.stop()
+  })
+
+  it('run-cancel triggers AbortController.abort on inflight run', async () => {
+    const longEvents = Array.from({ length: 100 }, (_, i) => ({
+      type: 'text-delta',
+      id: 'm',
+      text: `${i}`,
+    }))
+    const { runtime, calls } = createFakeRuntime({
+      spec: { events: longEvents, doneAfterMs: 10 },
+    })
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-start', threadId: 't1', prompt: 'hi' })
+    // Receive a couple of frames then cancel
+    await reader.next()
+    send(ws, { type: 'run-cancel', runId: 'run-1' })
+    await reader.collectUntil((f) => f.type === 'run-done', 2000)
+    expect(calls[0]?.aborted()).toBe(true)
+    ws.close()
+    await plane.stop()
+  })
+
+  it('two concurrent runs on one connection both stream', async () => {
+    const { runtime } = createFakeRuntime({
+      spec: (opts) => ({
+        runId: `run-${opts.threadId}`,
+        events: [
+          { type: 'text-start', id: opts.threadId },
+          { type: 'text-delta', id: opts.threadId, text: opts.intent },
+          { type: 'text-end', id: opts.threadId },
+          { type: 'finish', finishReason: 'stop', totalUsage: { inputTokens: 1, outputTokens: 1 } },
+        ],
+      }),
+    })
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-start', threadId: 'A', prompt: 'first' })
+    send(ws, { type: 'run-start', threadId: 'B', prompt: 'second' })
+
+    const seenDones = new Set<string>()
+    while (seenDones.size < 2) {
+      const f = await reader.next(3000)
+      if (f.type === 'run-done') seenDones.add(f.runId)
+    }
+    expect(seenDones).toEqual(new Set(['run-A', 'run-B']))
+    ws.close()
+    await plane.stop()
+  })
+
+  it('disconnect aborts all inflight runs', async () => {
+    const longEvents = Array.from({ length: 100 }, (_, i) => ({
+      type: 'text-delta',
+      id: 'm',
+      text: `${i}`,
+    }))
+    const { runtime, calls } = createFakeRuntime({
+      spec: { events: longEvents, doneAfterMs: 100 },
+    })
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-start', threadId: 't1', prompt: 'hi' })
+    await reader.next()
+    ws.close()
+    await new Promise((r) => setTimeout(r, 100))
+    expect(calls[0]?.aborted()).toBe(true)
+    await plane.stop()
+  })
+
+  it('runtime.run failure -> RUN_START_FAILED frame', async () => {
+    const failingRuntime: AgentRuntime = {
+      async run() {
+        throw new Error('runtime exploded')
+      },
+    }
+    const { plane, url } = await startPlane(failingRuntime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-start', threadId: 't', prompt: 'hi' })
+    const err = await reader.next()
+    expect(err.type).toBe('error')
+    if (err.type === 'error') {
+      expect(err.code).toBe('RUN_START_FAILED')
+      expect(err.message).toContain('runtime exploded')
+    }
+    ws.close()
+    await plane.stop()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Drain shutdown
+// ---------------------------------------------------------------------------
+
+describe('graceful shutdown', () => {
+  it('stop() aborts inflight runs and closes the server', async () => {
+    const longEvents = Array.from({ length: 100 }, (_, i) => ({
+      type: 'text-delta',
+      id: 'm',
+      text: `${i}`,
+    }))
+    const { runtime, calls } = createFakeRuntime({
+      spec: { events: longEvents, doneAfterMs: 100 },
+    })
+    const { plane, url } = await startPlane(runtime)
+    const { ws, reader } = await connectClient(url)
+    await helloAndAuth(ws, reader)
+    send(ws, { type: 'run-start', threadId: 't1', prompt: 'hi' })
+    await reader.next()
+    await plane.stop({ drainTimeoutMs: 500 })
+    expect(calls[0]?.aborted()).toBe(true)
+    expect(plane.connectionCount()).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// streamRunToWs (unit-ish — bypasses WS)
+// ---------------------------------------------------------------------------
+
+describe('streamRunToWs', () => {
+  it('forwards events and emits run-done with finishReason + usage', async () => {
+    const events = [
+      { type: 'text-delta', id: 'm', text: 'hi' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        totalUsage: { inputTokens: 3, outputTokens: 2 },
+      },
+    ]
+    const handle: RunHandle = {
+      runId: 'r-1',
+      fullStream: (async function* () {
+        for (const e of events) yield e as never
+      })(),
+      done: Promise.resolve(),
+    }
+    const sent: ServerFrame[] = []
+    await streamRunToWs({ handle, send: (f) => sent.push(f) })
+    expect(sent.filter((f) => f.type === 'run-event')).toHaveLength(2)
+    const done = sent[sent.length - 1]
+    expect(done?.type).toBe('run-done')
+    if (done?.type === 'run-done') {
+      expect(done.finishReason).toBe('stop')
+      expect(done.usage).toEqual({ inputTokens: 3, outputTokens: 2 })
+    }
+  })
+
+  it('still emits run-done if handle.done rejects (runtime swallows)', async () => {
+    const handle: RunHandle = {
+      runId: 'r-2',
+      fullStream: (async function* () {})(),
+      done: Promise.reject(new Error('post-run hook failed')),
+    }
+    const sent: ServerFrame[] = []
+    await streamRunToWs({ handle, send: (f) => sent.push(f) })
+    expect(sent[sent.length - 1]?.type).toBe('run-done')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// install-service (pure functions)
+// ---------------------------------------------------------------------------
+
+describe('renderServiceArtifact', () => {
+  it('renders a launchd plist on darwin', () => {
+    const a = renderServiceArtifact({
+      binPath: '/opt/talos/talosd',
+      home: '/Users/alice',
+      platform: 'darwin',
+      logDir: '/Users/alice/.local/share/talos',
+    })
+    expect(a.platform).toBe('darwin')
+    expect(a.servicePath).toBe('/Users/alice/Library/LaunchAgents/com.talos.daemon.plist')
+    expect(a.body).toContain('<key>Label</key>')
+    expect(a.body).toContain('<string>com.talos.daemon</string>')
+    expect(a.body).toContain('<string>/opt/talos/talosd</string>')
+    expect(a.followups[0]).toContain('launchctl load')
+  })
+
+  it('renders a systemd user unit on linux', () => {
+    const a = renderServiceArtifact({
+      binPath: '/opt/talos/talosd',
+      home: '/home/alice',
+      platform: 'linux',
+      logDir: '/home/alice/.local/share/talos',
+    })
+    expect(a.platform).toBe('linux')
+    expect(a.servicePath).toBe('/home/alice/.config/systemd/user/talosd.service')
+    expect(a.body).toContain('[Service]')
+    expect(a.body).toContain('ExecStart=/opt/talos/talosd')
+    expect(a.followups.some((c) => c.includes('systemctl --user enable'))).toBe(true)
+  })
+
+  it('throws on unsupported platforms', () => {
+    expect(() =>
+      renderServiceArtifact({ binPath: '/opt/x', platform: 'win32' as NodeJS.Platform }),
+    ).toThrow(/unsupported platform/)
+  })
+
+  it('writeServiceArtifact writes the file 0644 and creates parents', async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), 'talos-svc-'))
+    const artifact = renderServiceArtifact({
+      binPath: '/opt/talos/talosd',
+      home: tmp,
+      platform: 'linux',
+      logDir: '/var/log/talos',
+    })
+    writeServiceArtifact(artifact)
+    expect(fs.existsSync(artifact.servicePath)).toBe(true)
+    const stat = fs.statSync(artifact.servicePath)
+    expect(stat.mode & 0o777).toBe(0o644)
+    await fsp.rm(tmp, { recursive: true, force: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatDiagnostics
+// ---------------------------------------------------------------------------
+
+describe('formatDiagnostics', () => {
+  it('aligns name column and prefixes pass/fail', () => {
+    const out = formatDiagnostics([
+      { name: 'db', pass: true, detail: 'ok' },
+      { name: 'keeperhub', pass: false, detail: 'no session' },
+    ])
+    const lines = out.split('\n')
+    expect(lines[0]?.startsWith('PASS')).toBe(true)
+    expect(lines[1]?.startsWith('FAIL')).toBe(true)
+    // name column padded to longest name (9 chars: 'keeperhub')
+    expect(lines[0]).toContain('db       ')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PID file lifecycle (covered indirectly elsewhere; smoke test here)
+// ---------------------------------------------------------------------------
+
+describe('pidfile helpers', () => {
+  let tmpDir: string
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'talos-pid-'))
+  })
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writePidFile + removePidFile round-trip', async () => {
+    const { writePidFile, removePidFile } = await import('@/persistence/ownership')
+    const pidPath = path.join(tmpDir, 'sub', 'daemon.pid')
+    writePidFile({ paths: { pidPath }, pid: 12345 })
+    expect(fs.readFileSync(pidPath, 'utf8').trim()).toBe('12345')
+    removePidFile({ paths: { pidPath } })
+    expect(fs.existsSync(pidPath)).toBe(false)
+    // idempotent
+    removePidFile({ paths: { pidPath } })
+  })
+})


### PR DESCRIPTION
## Summary

Implements issue #9 — long-running `talosd` daemon that owns the file-backed PGLite database and exposes a localhost WebSocket control plane for clients (CLI today; TG/MCP-host bridge in #13).

- **Control plane** (`src/daemon/server.ts`): WS server on `127.0.0.1:7711`, hello/auth state machine, bearer-token auth via constant-time compare, per-connection AbortController per inflight run, `run-start`/`run-cancel`/`run-event`/`run-done`/`error` frames, drain-on-stop with deadline.
- **Run streamer** (`src/daemon/runs.ts`): adapts `RunHandle.fullStream` to `ServerFrame` events, captures `finishReason` + `usage` from the finish event.
- **Lifecycle** (`src/daemon/lifecycle.ts`): boots env -> `ensureToken` -> DB + migrations -> runtime -> control plane -> PID file -> SIGTERM/SIGINT teardown.
- **Doctor** (`src/daemon/doctor.ts`): 3 checks (db / daemon WS / keeperhub session) for `talos doctor`.
- **install-service** (`src/daemon/install-service.ts`): launchd plist (darwin) + systemd user unit (linux), `--print` to dump body, `--bin` to override binary path.
- **CLI**: `bin/talosd.ts` (daemon entrypoint) + `bin/talos.ts` adds `install-service` and `doctor` subcommands.
- **PID file**: `writePidFile` / `removePidFile` in `src/persistence/ownership.ts`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm biome check` clean
- [x] `pnpm test` — **149 passed + 1 todo** (was 123 in #25 merge); 26 new daemon tests covering:
  - Frame protocol: hello/auth state machine, repeat hello, auth-before-hello, invalid tokens, malformed frames
  - Run streaming: full event pass-through, finish-event capture, multiple inflight runs per connection
  - Cancellation: `run-cancel` aborts the right run, disconnect aborts all conn's runs, unknown runId
  - Drain: stop aborts inflight, closes sockets, respects deadline
  - install-service: darwin plist + linux unit rendering, unsupported platform throw, write to disk
- [ ] CI green on Node 20 + 22

## Out of scope

- Channel registration (CLI/TG/MCP-host) -> #13
- `talos init` wizard -> #14
- KeeperHub session integration in `doctor` is a presence/expiry check; full DCR refresh probe stays in #8 territory.

Closes #9.