### PR TITLE
feat(tools): blockscout-mcp wiring (hosted Streamable HTTP)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -19,6 +19,10 @@ const EnvSchema = z.object({
   TALOS_LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
   TALOS_DATA_DIR: z.string().optional(),
   TALOS_CONFIG_DIR: z.string().optional(),
+  BLOCKSCOUT_MCP_URL: z.preprocess(
+    (v) => (v === '' || v == null ? 'https://mcp.blockscout.com/mcp' : v),
+    z.string().url(),
+  ),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 })
 

--- a/src/mcp-host/defaults.ts
+++ b/src/mcp-host/defaults.ts
@@ -1,21 +1,23 @@
+import { loadEnv } from '@/config/env'
 import type { McpServerConfig } from './index'
 
 /**
  * Default MCP servers Talos boots with.
  *
- * Each entry is connected at daemon startup by `lifecycle.ts`. Servers are
- * spawned with the parent process's environment, so any keys the user has set
- * (`EVM_PRIVATE_KEY`, `EVM_MNEMONIC`, `ETHERSCAN_API_KEY`, ...) are inherited
- * by the npx-launched child without explicit wiring.
+ * Each entry is connected at daemon startup by `lifecycle.ts`. Stdio servers
+ * are spawned with the parent process's environment, so any keys the user has
+ * set (`EVM_PRIVATE_KEY`, `EVM_MNEMONIC`, `ETHERSCAN_API_KEY`, ...) are
+ * inherited by the npx-launched child without explicit wiring. HTTP servers
+ * connect via the URL configured here (overridable via env).
  *
  * `staticAnnotations` corrects audit-routing for tools that the KeeperHub
  * middleware would otherwise route through workflow audit by default. The
  * middleware's `KNOWN_READONLY` regex covers most read patterns
- * (`_get_/`, `_balance$`, `_quote$`, ...) but a few read-only tools fall
- * outside the regex set and need an explicit `readOnly: true`.
+ * (`_get_/`, `_balance$`, `_quote$`, `^blockscout_`, ...) but a few read-only
+ * tools fall outside the regex set and need an explicit `readOnly: true`.
  */
 export function defaultMcpServers(): McpServerConfig[] {
-  return [evmMcpServer()]
+  return [evmMcpServer(), blockscoutMcpServer()]
 }
 
 /**
@@ -47,5 +49,30 @@ function evmMcpServer(): McpServerConfig {
       read_contract: { readOnly: true },
       multicall: { readOnly: true },
     },
+  }
+}
+
+/**
+ * Blockscout MCP server — Python service exposing 16 read-only tools wrapping
+ * Blockscout's indexed chain explorer APIs (Etherscan-shaped surface, but
+ * multi-chain via Chainscout instance routing). Strict superset of evm-mcp's
+ * read coverage for transaction history, token transfers, NFT holdings, ABIs.
+ *
+ * Hosted at `https://mcp.blockscout.com/mcp` by default; override with the
+ * `BLOCKSCOUT_MCP_URL` env var to point at a self-hosted instance. No API key
+ * required for the hosted endpoint.
+ *
+ * Audit routing: all 16 tools start with `blockscout_` after namespacing and
+ * are caught by the `^blockscout_` regex in the KeeperHub middleware's
+ * `KNOWN_READONLY` allowlist — no `staticAnnotations` needed.
+ *
+ * Reference: https://github.com/blockscout/mcp-server
+ */
+function blockscoutMcpServer(): McpServerConfig {
+  const env = loadEnv()
+  return {
+    name: 'blockscout',
+    transport: 'http',
+    url: env.BLOCKSCOUT_MCP_URL,
   }
 }

--- a/tests/integration/blockscout-defaults.test.ts
+++ b/tests/integration/blockscout-defaults.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAudit } from '@/keeperhub/middleware'
+import type { ToolAnnotations } from '@/mcp-host'
+import { defaultMcpServers, namespaceToolName } from '@/mcp-host'
+
+const blockscout = () => {
+  const server = defaultMcpServers().find((s) => s.name === 'blockscout')
+  if (!server) throw new Error('blockscout server not found in defaults')
+  return server
+}
+
+describe('defaultMcpServers — blockscout', () => {
+  it('is wired as Streamable HTTP', () => {
+    const s = blockscout()
+    expect(s.transport).toBe('http')
+    expect(s.url).toMatch(/^https?:\/\//)
+  })
+
+  it('defaults to the hosted endpoint when no env override is set', () => {
+    const s = blockscout()
+    // Allow either the public host (default) or a user-configured override.
+    expect(s.url).toBeTruthy()
+    if (!process.env.BLOCKSCOUT_MCP_URL) {
+      expect(s.url).toBe('https://mcp.blockscout.com/mcp')
+    }
+  })
+
+  it('declares no staticAnnotations (regex covers every tool)', () => {
+    const s = blockscout()
+    // Every tool starts with `blockscout_` after namespacing, so the
+    // `^blockscout_` regex in KNOWN_READONLY catches all of them.
+    expect(s.staticAnnotations).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Audit-routing table — every blockscout-mcp tool, namespaced as
+// `blockscout_${name}`, run through `shouldAudit`. All 16 are read-only and
+// must bypass audit via the `^blockscout_` regex (KNOWN_READONLY).
+//
+// Including the underscore-padded `__unlock_blockchain_analysis__` tool, which
+// also starts with `blockscout_` after namespacing.
+// ---------------------------------------------------------------------------
+
+const BLOCKSCOUT_TOOLS: string[] = [
+  '__unlock_blockchain_analysis__',
+  'get_chains_list',
+  'get_address_by_ens_name',
+  'lookup_token_by_symbol',
+  'get_contract_abi',
+  'inspect_contract_code',
+  'get_address_info',
+  'get_tokens_by_address',
+  'get_block_number',
+  'get_transactions_by_address',
+  'get_token_transfers_by_address',
+  'nft_tokens_by_address',
+  'get_block_info',
+  'get_transaction_info',
+  'read_contract',
+  'direct_api_call',
+]
+
+describe('blockscout audit-routing table', () => {
+  it.each(BLOCKSCOUT_TOOLS)('routes %s as a read-only bypass', (tool) => {
+    const namespaced = namespaceToolName('blockscout', tool)
+    // Blockscout ships no MCP-level annotations from the upstream; defaults
+    // are all-false from parseToolAnnotations.
+    const annotations: ToolAnnotations = {
+      mutates: false,
+      readOnly: false,
+      destructive: false,
+    }
+    const decision = shouldAudit(namespaced, annotations)
+    expect(decision.shouldAudit).toBe(false)
+    expect(decision.reason).toBe('KNOWN_READONLY')
+  })
+
+  it('covers every tool the upstream documents', () => {
+    // Tracks the upstream's current surface (16 tools at v0.x). Adjust if
+    // the server adds new tools.
+    expect(BLOCKSCOUT_TOOLS).toHaveLength(16)
+  })
+})


### PR DESCRIPTION
## Summary

Wires `blockscout/mcp-server` as PR-2 of issue #10 (tool wiring). Adds 16 namespaced read-only tools (`blockscout_*`) covering address state, transaction/transfer history, NFT holdings, contract ABIs and verified source, plus a generic `direct_api_call` escape hatch. Multi-chain via the `chain_id` parameter routed through Chainscout instances.

- **`BLOCKSCOUT_MCP_URL` env var** - defaults to `https://mcp.blockscout.com/mcp` (hosted, no API key, no rate limit documented). Override to point at a self-hosted instance.
- **Streamable HTTP transport** - first non-stdio default in the host, validates the HTTP code path against a real upstream. No spawn overhead, no Python toolchain required on user box.
- **No `staticAnnotations` needed** - every tool starts with `blockscout_` after namespacing and the existing `/^blockscout_/` regex in `src/keeperhub/middleware.ts` (KNOWN_READONLY) catches all of them.

## Why this PR matters

`evm-mcp` (PR-1) covers RPC reads but can't answer "what happened on chain" - tx history, token transfers, holders, verified source code. `blockscout` fills that gap with no install cost (hosted) and no spawn overhead (HTTP). The two surfaces are complementary:

| Question | Tool |
|---|---|
| "what's my balance now" | evm-mcp |
| "what's the latest block" | evm-mcp |
| "read totalSupply()" | evm-mcp |
| "show me the last 10 transactions of 0xabc" | **blockscout** |
| "list all USDC transfers to 0xabc this month" | **blockscout** |
| "what NFTs does this address hold" | **blockscout** |
| "fetch the verified source of contract 0xdef" | **blockscout** |

Smoke also confirmed blockscout reliably resolves ENS on mainnet where `evm-mcp`'s upstream RPC default (eth.llamarpc.com) was returning malformed JSON.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm biome check` (no new errors; only pre-existing keeperhub.test.ts warnings)
- [x] `pnpm test` - 232 passed (was 212, +20 new)
- [x] Live smoke test against hosted endpoint - agent chained `blockscout_get_address_by_ens_name` + `blockscout_get_transactions_by_address` and returned real mainnet data, including cross-tool composition with `evmmcp_get_transaction` for tx detail enrichment. End-to-end ~28s including LLM streaming.
- [ ] CI green on Node 20 + 22

New tests:
- **`blockscout-defaults.test.ts`** - 16-row `it.each` audit-routing table asserting every documented tool routes through `shouldAudit` with `reason: 'KNOWN_READONLY'`. Tracks the upstream surface so added/removed tools fail loudly.
- Plus 3 describe-level checks for transport shape, default URL, and absence of staticAnnotations.

## Open follow-ups (not in this PR)

- **KeeperHub middleware not yet wired into the runtime.** Found during smoke testing - `lifecycle.ts` creates the runtime without `middleware: [createKeeperHubMiddleware(...)]`, so the `tool_calls` audit table stays empty live. Read paths still bypass correctly; write paths bypass audit too (but no write tools exist yet on Sepolia in defaults). Worth a small follow-up PR before #12 (demo-flow eval).
- **`__unlock_blockchain_analysis__` auto-call** - blockscout's docs call this a "mandatory first step". The agent picks it up from the tool description; not auto-called on boot. Revisit if the LLM ever skips it and the rest fails.

## Stack

This PR targets `feat/tool-evm-mcp` (PR-1, #28) so its diff stays scoped to blockscout. Once PR-1 merges, GitHub will rebase the base to `main` and only show PR-2's deltas.

Refs #10