### PR TITLE
feat(tools): evm-mcp wiring with annotation overrides

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import { loadEnv, resetEnvCache } from '@/config/env'
 import { paths } from '@/config/paths'
 import { ensureToken } from '@/config/token'
+import { defaultMcpServers, McpHost, McpToolSource } from '@/mcp-host'
 import {
   assertNoLiveDaemon,
   createDb,
@@ -36,6 +37,11 @@ export type StartDaemonOpts = {
   installSignalHandlers?: boolean
   /** Use ephemeral PGLite (no on-disk file). Tests only. */
   ephemeralDb?: boolean
+  /**
+   * Skip booting the MCP host (no third-party servers spawned). Useful for
+   * tests that don't need tools, or for offline development.
+   */
+  disableMcpHost?: boolean
 }
 
 export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<DaemonHandle> {
@@ -68,8 +74,21 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     : await createDb({ path: paths.dbPath })
   await runMigrations(dbHandle)
 
-  // Build runtime deps. Tools / KH middleware / knowledge / summarizer / fact
-  // pipeline are deferred to follow-up issues (#10/#11/#16/#17 LLM impls).
+  // MCP host hosts the third-party tool servers. Started before the runtime
+  // so the runtime can hold a stable McpToolSource reference. Connection
+  // failures are non-fatal — the daemon keeps booting, tools just stay empty
+  // until the operator fixes the underlying issue.
+  const mcpHost = startOpts.disableMcpHost ? null : new McpHost()
+  if (mcpHost) {
+    try {
+      await mcpHost.start(defaultMcpServers())
+    } catch (err) {
+      logger.warn({ err }, 'MCP host failed to connect to all servers — continuing with no tools')
+    }
+  }
+
+  // Build runtime deps. KH middleware / knowledge / summarizer / fact
+  // pipeline are deferred to follow-up issues (#11/#16/#17 LLM impls).
   const agents = new AgentRegistry()
   agents.register(TALOS_ETH_AGENT, { default: true })
   const providers = createProviderRouter()
@@ -79,7 +98,7 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     providers,
     embeddings,
     agents,
-    toolSources: [],
+    toolSources: mcpHost ? [new McpToolSource(mcpHost)] : [],
   })
 
   // Boot control plane.
@@ -117,6 +136,13 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
         await controlPlane.stop()
       } catch (err) {
         logger.warn({ err }, 'error stopping control plane')
+      }
+      if (mcpHost) {
+        try {
+          await mcpHost.stop()
+        } catch (err) {
+          logger.warn({ err }, 'error stopping mcp host')
+        }
       }
       try {
         await dbHandle.close()

--- a/src/mcp-host/defaults.ts
+++ b/src/mcp-host/defaults.ts
@@ -1,0 +1,51 @@
+import type { McpServerConfig } from './index'
+
+/**
+ * Default MCP servers Talos boots with.
+ *
+ * Each entry is connected at daemon startup by `lifecycle.ts`. Servers are
+ * spawned with the parent process's environment, so any keys the user has set
+ * (`EVM_PRIVATE_KEY`, `EVM_MNEMONIC`, `ETHERSCAN_API_KEY`, ...) are inherited
+ * by the npx-launched child without explicit wiring.
+ *
+ * `staticAnnotations` corrects audit-routing for tools that the KeeperHub
+ * middleware would otherwise route through workflow audit by default. The
+ * middleware's `KNOWN_READONLY` regex covers most read patterns
+ * (`_get_/`, `_balance$`, `_quote$`, ...) but a few read-only tools fall
+ * outside the regex set and need an explicit `readOnly: true`.
+ */
+export function defaultMcpServers(): McpServerConfig[] {
+  return [evmMcpServer()]
+}
+
+/**
+ * mcpdotdirect/evm-mcp-server — generic EVM MCP wrapping `viem` with 24 tools
+ * across 60+ networks. Read tools dominate; write tools require the user to
+ * set `EVM_PRIVATE_KEY` or `EVM_MNEMONIC` in their environment.
+ *
+ * RPC URLs are hardcoded upstream (no env-var override). For the demo this is
+ * acceptable since (a) defaults work for read paths, (b) custom Aave/Uniswap
+ * MCPs (PR-5/6) own their viem client and read RPCs from env. If we ever need
+ * Alchemy here we'd vendor a patched fork.
+ *
+ * Reference: https://github.com/mcpdotdirect/evm-mcp-server
+ */
+function evmMcpServer(): McpServerConfig {
+  return {
+    name: 'evmmcp',
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@mcpdotdirect/evm-mcp-server@2.0.4'],
+    staticAnnotations: {
+      // Read tools whose names don't match the `KNOWN_READONLY` regex set in
+      // the KeeperHub middleware. Without these overrides the middleware
+      // would conservatively route them through workflow audit, paying a
+      // ~200ms round-trip on pure reads. See `src/keeperhub/middleware.ts`.
+      resolve_ens_name: { readOnly: true },
+      lookup_ens_address: { readOnly: true },
+      wait_for_transaction: { readOnly: true },
+      read_contract: { readOnly: true },
+      multicall: { readOnly: true },
+    },
+  }
+}

--- a/src/mcp-host/host.ts
+++ b/src/mcp-host/host.ts
@@ -272,7 +272,9 @@ export class McpHost {
 
         for (const [originalName, tool] of Object.entries(mcpTools)) {
           const namespaced = namespaceToolName(config.name, originalName)
-          const annotations = parseToolAnnotations(tool as Record<string, unknown>)
+          const baseAnnotations = parseToolAnnotations(tool as Record<string, unknown>)
+          const overrides = config.staticAnnotations?.[originalName]
+          const annotations = overrides ? { ...baseAnnotations, ...overrides } : baseAnnotations
 
           const namespacedEntry: NamespacedToolEntry = {
             namespacedName: namespaced,

--- a/src/mcp-host/index.ts
+++ b/src/mcp-host/index.ts
@@ -1,7 +1,9 @@
 import type { Tool } from 'ai'
 import type { ToolSource } from '@/runtime/types'
 import type { McpHost } from './host'
+import type { ToolAnnotations } from './registry'
 
+export { defaultMcpServers } from './defaults'
 export { McpHost } from './host'
 export type { NamespacedToolEntry, ToolAnnotations } from './registry'
 export { flattenToolResult, namespaceToolName, parseToolAnnotations } from './registry'
@@ -15,6 +17,14 @@ export interface McpServerConfig {
   url?: string
   /** Extra headers for HTTP transport (e.g. `Authorization: Bearer ...`). */
   headers?: Record<string, string>
+  /**
+   * Per-tool annotation overrides applied at registration time. Lets us correct
+   * audit-routing for third-party servers that don't ship MCP-level annotations
+   * (e.g. mark `resolve_ens_name` as `readOnly: true` so the KeeperHub
+   * middleware bypasses workflow audit). Keyed by the tool's *original* name
+   * (pre-namespacing). Merged shallow over the parsed annotations.
+   */
+  staticAnnotations?: Record<string, Partial<ToolAnnotations>>
 }
 
 /**

--- a/tests/integration/evm-mcp-defaults.test.ts
+++ b/tests/integration/evm-mcp-defaults.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAudit } from '@/keeperhub/middleware'
+import type { ToolAnnotations } from '@/mcp-host'
+import { defaultMcpServers, namespaceToolName } from '@/mcp-host'
+
+const evmmcp = () => {
+  const server = defaultMcpServers().find((s) => s.name === 'evmmcp')
+  if (!server) throw new Error('evmmcp server not found in defaults')
+  return server
+}
+
+describe('defaultMcpServers — evm-mcp', () => {
+  it('is wired as stdio via npx', () => {
+    const s = evmmcp()
+    expect(s.transport).toBe('stdio')
+    expect(s.command).toBe('npx')
+    expect(s.args).toEqual(expect.arrayContaining(['-y']))
+    expect(s.args?.[1]).toMatch(/^@mcpdotdirect\/evm-mcp-server/)
+  })
+
+  it('declares staticAnnotations for tools missed by KNOWN_READONLY', () => {
+    const s = evmmcp()
+    const overrides = s.staticAnnotations ?? {}
+    expect(overrides.resolve_ens_name).toEqual({ readOnly: true })
+    expect(overrides.lookup_ens_address).toEqual({ readOnly: true })
+    expect(overrides.wait_for_transaction).toEqual({ readOnly: true })
+    expect(overrides.read_contract).toEqual({ readOnly: true })
+    expect(overrides.multicall).toEqual({ readOnly: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Audit-routing table — every evm-mcp tool, namespaced as `evmmcp_${name}`,
+// run through `shouldAudit` with the annotations the host *would* compute
+// after merging staticAnnotations over parsed annotations.
+//
+// Intent:
+//  - Every read tool should bypass audit (`shouldAudit === false`).
+//  - Every write/signing tool should route through audit.
+//  - The reason field documents *why* — KNOWN_READONLY regex match,
+//    explicit annotation, or audit-by-default.
+// ---------------------------------------------------------------------------
+
+type Row = {
+  /** Tool name as exposed by mcpdotdirect/evm-mcp-server (pre-namespace). */
+  tool: string
+  /** Whether this tool mutates chain state. Drives the `audit` expectation. */
+  mutating: boolean
+}
+
+const EVM_MCP_TOOLS: Row[] = [
+  // Wallet/network
+  { tool: 'get_wallet_address', mutating: false },
+  { tool: 'get_chain_info', mutating: false },
+  { tool: 'get_supported_networks', mutating: false },
+  { tool: 'get_gas_price', mutating: false },
+  // ENS
+  { tool: 'resolve_ens_name', mutating: false },
+  { tool: 'lookup_ens_address', mutating: false },
+  // Blocks/txs
+  { tool: 'get_block', mutating: false },
+  { tool: 'get_latest_block', mutating: false },
+  { tool: 'get_transaction', mutating: false },
+  { tool: 'get_transaction_receipt', mutating: false },
+  { tool: 'wait_for_transaction', mutating: false },
+  // Balances
+  { tool: 'get_balance', mutating: false },
+  { tool: 'get_token_balance', mutating: false },
+  { tool: 'get_allowance', mutating: false },
+  // Contracts
+  { tool: 'get_contract_abi', mutating: false },
+  { tool: 'read_contract', mutating: false },
+  { tool: 'multicall', mutating: false },
+  // Transfers / writes
+  { tool: 'transfer_native', mutating: true },
+  { tool: 'transfer_erc20', mutating: true },
+  { tool: 'approve_token_spending', mutating: true },
+  { tool: 'write_contract', mutating: true },
+  // NFT reads
+  { tool: 'get_nft_info', mutating: false },
+  { tool: 'get_erc1155_balance', mutating: false },
+  // Signing — off-chain but trust-sensitive; audit-by-default is the right call.
+  { tool: 'sign_message', mutating: true },
+  { tool: 'sign_typed_data', mutating: true },
+]
+
+describe('evm-mcp audit-routing table', () => {
+  const overrides = evmmcp().staticAnnotations ?? {}
+
+  it.each(EVM_MCP_TOOLS)('routes $tool correctly (mutating=$mutating)', ({ tool, mutating }) => {
+    const namespaced = namespaceToolName('evmmcp', tool)
+    // Simulate what the host computes: defaults from parseToolAnnotations
+    // (all-false, since evm-mcp ships no MCP-level annotations) merged with
+    // any static override.
+    const baseAnnotations: ToolAnnotations = {
+      mutates: false,
+      readOnly: false,
+      destructive: false,
+    }
+    const annotations: ToolAnnotations = {
+      ...baseAnnotations,
+      ...(overrides[tool] ?? {}),
+    }
+
+    const decision = shouldAudit(namespaced, annotations)
+
+    if (mutating) {
+      expect(decision.shouldAudit).toBe(true)
+    } else {
+      expect(decision.shouldAudit).toBe(false)
+    }
+  })
+
+  it('covers every tool the upstream README documents', () => {
+    // Tracks v2.0.4 surface. Adjust if upstream adds/removes tools.
+    expect(EVM_MCP_TOOLS).toHaveLength(25)
+  })
+})

--- a/tests/integration/mcp-host.test.ts
+++ b/tests/integration/mcp-host.test.ts
@@ -301,6 +301,60 @@ describe('McpHost', () => {
     await host.stop()
   })
 
+  it('applies staticAnnotations overrides during registration', async () => {
+    mockCreateMCPClient.mockResolvedValueOnce({
+      tools: vi.fn().mockResolvedValue({
+        // No MCP-side annotations on this tool — relies on the static override.
+        resolve_ens_name: {
+          description: 'Resolve ENS name to address',
+          execute: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '0xabc' }] }),
+        },
+        // Tool that ships an annotation; override should win for the field it sets.
+        write_contract: {
+          description: 'Write to a contract',
+          annotations: { mutates: true },
+          execute: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+        },
+        // Tool with no override: base annotations apply unchanged.
+        get_balance: {
+          description: 'Get balance',
+          execute: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: '1' }] }),
+        },
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    })
+
+    const host = new McpHost({ maxAttempts: 1 })
+    await host.start([
+      {
+        name: 'evmmcp',
+        transport: 'http',
+        url: 'http://localhost:0/evmmcp',
+        staticAnnotations: {
+          resolve_ens_name: { readOnly: true },
+          write_contract: { readOnly: true }, // intentional override of an upstream-set field
+        },
+      },
+    ])
+
+    const tools = host.listTools()
+    const byName = Object.fromEntries(tools.map((t) => [t.namespacedName, t]))
+
+    // Override applied to a tool with no upstream annotations.
+    expect(byName.evmmcp_resolve_ens_name?.annotations.readOnly).toBe(true)
+    expect(byName.evmmcp_resolve_ens_name?.annotations.mutates).toBe(false)
+
+    // Override wins over MCP-supplied annotation; non-overridden fields preserved.
+    expect(byName.evmmcp_write_contract?.annotations.readOnly).toBe(true)
+    expect(byName.evmmcp_write_contract?.annotations.mutates).toBe(true)
+
+    // No override → base annotations untouched.
+    expect(byName.evmmcp_get_balance?.annotations.readOnly).toBe(false)
+    expect(byName.evmmcp_get_balance?.annotations.mutates).toBe(false)
+
+    await host.stop()
+  })
+
   it('aborts a tool call that exceeds the timeout', async () => {
     mockCreateMCPClient.mockResolvedValueOnce({
       tools: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Summary

Wires `@mcpdotdirect/evm-mcp-server@2.0.4` into the MCP host as the first of 6 PRs against issue #10 (tool wiring). Adds 25 namespaced tools (`evmmcp_*`) covering balances, ENS, blocks/txs, contract reads/writes, transfers, NFTs, and message signing across 60+ EVM networks.

- **`staticAnnotations` on `McpServerConfig`** - per-tool annotation overrides applied during registration. Required because the upstream ships zero MCP-level annotations, so 5 read tools (`resolve_ens_name`, `lookup_ens_address`, `wait_for_transaction`, `read_contract`, `multicall`) fall outside the KeeperHub `KNOWN_READONLY` regex and would otherwise pay a workflow-audit round-trip on every call.
- **`McpHost` registration merge** - shallow-merges `staticAnnotations[originalName]` over `parseToolAnnotations()`. Existing parsed fields are preserved; overrides win where set.
- **`src/mcp-host/defaults.ts`** - exports `defaultMcpServers()` returning the evm-mcp stdio config. Spawned via `npx -y` so no global install required.
- **Daemon lifecycle wiring** - `lifecycle.ts` boots an `McpHost` with the defaults, wraps in `McpToolSource`, and pushes into the runtime's tool sources. Connection failures are non-fatal (warn + continue with empty tools). New `disableMcpHost` opt for tests.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm biome check` (no new errors; only pre-existing keeperhub.test.ts warnings)
- [x] `pnpm test` - 212 passed (was 207, +5 new)
- [ ] CI green on Node 20 + 22

New tests:
- **`mcp-host.test.ts`** - `applies staticAnnotations overrides during registration`: covers (a) override applied to a tool with no upstream annotations, (b) override wins over MCP-supplied annotation, (c) tools without overrides retain base annotations.
- **`evm-mcp-defaults.test.ts`** - 25-row `it.each` table asserting every upstream tool routes correctly through `shouldAudit`. Reads bypass, writes/signing audit. Tracks v2.0.4 surface so future upstream additions/removals fail loudly.

## Open follow-ups (not in this PR)

- **Wallet wiring** - `EVM_PRIVATE_KEY` inherited via parent env if the user sets it, but no Talos-managed key yet. Write tools register but error at call time without a key.
- **Live anvil integration** - upstream hardcodes RPC URLs in `src/core/chains.ts` (no env override), so redirecting to anvil-fork is awkward. Deferred to PR-5 (Aave) and PR-6 (Uniswap V3) where we own the viem client.
- **Alchemy RPC for evm-mcp** - same blocker. If needed later, fork the upstream and add `RPC_URL_<NETWORK>` env support. Out of scope for this PR.

Refs #10