### PR TITLE
feat(runtime): wire keeperhub middleware end-to-end + step_id backfill + ai pin + mutate routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@electric-sql/pglite": "latest",
     "@lifi/sdk": "^3.16.3",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "ai": "latest",
+    "ai": "^6.0.0",
     "commander": "latest",
     "dotenv": "latest",
     "drizzle-orm": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
       ai:
-        specifier: latest
+        specifier: ^6.0.0
         version: 6.0.168(zod@4.3.6)
       commander:
         specifier: latest
@@ -5395,7 +5395,7 @@ snapshots:
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@6.0.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@6.0.3)(zod@4.3.6)
       preact: 10.24.2
       viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.3)(utf-8-validate@6.0.6)(zod@3.25.76)
       zustand: 5.0.3(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
@@ -10708,20 +10708,6 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.6.9(typescript@6.0.3)(zod@3.25.76):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/curves': 1.9.7
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@6.0.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.3

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs'
 import { loadEnv, resetEnvCache } from '@/config/env'
 import { paths } from '@/config/paths'
 import { ensureToken } from '@/config/token'
-import { defaultMcpServers, McpHost, McpToolSource } from '@/mcp-host'
+import { type AnnotationLookup, createKeeperHubMiddleware, type ToolMiddleware } from '@/keeperhub'
+import { defaultMcpServers, McpHost, McpToolSource, type ToolAnnotations } from '@/mcp-host'
 import {
   assertNoLiveDaemon,
   createDb,
@@ -15,6 +16,7 @@ import { AgentRegistry, TALOS_ETH_AGENT } from '@/runtime/agents'
 import { createOpenAIEmbeddings } from '@/runtime/embeddings'
 import { createProviderRouter } from '@/runtime/providers'
 import { createRuntime } from '@/runtime/runtime'
+import type { RunContext } from '@/runtime/types'
 import { logger } from '@/shared/logger'
 import { createAgentKitToolSource } from '@/tools/agentkit'
 import { createLifiToolSource } from '@/tools/lifi'
@@ -111,8 +113,34 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     logger.info({ source: src.name, tools: src.toolNames().length }, 'native tool source ready')
   }
 
-  // Build runtime deps. KH middleware / knowledge / summarizer / fact
-  // pipeline are deferred to follow-up issues (#11/#16/#17 LLM impls).
+  // Annotation lookup feeds the KeeperHub `shouldAudit` policy. Native sources
+  // declare their own annotations; the MCP host carries parsed + override-merged
+  // annotations on its tool index. Native takes priority on collision (matches
+  // `mergeToolSources` ordering).
+  const annotationLookup: AnnotationLookup = (name) => {
+    for (const src of nativeSources) {
+      const a = src.annotations(name)
+      if (a) return a
+    }
+    if (mcpHost) {
+      const entry = mcpHost.listTools().find((t) => t.namespacedName === name)
+      if (entry) return entry.annotations as ToolAnnotations
+    }
+    return undefined
+  }
+
+  // Per-run middleware factory. Bound at boot to db + annotation lookup; the
+  // runtime calls it per run with the runId so audit rows carry the right
+  // run context. Single writer for `tool_calls` (persistStep no longer inserts).
+  const toolMiddleware = (ctx: RunContext): ToolMiddleware =>
+    createKeeperHubMiddleware({
+      db: dbHandle.db,
+      runContext: () => ctx,
+      annotations: annotationLookup,
+    })
+
+  // Build runtime deps. Knowledge / summarizer / fact pipeline are deferred
+  // to follow-up issues (#11/#16/#17 LLM impls).
   const agents = new AgentRegistry()
   agents.register(TALOS_ETH_AGENT, { default: true })
   const providers = createProviderRouter()
@@ -123,6 +151,7 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     embeddings,
     agents,
     toolSources: [...(mcpHost ? [new McpToolSource(mcpHost)] : []), ...nativeSources],
+    toolMiddleware,
   })
 
   // Boot control plane.

--- a/src/keeperhub/index.ts
+++ b/src/keeperhub/index.ts
@@ -13,6 +13,7 @@ export {
   createKeeperHubMiddleware,
   type KeeperHubMiddlewareDeps,
   KNOWN_READONLY,
+  type MutateRoute,
   type RunContextProvider,
   type ShouldAuditDecision,
   shouldAudit,

--- a/src/keeperhub/index.ts
+++ b/src/keeperhub/index.ts
@@ -1,3 +1,4 @@
+export type { RunContext, ToolMiddleware } from '@/runtime/types'
 export {
   type ContractCallInput,
   createKeeperHubClient,
@@ -12,11 +13,9 @@ export {
   createKeeperHubMiddleware,
   type KeeperHubMiddlewareDeps,
   KNOWN_READONLY,
-  type RunContext,
   type RunContextProvider,
   type ShouldAuditDecision,
   shouldAudit,
-  type ToolMiddleware,
 } from './middleware'
 export {
   type AuthServerMetadata,

--- a/src/keeperhub/middleware.ts
+++ b/src/keeperhub/middleware.ts
@@ -3,6 +3,7 @@ import type { ToolAnnotations } from '@/mcp-host/registry'
 import { appendToolCallAudit, type Db, type ToolAuditMeta } from '@/persistence/queries'
 import type { RunContext, ToolMiddleware } from '@/runtime/types'
 import { child } from '@/shared/logger'
+import type { ContractCallInput, KeeperHubClient } from './client'
 
 const log = child({ module: 'keeperhub-middleware' })
 
@@ -50,6 +51,15 @@ export type RunContextProvider = () => RunContext | null
 
 export type AnnotationLookup = (toolName: string) => ToolAnnotations | undefined
 
+/**
+ * Maps a mutate tool's incoming args to a KeeperHub contract-call payload.
+ * Implementations live with each protocol tool (e.g. `aave_supply` provides
+ * its own route that builds the `Pool.supply` call). Returning the payload
+ * is the only contract — when no route is registered for a mutate tool, the
+ * middleware falls through to the original `execute`.
+ */
+export type MutateRoute = (args: unknown) => ContractCallInput
+
 export type KeeperHubMiddlewareDeps = {
   db: Db
   /**
@@ -66,16 +76,29 @@ export type KeeperHubMiddlewareDeps = {
    * Returns `undefined` for tools that have no annotations (defaults apply).
    */
   annotations?: AnnotationLookup
+  /**
+   * KeeperHub workflow routing for mutate tools. When provided AND the tool's
+   * audit decision is `annotation_mutates` AND a route is registered for the
+   * tool's name, the wrapper calls `kh.client.executeContractCall(route(args))`
+   * INSTEAD of the original `execute`. The tool's return becomes the
+   * `ExecutionResult` shape; audit row gains `executionId` and `txHash`.
+   *
+   * Mutate tools without a registered route fall through to the original
+   * `execute` (audit row still records `shouldAudit: true, reason:
+   * 'annotation_mutates'`). Routes are added per protocol as their tools land
+   * (custom Aave PR-5, Uniswap V3 PR-6, etc.).
+   */
+  kh?: {
+    client: KeeperHubClient
+    routes: ReadonlyMap<string, MutateRoute>
+  }
 }
 
 /**
  * Build an audit-by-default middleware that wraps each tool's `execute`,
- * applies `shouldAudit`, runs the original tool, and persists a tool-call
- * row with structured audit metadata.
- *
- * For #8 the middleware always passes through to the original tool (no
- * workflow envelope). #10 will plug in `KeeperHubClient.executeContractCall`
- * for tools whose decision is `shouldAudit=true`.
+ * applies `shouldAudit`, runs the original tool (or routes through KeeperHub
+ * when a mutate route is configured), and persists a tool-call row with
+ * structured audit metadata.
  */
 export function createKeeperHubMiddleware(deps: KeeperHubMiddlewareDeps): ToolMiddleware {
   return (tools) => {
@@ -90,6 +113,12 @@ export function createKeeperHubMiddleware(deps: KeeperHubMiddlewareDeps): ToolMi
 function wrapTool(name: string, original: Tool, deps: KeeperHubMiddlewareDeps): Tool {
   const annotations = deps.annotations?.(name)
   const decision = shouldAudit(name, annotations)
+  // Route this tool through KeeperHub only when (a) it's annotated mutates AND
+  // (b) a route is registered. Mutate tools without a route still audit but
+  // call the original execute.
+  const route =
+    deps.kh && decision.reason === 'annotation_mutates' ? deps.kh.routes.get(name) : undefined
+  const khClient = route ? deps.kh?.client : undefined
 
   const originalExecute = original.execute
   if (!originalExecute) return original
@@ -101,7 +130,21 @@ function wrapTool(name: string, original: Tool, deps: KeeperHubMiddlewareDeps): 
       const runCtx = deps.runContext()
       let result: unknown
       let error: string | undefined
+      let executionId: string | undefined
+      let txHash: string | undefined
       try {
+        if (route && khClient) {
+          const callInput = route(args)
+          const exec = await khClient.executeContractCall(callInput)
+          executionId = exec.executionId
+          if (exec.txHash) txHash = exec.txHash
+          if (exec.status === 'failed' || exec.error) {
+            const msg = exec.error ?? 'KeeperHub execution failed'
+            throw new Error(msg)
+          }
+          result = exec
+          return result
+        }
         result = await originalExecute(args, ctx)
         return result
       } catch (e) {
@@ -112,8 +155,11 @@ function wrapTool(name: string, original: Tool, deps: KeeperHubMiddlewareDeps): 
         const auditMeta: ToolAuditMeta = {
           shouldAudit: decision.shouldAudit,
           reason: decision.reason,
+          ...(executionId ? { executionId } : {}),
+          ...(txHash ? { txHash } : {}),
           details: {
             elapsedMs: finishedAt.getTime() - startedAt.getTime(),
+            ...(route ? { routedThrough: 'keeperhub' as const } : {}),
           },
         }
         if (runCtx) {

--- a/src/keeperhub/middleware.ts
+++ b/src/keeperhub/middleware.ts
@@ -1,6 +1,7 @@
 import type { Tool } from 'ai'
 import type { ToolAnnotations } from '@/mcp-host/registry'
 import { appendToolCallAudit, type Db, type ToolAuditMeta } from '@/persistence/queries'
+import type { RunContext, ToolMiddleware } from '@/runtime/types'
 import { child } from '@/shared/logger'
 
 const log = child({ module: 'keeperhub-middleware' })
@@ -45,12 +46,6 @@ export function shouldAudit(toolName: string, annotations?: ToolAnnotations): Sh
   return { shouldAudit: true, reason: 'audit_default' }
 }
 
-/** Per-call run context that the runtime threads in (one per agent run). */
-export type RunContext = {
-  runId: string
-  stepId?: string | null
-}
-
 export type RunContextProvider = () => RunContext | null
 
 export type AnnotationLookup = (toolName: string) => ToolAnnotations | undefined
@@ -72,8 +67,6 @@ export type KeeperHubMiddlewareDeps = {
    */
   annotations?: AnnotationLookup
 }
-
-export type ToolMiddleware = (tools: Record<string, Tool>) => Record<string, Tool>
 
 /**
  * Build an audit-by-default middleware that wraps each tool's `execute`,

--- a/src/persistence/queries.ts
+++ b/src/persistence/queries.ts
@@ -69,6 +69,31 @@ export async function recordToolCall(db: Db, input: NewToolCall) {
   return row
 }
 
+/**
+ * Backfill `step_id` on audit rows already inserted by the KeeperHub
+ * middleware. The middleware fires at tool execute time — before the step row
+ * exists — so it writes `step_id = null` and the runtime UPDATEs after
+ * `appendStep` returns. Scoped by `run_id + tool_call_id` so concurrent runs
+ * never cross-contaminate.
+ */
+export async function updateToolCallStepIds(
+  db: Db,
+  runId: string,
+  toolCallIds: readonly string[],
+  stepId: string,
+): Promise<void> {
+  if (toolCallIds.length === 0) return
+  await db
+    .update(toolCalls)
+    .set({ stepId })
+    .where(
+      sql`${toolCalls.runId} = ${runId} AND ${toolCalls.toolCallId} IN (${sql.join(
+        toolCallIds.map((id) => sql`${id}`),
+        sql`, `,
+      )})`,
+    )
+}
+
 export type ToolAuditMeta = {
   /** True if KeeperHub middleware would route this through workflow audit. */
   shouldAudit: boolean

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -13,7 +13,6 @@ import {
   closeRun,
   insertMessageEmbedding,
   openRun,
-  recordToolCall,
   upsertThread,
   writeThreadSummary,
 } from '@/persistence/queries'
@@ -32,6 +31,7 @@ import type {
   RunOptions,
   RuntimeConfig,
   ThreadSummarizer,
+  ToolMiddlewareFactory,
   ToolSource,
 } from './types'
 
@@ -45,6 +45,12 @@ export type RuntimeDeps = {
   embeddings: EmbeddingsService
   agents: AgentRegistry
   toolSources?: readonly ToolSource[]
+  /**
+   * Per-run middleware factory (KeeperHub audit-by-default in production).
+   * Called once per run after `openRun` so the middleware has the runId. When
+   * unset, tools pass through unwrapped and `tool_calls` rows are not written.
+   */
+  toolMiddleware?: ToolMiddlewareFactory
   knowledgeRetriever?: KnowledgeRetriever
   factPipeline?: FactPipeline
   summarizer?: ThreadSummarizer
@@ -98,14 +104,15 @@ export function createRuntime(deps: RuntimeDeps): AgentRuntime {
         knowledge.retrieve(opts.intent, { topK: cfg.knowledgeTopK }),
       ])
 
-      // 4. Mount tools + assemble system prompt.
-      const tools = await mergeToolSources(toolSources)
+      // 4. Mount tools + assemble system prompt. Names stay the same after
+      //    middleware wrapping, so the prompt can be built before the wrap.
+      const rawTools = await mergeToolSources(toolSources)
       const system = buildSystemPrompt({
         persona: agent.persona,
         warmSummary,
         coldRecallSummaries: coldSummaries,
         knowledgeChunks,
-        toolNames: Object.keys(tools),
+        toolNames: Object.keys(rawTools),
       })
 
       // 5. Open run row (status = 'running').
@@ -116,6 +123,12 @@ export function createRuntime(deps: RuntimeDeps): AgentRuntime {
       const runId = runRow.id
 
       log.info({ runId }, 'run opened')
+
+      // 5b. Apply tool middleware now that runId exists. The middleware writes
+      //     `tool_calls` audit rows (KeeperHub policy) so this is the single
+      //     writer — `persistStep` no longer inserts into `tool_calls`. When
+      //     unset, tools pass through and the table stays empty for this run.
+      const tools = deps.toolMiddleware ? deps.toolMiddleware({ runId })(rawTools) : rawTools
 
       // 6. Build messages for the model: hot tier + new user message.
       const messages: ModelMessage[] = [...hotMessages, { role: 'user', content: opts.intent }]
@@ -197,7 +210,11 @@ async function persistStep(
   stepIndex: number,
   event: OnStepFinishEvent<ToolSet>,
 ): Promise<void> {
-  const stepRow = await appendStep(db.db, {
+  // The KeeperHub middleware is the single writer of `tool_calls` rows (with
+  // audit metadata). `persistStep` only writes the step row — the
+  // `tool_calls` jsonb summary on the step keeps step-level reasoning even
+  // when middleware is absent.
+  await appendStep(db.db, {
     runId,
     stepIndex,
     role: 'assistant',
@@ -205,23 +222,6 @@ async function persistStep(
     toolCalls: event.toolCalls.length > 0 ? event.toolCalls.map(toolCallShape) : null,
     finishReason: event.finishReason,
   })
-
-  if (event.toolCalls.length === 0) return
-
-  // Match toolResults to their toolCalls by toolCallId.
-  const resultByCallId = new Map(event.toolResults.map((r) => [r.toolCallId, r]))
-  for (const call of event.toolCalls) {
-    const result = resultByCallId.get(call.toolCallId)
-    await recordToolCall(db.db, {
-      runId,
-      stepId: stepRow.id,
-      toolCallId: call.toolCallId,
-      toolName: call.toolName,
-      args: call.input as Record<string, unknown>,
-      result: result?.output as Record<string, unknown> | null,
-      error: null,
-    })
-  }
 }
 
 function toolCallShape(call: { toolCallId: string; toolName: string; input: unknown }) {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -13,6 +13,7 @@ import {
   closeRun,
   insertMessageEmbedding,
   openRun,
+  updateToolCallStepIds,
   upsertThread,
   writeThreadSummary,
 } from '@/persistence/queries'
@@ -211,10 +212,12 @@ async function persistStep(
   event: OnStepFinishEvent<ToolSet>,
 ): Promise<void> {
   // The KeeperHub middleware is the single writer of `tool_calls` rows (with
-  // audit metadata). `persistStep` only writes the step row — the
-  // `tool_calls` jsonb summary on the step keeps step-level reasoning even
-  // when middleware is absent.
-  await appendStep(db.db, {
+  // audit metadata). `persistStep` writes the step row + backfills `step_id`
+  // on audit rows already inserted by the middleware (it fires at tool
+  // execute time, before this step row exists, so it writes step_id = null).
+  // The `tool_calls` jsonb summary on the step keeps step-level reasoning
+  // even when middleware is absent.
+  const stepRow = await appendStep(db.db, {
     runId,
     stepIndex,
     role: 'assistant',
@@ -222,6 +225,15 @@ async function persistStep(
     toolCalls: event.toolCalls.length > 0 ? event.toolCalls.map(toolCallShape) : null,
     finishReason: event.finishReason,
   })
+
+  if (event.toolCalls.length > 0) {
+    await updateToolCallStepIds(
+      db.db,
+      runId,
+      event.toolCalls.map((c) => c.toolCallId),
+      stepRow.id,
+    )
+  }
 }
 
 function toolCallShape(call: { toolCallId: string; toolName: string; input: unknown }) {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -32,6 +32,28 @@ export interface ToolSource {
   getTools(): Promise<Record<string, Tool>>
 }
 
+// ---------- tool middleware ----------
+
+/** Per-call run context the runtime threads through to middleware. */
+export type RunContext = {
+  runId: string
+  stepId?: string | null
+}
+
+/**
+ * Wraps a record of tools, returning a record with the same keys. Implementations
+ * may intercept `execute`, replace behavior, or just observe. The KeeperHub
+ * middleware is the production implementation; tests may pass identity functions.
+ */
+export type ToolMiddleware = (tools: Record<string, Tool>) => Record<string, Tool>
+
+/**
+ * Per-run middleware factory. The daemon constructs this once at boot bound to
+ * the DB and annotation lookup; the runtime calls it per run with the run's id
+ * so audit rows carry the right runId without AsyncLocalStorage gymnastics.
+ */
+export type ToolMiddlewareFactory = (ctx: RunContext) => ToolMiddleware
+
 // ---------- knowledge layer (from #11) ----------
 
 export type KnowledgeChunkHit = {

--- a/tests/integration/keeperhub.test.ts
+++ b/tests/integration/keeperhub.test.ts
@@ -6,16 +6,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   type AuthServerMetadata,
   buildAuthorizeUrl,
+  type ContractCallInput,
   clearSession,
   createKeeperHubClient,
   createKeeperHubMiddleware,
   discoverAuthServer,
+  type ExecutionResult,
   exchangeCode,
   generatePkce,
   generateState,
   isExpired,
+  type KeeperHubClient,
   KNOWN_READONLY,
   loadSession,
+  type MutateRoute,
   type RegisteredClient,
   refreshToken,
   registerClient,
@@ -516,6 +520,194 @@ describe('createKeeperHubMiddleware', () => {
     const noExec = { description: 'meta', inputSchema: { type: 'object' as const } } as never
     const wrapped = middleware({ meta: noExec })
     expect(wrapped.meta).toBe(noExec)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Mutate-tool routing through KeeperHub workflow client (#10)
+  // ---------------------------------------------------------------------------
+
+  describe('mutate routing', () => {
+    function fakeKhClient(impl: {
+      executeContractCall: (input: ContractCallInput) => Promise<ExecutionResult>
+    }): KeeperHubClient {
+      return {
+        ensureToken: async () => 'token',
+        listTools: async () => ({}),
+        callTool: async () => undefined,
+        executeContractCall: impl.executeContractCall,
+        executeTransfer: async () => ({ executionId: 'noop', status: 'success' }),
+        getExecutionStatus: async () => ({ executionId: 'noop', status: 'success' }),
+        close: async () => {},
+      }
+    }
+
+    it('routes mutate tool through KH client when route is configured', async () => {
+      const calls: ContractCallInput[] = []
+      const client = fakeKhClient({
+        executeContractCall: async (input) => {
+          calls.push(input)
+          return { executionId: 'exec-1', status: 'success', txHash: '0xdead' }
+        },
+      })
+
+      const aaveRoute: MutateRoute = (args) => {
+        const a = args as { amount: string }
+        return {
+          network: 'sepolia',
+          contract_address: '0xAAVEPOOL',
+          function_name: 'supply',
+          function_args: [a.amount],
+        }
+      }
+
+      const originalCalled = vi.fn()
+      const middleware = createKeeperHubMiddleware({
+        db: handle.db,
+        runContext: () => ({ runId }),
+        annotations: () => ({ mutates: true }),
+        kh: { client, routes: new Map([['aave_supply', aaveRoute]]) },
+      })
+      const wrapped = middleware({
+        aave_supply: makeTool(async (args) => {
+          originalCalled(args)
+          return 'should not be called'
+        }),
+      })
+
+      const result = await wrapped.aave_supply!.execute!(
+        { amount: '100' },
+        { toolCallId: 'tc-mut-1', messages: [] },
+      )
+
+      expect(originalCalled).not.toHaveBeenCalled()
+      expect(calls).toHaveLength(1)
+      expect(calls[0]).toEqual({
+        network: 'sepolia',
+        contract_address: '0xAAVEPOOL',
+        function_name: 'supply',
+        function_args: ['100'],
+      })
+      expect(result).toMatchObject({ executionId: 'exec-1', txHash: '0xdead' })
+
+      const rows = await handle.pg.query<{
+        audit: {
+          shouldAudit: boolean
+          reason: string
+          executionId?: string
+          txHash?: string
+          details: { elapsedMs: number; routedThrough?: string }
+        }
+        result: { executionId: string }
+      }>(`SELECT audit, result FROM tool_calls WHERE tool_call_id = $1`, ['tc-mut-1'])
+      expect(rows.rows[0]?.audit.shouldAudit).toBe(true)
+      expect(rows.rows[0]?.audit.reason).toBe('annotation_mutates')
+      expect(rows.rows[0]?.audit.executionId).toBe('exec-1')
+      expect(rows.rows[0]?.audit.txHash).toBe('0xdead')
+      expect(rows.rows[0]?.audit.details.routedThrough).toBe('keeperhub')
+      expect(rows.rows[0]?.result.executionId).toBe('exec-1')
+    })
+
+    it('falls through to original execute when mutate tool has no route registered', async () => {
+      const client = fakeKhClient({
+        executeContractCall: vi.fn(
+          async (): Promise<ExecutionResult> => ({ executionId: 'noop', status: 'success' }),
+        ),
+      })
+
+      const middleware = createKeeperHubMiddleware({
+        db: handle.db,
+        runContext: () => ({ runId }),
+        annotations: () => ({ mutates: true }),
+        kh: { client, routes: new Map() },
+      })
+      const wrapped = middleware({
+        unknown_swap: makeTool(async () => ({ ok: true })),
+      })
+
+      const result = await wrapped.unknown_swap!.execute!(
+        {},
+        { toolCallId: 'tc-mut-2', messages: [] },
+      )
+
+      expect(result).toEqual({ ok: true })
+      expect(client.executeContractCall).not.toHaveBeenCalled()
+
+      const rows = await handle.pg.query<{
+        audit: { reason: string; executionId?: string; details: { routedThrough?: string } }
+      }>(`SELECT audit FROM tool_calls WHERE tool_call_id = $1`, ['tc-mut-2'])
+      expect(rows.rows[0]?.audit.reason).toBe('annotation_mutates')
+      expect(rows.rows[0]?.audit.executionId).toBeUndefined()
+      expect(rows.rows[0]?.audit.details.routedThrough).toBeUndefined()
+    })
+
+    it('records error when KH execution returns failed status', async () => {
+      const client = fakeKhClient({
+        executeContractCall: async () => ({
+          executionId: 'exec-err',
+          status: 'failed',
+          error: 'revert: insufficient collateral',
+        }),
+      })
+
+      const middleware = createKeeperHubMiddleware({
+        db: handle.db,
+        runContext: () => ({ runId }),
+        annotations: () => ({ mutates: true }),
+        kh: {
+          client,
+          routes: new Map([
+            [
+              'aave_supply',
+              () => ({ network: 'sepolia', contract_address: '0xX', function_name: 'supply' }),
+            ],
+          ]),
+        },
+      })
+      const wrapped = middleware({ aave_supply: makeTool(async () => 'never') })
+
+      await expect(
+        wrapped.aave_supply!.execute!({}, { toolCallId: 'tc-mut-3', messages: [] }),
+      ).rejects.toThrow(/insufficient collateral/)
+
+      const rows = await handle.pg.query<{
+        error: string
+        audit: { executionId?: string }
+      }>(`SELECT error, audit FROM tool_calls WHERE tool_call_id = $1`, ['tc-mut-3'])
+      expect(rows.rows[0]?.error).toContain('insufficient collateral')
+      expect(rows.rows[0]?.audit.executionId).toBe('exec-err')
+    })
+
+    it('does not route read tools even when KH client + route are present', async () => {
+      const client = fakeKhClient({
+        executeContractCall: vi.fn(
+          async (): Promise<ExecutionResult> => ({ executionId: 'wrong', status: 'success' }),
+        ),
+      })
+
+      const middleware = createKeeperHubMiddleware({
+        db: handle.db,
+        runContext: () => ({ runId }),
+        annotations: () => ({ readOnly: true }),
+        kh: {
+          client,
+          routes: new Map([
+            [
+              'aave_get_position',
+              () => ({ network: 'sepolia', contract_address: '0xX', function_name: 'pos' }),
+            ],
+          ]),
+        },
+      })
+      const wrapped = middleware({
+        aave_get_position: makeTool(async () => ({ debt: '0', collateral: '5' })),
+      })
+      const result = await wrapped.aave_get_position!.execute!(
+        {},
+        { toolCallId: 'tc-mut-4', messages: [] },
+      )
+      expect(result).toEqual({ debt: '0', collateral: '5' })
+      expect(client.executeContractCall).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/tests/integration/runtime.test.ts
+++ b/tests/integration/runtime.test.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai'
 import { MockLanguageModelV3, simulateReadableStream } from 'ai/test'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { z } from 'zod'
+import { createKeeperHubMiddleware } from '@/keeperhub'
 import {
   applyFactOps,
   createDb,
@@ -18,8 +19,10 @@ import {
   type EmbeddingsService,
   type FactPipeline,
   type ProviderRouter,
+  type RunContext,
   TALOS_ETH_AGENT,
   type ThreadSummarizer,
+  type ToolMiddleware,
   type ToolSource,
 } from '@/runtime'
 
@@ -331,7 +334,7 @@ describe('runtime — tool calling', () => {
     await handle?.close()
   })
 
-  it('records tool_calls with args + result; multi-step run advances stepIndex', async () => {
+  it('writes a single audit row per tool call (KeeperHub middleware single writer)', async () => {
     const flow = toolCallThenTextChunks({
       toolName: 'getBalance',
       toolCallId: 'call_1',
@@ -347,12 +350,19 @@ describe('runtime — tool calling', () => {
     })
     const toolSource: ToolSource = { getTools: async () => ({ getBalance: balanceTool }) }
 
+    const toolMiddleware = (ctx: RunContext): ToolMiddleware =>
+      createKeeperHubMiddleware({
+        db: handle.db,
+        runContext: () => ctx,
+      })
+
     const runtime = createRuntime({
       db: handle,
       providers: singleModelRouter(model),
       embeddings: deterministicEmbeddings(),
       agents: withRegistry(),
       toolSources: [toolSource],
+      toolMiddleware,
       config: { maxSteps: 3 },
     })
 
@@ -365,18 +375,127 @@ describe('runtime — tool calling', () => {
 
     const tcalls = await handle.pg.query<{
       tool_name: string
-      args: unknown
-      result: unknown
-      step_id: string
-    }>(`SELECT tool_name, args, result, step_id FROM tool_calls WHERE run_id = $1`, [r.runId])
+      args: { wallet: string }
+      result: { balance: string }
+      audit: { shouldAudit: boolean; reason: string; details: { elapsedMs: number } }
+      error: string | null
+    }>(`SELECT tool_name, args, result, audit, error FROM tool_calls WHERE run_id = $1`, [r.runId])
     expect(tcalls.rows.length).toBe(1)
-    expect(tcalls.rows[0]?.tool_name).toBe('getBalance')
+    const row = tcalls.rows[0]!
+    expect(row.tool_name).toBe('getBalance')
+    expect(row.args.wallet).toBe('0xABC')
+    expect(row.result.balance).toBe('5 ETH')
+    expect(row.audit.shouldAudit).toBe(true)
+    expect(row.audit.reason).toBe('audit_default')
+    expect(row.audit.details.elapsedMs).toBeGreaterThanOrEqual(0)
+    expect(row.error).toBeNull()
 
     const steps = await handle.pg.query<{ count: string }>(
       `SELECT COUNT(*)::text AS count FROM steps WHERE run_id = $1`,
       [r.runId],
     )
     expect(Number(steps.rows[0]?.count ?? '0')).toBeGreaterThanOrEqual(2)
+  })
+
+  it('records error and shouldAudit reason when tool throws', async () => {
+    const flow = toolCallThenTextChunks({
+      toolName: 'aave_supply',
+      toolCallId: 'call_err',
+      input: { amount: '100' },
+      finalText: 'I could not complete the supply.',
+    })
+    const model = makeMockModel([flow.step1, flow.step2])
+
+    const supplyTool = tool({
+      description: 'Supply to Aave',
+      inputSchema: z.object({ amount: z.string() }),
+      execute: async (_input): Promise<{ ok: boolean }> => {
+        throw new Error('insufficient liquidity')
+      },
+    })
+    const toolSource: ToolSource = { getTools: async () => ({ aave_supply: supplyTool }) }
+
+    const toolMiddleware = (ctx: RunContext): ToolMiddleware =>
+      createKeeperHubMiddleware({
+        db: handle.db,
+        runContext: () => ctx,
+        annotations: (name) => (name === 'aave_supply' ? { mutates: true } : undefined),
+      })
+
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+      toolSources: [toolSource],
+      toolMiddleware,
+      config: { maxSteps: 3 },
+    })
+
+    const r = await runtime.run({
+      threadId: 't-tools-err',
+      channel: 'cli',
+      intent: 'supply 100 USDC',
+    })
+    await drain(r)
+
+    const tcalls = await handle.pg.query<{
+      tool_name: string
+      audit: { shouldAudit: boolean; reason: string }
+      error: string | null
+    }>(`SELECT tool_name, audit, error FROM tool_calls WHERE run_id = $1`, [r.runId])
+    expect(tcalls.rows.length).toBe(1)
+    const row = tcalls.rows[0]!
+    expect(row.tool_name).toBe('aave_supply')
+    expect(row.audit.shouldAudit).toBe(true)
+    expect(row.audit.reason).toBe('annotation_mutates')
+    expect(row.error).toContain('insufficient liquidity')
+  })
+
+  it('passes tools through unchanged when toolMiddleware is undefined (no audit rows)', async () => {
+    const flow = toolCallThenTextChunks({
+      toolName: 'getBalance',
+      toolCallId: 'call_no_mw',
+      input: { wallet: '0xDEF' },
+      finalText: 'ok',
+    })
+    const model = makeMockModel([flow.step1, flow.step2])
+
+    const balanceTool = tool({
+      description: 'Get wallet balance',
+      inputSchema: z.object({ wallet: z.string() }),
+      execute: async ({ wallet }) => ({ wallet, balance: '0' }),
+    })
+    const toolSource: ToolSource = { getTools: async () => ({ getBalance: balanceTool }) }
+
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+      toolSources: [toolSource],
+      config: { maxSteps: 3 },
+    })
+
+    const r = await runtime.run({
+      threadId: 't-no-mw',
+      channel: 'cli',
+      intent: 'check 0xDEF',
+    })
+    await drain(r)
+
+    const tcalls = await handle.pg.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM tool_calls WHERE run_id = $1`,
+      [r.runId],
+    )
+    expect(tcalls.rows[0]?.count).toBe('0')
+
+    // step row still landed with tool_calls jsonb summary
+    const stepRow = await handle.pg.query<{ tool_calls: unknown }>(
+      `SELECT tool_calls FROM steps WHERE run_id = $1 ORDER BY step_index ASC LIMIT 1`,
+      [r.runId],
+    )
+    expect(stepRow.rows[0]?.tool_calls).not.toBeNull()
   })
 })
 

--- a/tests/integration/runtime.test.ts
+++ b/tests/integration/runtime.test.ts
@@ -397,6 +397,57 @@ describe('runtime — tool calling', () => {
     expect(Number(steps.rows[0]?.count ?? '0')).toBeGreaterThanOrEqual(2)
   })
 
+  it('backfills tool_calls.step_id to the step that produced the call', async () => {
+    const flow = toolCallThenTextChunks({
+      toolName: 'getBalance',
+      toolCallId: 'call_step_id',
+      input: { wallet: '0xABC' },
+      finalText: 'You have 5 ETH.',
+    })
+    const model = makeMockModel([flow.step1, flow.step2])
+
+    const balanceTool = tool({
+      description: 'Get wallet balance',
+      inputSchema: z.object({ wallet: z.string() }),
+      execute: async ({ wallet }) => ({ wallet, balance: '5 ETH' }),
+    })
+    const toolSource: ToolSource = { getTools: async () => ({ getBalance: balanceTool }) }
+
+    const toolMiddleware = (ctx: RunContext): ToolMiddleware =>
+      createKeeperHubMiddleware({ db: handle.db, runContext: () => ctx })
+
+    const runtime = createRuntime({
+      db: handle,
+      providers: singleModelRouter(model),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+      toolSources: [toolSource],
+      toolMiddleware,
+      config: { maxSteps: 3 },
+    })
+
+    const r = await runtime.run({
+      threadId: 't-step-id',
+      channel: 'cli',
+      intent: 'check balance',
+    })
+    await drain(r)
+
+    const tcalls = await handle.pg.query<{ tool_call_id: string; step_id: string | null }>(
+      `SELECT tool_call_id, step_id FROM tool_calls WHERE run_id = $1`,
+      [r.runId],
+    )
+    expect(tcalls.rows.length).toBe(1)
+    const tcStepId = tcalls.rows[0]?.step_id
+    expect(tcStepId).not.toBeNull()
+
+    const stepRow = await handle.pg.query<{ id: string }>(
+      `SELECT id FROM steps WHERE run_id = $1 AND step_index = 0`,
+      [r.runId],
+    )
+    expect(stepRow.rows[0]?.id).toBe(tcStepId)
+  })
+
   it('records error and shouldAudit reason when tool throws', async () => {
     const flow = toolCallThenTextChunks({
       toolName: 'aave_supply',


### PR DESCRIPTION
## Summary

Completes the deferred follow-up from #8 / PR #25 (the middleware factory was built but never wired into the runtime, so real agent runs produced zero `tool_calls` rows). Also lands the three small follow-ups identified during wiring: stepId precision, ai version pin, and the mutate-routing infrastructure for #10.

Four commits, kept small + cohesive.

### 1. `feat(runtime): wire keeperhub middleware end-to-end` (f464264)

- `RuntimeDeps` accepts a `ToolMiddlewareFactory`; runtime calls it once per run after `openRun` so audit rows carry the correct runId. Factory pattern picked over AsyncLocalStorage to keep per-run scoping explicit and avoid global state.
- `RunContext` and `ToolMiddleware` types move to `@/runtime/types` so the runtime is middleware-agnostic; `@/keeperhub` re-exports them for back-compat.
- Drops `persistStep`'s `recordToolCall` insert. The KeeperHub middleware is now the **single writer** of `tool_calls` (with audit metadata) — without this, every call would double-write.
- `lifecycle.ts` builds a unified `annotationLookup` (native sources first, MCP host fallthrough) and constructs the per-run factory.

### 2. `feat(persistence): backfill tool_calls.step_id from persistStep` (f196640)

The middleware fires at tool execute time — before the step row exists. Pre-allocating step ids via `experimental_onStepStart` would violate the `tool_calls.step_id -> steps.id` foreign key. Backfill via single UPDATE in `persistStep` after `appendStep` returns; scoped by `(run_id, tool_call_id IN (...))` so concurrent runs cannot cross-contaminate.

### 3. `chore(deps): pin ai to ^6.0.0` (67a524d)

Was `latest`. v7 will rename `experimental_onToolCallStart/Finish/context` and the middleware contract would break silently on auto-bump. Resolved version unchanged at 6.0.168.

### 4. `feat(keeperhub): mutate-tool routing through workflow client` (ba61e04)

Adds optional `kh.client` + `kh.routes: ReadonlyMap<string, MutateRoute>` to the middleware. When a tool's audit decision is `annotation_mutates` AND a route is registered, the wrapper calls `kh.client.executeContractCall(route(args))` instead of the original `execute`. Result becomes the `ExecutionResult` shape; audit row gains `executionId`, `txHash`, and `details.routedThrough: 'keeperhub'`.

- Mutate tools without a registered route fall through (audit only) — preserves current behavior.
- Read tools never route, even with `kh + route` present.
- KH-side failures (`status: 'failed'` or `error` set) throw with the captured error so the AI SDK records it as a tool-error step. Audit row records the `executionId` of the failed run for traceability.
- Routes are added per protocol as their tools land (custom Aave PR-5, Uniswap V3 PR-6); none are registered here.

## What's NOT in this PR (follow-ups)

- Actual protocol routes (Aave, Uniswap V3) — land with PR-5 / PR-6 of #10
- Streaming KH events (`keeperhub:workflow_create`, `tx_broadcast`, `tx_confirmed` from `architecture.md`) — needs a way for middleware to push into the runtime stream
- Pin `@ai-sdk/openai` and `@ai-sdk/mcp` — same v7-rename risk, separate concern

## Test plan

- [x] `pnpm vitest run tests/integration/runtime.test.ts tests/integration/keeperhub.test.ts` — 61 passing (was 56 in these suites)
- [x] `pnpm vitest run tests/integration/runtime.test.ts tests/integration/keeperhub.test.ts tests/integration/daemon.test.ts tests/integration/persistence.test.ts` — 96 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors, 29 warnings (all pre-existing `noNonNullAssertion` style in test files)

### New tests
- runtime: single audit row per call, error path, middleware-absent graceful degradation, **step_id backfilled to the producing step**
- keeperhub middleware: **mutate routing** (route-hit, route-miss, KH execution failure, read-tool-no-route)

References #8 (completes deferred wiring) and #10 (mutate routing infrastructure).