### PR TITLE
feat(tools): uniswap V3 (quote + approve + swap) on sepolia + native source routes

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,8 +1,17 @@
 import fs from 'node:fs'
+import { createPublicClient, http } from 'viem'
+import { sepolia } from 'viem/chains'
 import { loadEnv, resetEnvCache } from '@/config/env'
 import { paths } from '@/config/paths'
 import { ensureToken } from '@/config/token'
-import { type AnnotationLookup, createKeeperHubMiddleware, type ToolMiddleware } from '@/keeperhub'
+import {
+  type AnnotationLookup,
+  createKeeperHubClient,
+  createKeeperHubMiddleware,
+  type KeeperHubClient,
+  type MutateRoute,
+  type ToolMiddleware,
+} from '@/keeperhub'
 import { defaultMcpServers, McpHost, McpToolSource, type ToolAnnotations } from '@/mcp-host'
 import {
   assertNoLiveDaemon,
@@ -21,6 +30,8 @@ import { logger } from '@/shared/logger'
 import { createAgentKitToolSource } from '@/tools/agentkit'
 import { createLifiToolSource } from '@/tools/lifi'
 import type { NativeToolSource } from '@/tools/native'
+import { createUniswapToolSource } from '@/tools/uniswap'
+import { getViemWalletClient, getWalletAddress } from '@/wallet'
 import { type ControlPlane, createControlPlane } from './server'
 
 /**
@@ -28,11 +39,28 @@ import { type ControlPlane, createControlPlane } from './server'
  * Each source contributes pre-namespaced tools and self-declared
  * annotations consulted by the KeeperHub middleware.
  *
- * AgentKit init is async (it awaits action-provider registration); other
- * sources construct synchronously.
+ * Uniswap needs the wallet + a Sepolia RPC. AgentKit init is async (it awaits
+ * action-provider registration); other sources construct synchronously.
  */
-async function defaultNativeToolSources(): Promise<NativeToolSource[]> {
-  return [createLifiToolSource(), await createAgentKitToolSource()]
+async function defaultNativeToolSources(env: {
+  RPC_URL_SEPOLIA?: string | undefined
+}): Promise<NativeToolSource[]> {
+  const sepoliaPublicClient = createPublicClient({
+    chain: sepolia,
+    transport: http(env.RPC_URL_SEPOLIA),
+  })
+  const sepoliaWalletClient = getViemWalletClient('sepolia')
+  const walletAddress = getWalletAddress()
+
+  return [
+    createLifiToolSource(),
+    await createAgentKitToolSource(),
+    createUniswapToolSource({
+      walletClient: sepoliaWalletClient,
+      publicClient: sepoliaPublicClient,
+      walletAddress,
+    }),
+  ]
 }
 
 export type DaemonHandle = {
@@ -105,10 +133,13 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
   }
 
   // In-process (native) tool sources contribute Talos-owned tools (Li.Fi,
-  // AgentKit cherry-pick, future custom Aave/Uniswap). Share the runtime's
-  // tool surface with the MCP host and provide their own annotations to the
-  // KeeperHub middleware. No spawn cost, no serialization round-trip.
-  const nativeSources: NativeToolSource[] = await defaultNativeToolSources()
+  // AgentKit cherry-pick, Uniswap V3 on Sepolia, future custom Aave). Share
+  // the runtime's tool surface with the MCP host and provide their own
+  // annotations to the KeeperHub middleware. No spawn cost, no serialization
+  // round-trip.
+  const nativeSources: NativeToolSource[] = await defaultNativeToolSources({
+    RPC_URL_SEPOLIA: env.RPC_URL_SEPOLIA,
+  })
   for (const src of nativeSources) {
     logger.info({ source: src.name, tools: src.toolNames().length }, 'native tool source ready')
   }
@@ -129,14 +160,42 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     return undefined
   }
 
-  // Per-run middleware factory. Bound at boot to db + annotation lookup; the
-  // runtime calls it per run with the runId so audit rows carry the right
-  // run context. Single writer for `tool_calls` (persistStep no longer inserts).
+  // Aggregate KeeperHub mutate routes from every native source. Mutate tools
+  // in MCP-hosted servers don't yet declare routes — when they do, the host
+  // can expose a similar `routes()` getter and we union here.
+  const routes = new Map<string, MutateRoute>()
+  for (const src of nativeSources) {
+    for (const [name, route] of Object.entries(src.routes())) {
+      routes.set(name, route)
+    }
+  }
+  if (routes.size > 0) {
+    logger.info({ count: routes.size, names: [...routes.keys()] }, 'mutate routes registered')
+  }
+
+  // KeeperHub client is opt-in: built only when a session token exists on
+  // disk (operator ran `talos init` and completed OAuth). When absent, mutate
+  // tools fall through to direct execute and audit rows still record the
+  // call. We retain the warning so demo runs notice the missing wiring.
+  let khClient: KeeperHubClient | undefined
+  try {
+    khClient = await createKeeperHubClient({ tokenPath: paths.keeperhubTokenPath })
+  } catch (err) {
+    logger.info(
+      { err: err instanceof Error ? err.message : String(err) },
+      'keeperhub session not configured — mutate routing disabled (run `talos init` to enable)',
+    )
+  }
+
+  // Per-run middleware factory. Bound at boot to db + annotation lookup +
+  // optional KH client/routes; the runtime calls it per run with the runId so
+  // audit rows carry the right run context. Single writer for `tool_calls`.
   const toolMiddleware = (ctx: RunContext): ToolMiddleware =>
     createKeeperHubMiddleware({
       db: dbHandle.db,
       runContext: () => ctx,
       annotations: annotationLookup,
+      ...(khClient ? { kh: { client: khClient, routes } } : {}),
     })
 
   // Build runtime deps. Knowledge / summarizer / fact pipeline are deferred
@@ -195,6 +254,13 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
           await mcpHost.stop()
         } catch (err) {
           logger.warn({ err }, 'error stopping mcp host')
+        }
+      }
+      if (khClient) {
+        try {
+          await khClient.close()
+        } catch (err) {
+          logger.warn({ err }, 'error closing keeperhub client')
         }
       }
       try {

--- a/src/keeperhub/middleware.ts
+++ b/src/keeperhub/middleware.ts
@@ -54,11 +54,12 @@ export type AnnotationLookup = (toolName: string) => ToolAnnotations | undefined
 /**
  * Maps a mutate tool's incoming args to a KeeperHub contract-call payload.
  * Implementations live with each protocol tool (e.g. `aave_supply` provides
- * its own route that builds the `Pool.supply` call). Returning the payload
- * is the only contract — when no route is registered for a mutate tool, the
- * middleware falls through to the original `execute`.
+ * its own route that builds the `Pool.supply` call). May be sync or async —
+ * async lets the route fetch fresh chain state (quotes, allowances) before
+ * encoding. When no route is registered for a mutate tool, the middleware
+ * falls through to the original `execute`.
  */
-export type MutateRoute = (args: unknown) => ContractCallInput
+export type MutateRoute = (args: unknown) => ContractCallInput | Promise<ContractCallInput>
 
 export type KeeperHubMiddlewareDeps = {
   db: Db
@@ -134,7 +135,7 @@ function wrapTool(name: string, original: Tool, deps: KeeperHubMiddlewareDeps): 
       let txHash: string | undefined
       try {
         if (route && khClient) {
-          const callInput = route(args)
+          const callInput = await Promise.resolve(route(args))
           const exec = await khClient.executeContractCall(callInput)
           executionId = exec.executionId
           if (exec.txHash) txHash = exec.txHash

--- a/src/tools/native/source.ts
+++ b/src/tools/native/source.ts
@@ -1,4 +1,5 @@
 import type { Tool } from 'ai'
+import type { MutateRoute } from '@/keeperhub'
 import type { ToolAnnotations } from '@/mcp-host'
 import type { ToolSource } from '@/runtime/types'
 
@@ -15,10 +16,16 @@ import type { ToolSource } from '@/runtime/types'
  * Tool names are pre-namespaced by the source itself (e.g. `lifi_get_quote`)
  * so callers don't need a separate prefix configuration. Keep names matching
  * `[a-zA-Z0-9_]{1,64}` per the host convention.
+ *
+ * Mutate tools may register a `MutateRoute` so the KeeperHub middleware can
+ * route their execution through `executeContractCall` instead of the original
+ * `execute`. Routes are optional — sources without them keep the audit-only
+ * fallback.
  */
 export class NativeToolSource implements ToolSource {
   private readonly tools: Record<string, Tool>
   private readonly annotationsByName: Record<string, ToolAnnotations>
+  private readonly routesByName: Record<string, MutateRoute>
   readonly name: string
 
   constructor(opts: {
@@ -28,10 +35,13 @@ export class NativeToolSource implements ToolSource {
     tools: Record<string, Tool>
     /** Per-tool annotations, keyed by namespaced name. */
     annotations: Record<string, ToolAnnotations>
+    /** Optional KeeperHub mutate routes, keyed by namespaced tool name. */
+    routes?: Record<string, MutateRoute>
   }) {
     this.name = opts.name
     this.tools = opts.tools
     this.annotationsByName = opts.annotations
+    this.routesByName = opts.routes ?? {}
   }
 
   async getTools(): Promise<Record<string, Tool>> {
@@ -46,5 +56,10 @@ export class NativeToolSource implements ToolSource {
   /** All namespaced names this source contributes. */
   toolNames(): string[] {
     return Object.keys(this.tools)
+  }
+
+  /** Returns the registered KeeperHub routes (empty when none configured). */
+  routes(): Record<string, MutateRoute> {
+    return { ...this.routesByName }
   }
 }

--- a/src/tools/uniswap/approve.ts
+++ b/src/tools/uniswap/approve.ts
@@ -1,0 +1,92 @@
+import { tool } from 'ai'
+import {
+  type Address,
+  encodeFunctionData,
+  type Hex,
+  type PublicClient,
+  parseUnits,
+  type WalletClient,
+} from 'viem'
+import { z } from 'zod'
+import type { MutateRoute } from '@/keeperhub'
+import { ERC20_ABI, SEPOLIA_UNISWAP } from './contracts'
+import { resolveToken } from './tokens'
+
+const ApproveSchema = z.object({
+  token: z.string().describe('Token symbol (USDC, WETH, DAI) or 0x address'),
+  amount: z.string().describe('Approval amount in token human units (e.g. "100" for 100 USDC)'),
+})
+
+export type ApproveResult = {
+  token: { symbol: string; address: Address }
+  spender: Address
+  amount: string
+  amountRaw: string
+  txHash?: Hex
+}
+
+/**
+ * Build the `uniswap_approve_router` tool. Approves SwapRouter02 to spend
+ * `amount` of `token` from the wallet. Two roles:
+ *
+ * 1. **Direct execute** (no KH route configured) — sends an `approve` tx
+ *    via the wallet client and returns the tx hash.
+ * 2. **KeeperHub-routed** (production) — middleware swaps in the
+ *    `MutateRoute` below and KH executes the approve, returning workflow
+ *    metadata. Audit row records the route.
+ */
+export function buildApproveTool(opts: {
+  walletClient: WalletClient
+  publicClient: PublicClient
+  walletAddress: Address
+}) {
+  return tool({
+    description:
+      'Approve the Uniswap V3 SwapRouter02 to spend a token from the wallet. Required before swap_exact_in. Mutates state; routed through KeeperHub workflow when configured.',
+    inputSchema: ApproveSchema,
+    execute: async (args): Promise<ApproveResult> => {
+      const token = resolveToken(args.token)
+      const amountRaw = parseUnits(args.amount, token.decimals)
+
+      const data = encodeFunctionData({
+        abi: ERC20_ABI,
+        functionName: 'approve',
+        args: [SEPOLIA_UNISWAP.swapRouter02 as Address, amountRaw],
+      })
+
+      // viem's WalletClient.sendTransaction is the lowest-friction send for an
+      // arbitrary calldata; writeContract would re-encode args we already have.
+      const txHash = await opts.walletClient.sendTransaction({
+        account: opts.walletAddress,
+        chain: opts.walletClient.chain ?? null,
+        to: token.address,
+        data,
+      })
+
+      return {
+        token: { symbol: token.symbol, address: token.address },
+        spender: SEPOLIA_UNISWAP.swapRouter02 as Address,
+        amount: args.amount,
+        amountRaw: amountRaw.toString(),
+        txHash,
+      }
+    },
+  })
+}
+
+/**
+ * KeeperHub mutate route for `uniswap_approve_router`. Maps tool args to a
+ * single `ERC20.approve(spender, amount)` contract call.
+ */
+export const buildApproveRoute = (): MutateRoute => (args) => {
+  const parsed = ApproveSchema.parse(args)
+  const token = resolveToken(parsed.token)
+  const amountRaw = parseUnits(parsed.amount, token.decimals)
+  return {
+    network: 'sepolia',
+    contract_address: token.address,
+    function_name: 'approve',
+    function_args: [SEPOLIA_UNISWAP.swapRouter02, amountRaw.toString()],
+    abi: ERC20_ABI,
+  }
+}

--- a/src/tools/uniswap/contracts.ts
+++ b/src/tools/uniswap/contracts.ts
@@ -1,0 +1,54 @@
+import { type Abi, parseAbi } from 'viem'
+
+/**
+ * Uniswap V3 Sepolia deployment.
+ *
+ * SwapRouter02 (the simplified router that omits multicall + self-permit) is
+ * the target for `exactInputSingle`. QuoterV2 is called statically for read
+ * quotes — `quoteExactInputSingle` returns `(amountOut, sqrtPriceX96After,
+ * initializedTicksCrossed, gasEstimate)`.
+ *
+ * Source: https://developers.uniswap.org/contracts/v3/reference/deployments/ethereum-deployments
+ */
+export const SEPOLIA_UNISWAP = {
+  swapRouter02: '0x3bFA4769FB09eefC5a80d6E87c3B9C650f7Ae48E',
+  quoterV2: '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3',
+  factory: '0x0227628f3F023bb0B980b67D528571c95c6DaC1c',
+  weth: '0xfff9976782d46cc05630d1f6ebab18b2324d6b14',
+} as const
+
+/** Valid V3 fee tiers in basis points * 100 (i.e. 100 = 0.01%, 3000 = 0.3%). */
+export const V3_FEE_TIERS = [100, 500, 3000, 10000] as const
+export type V3FeeTier = (typeof V3_FEE_TIERS)[number]
+
+/** Default fee tier — 0.3% pool has the deepest USDC/WETH liquidity on Sepolia. */
+export const DEFAULT_FEE_TIER: V3FeeTier = 3000
+
+/** Default slippage tolerance — 100 bps (1%). */
+export const DEFAULT_SLIPPAGE_BPS = 100
+
+/** ABI fragment for SwapRouter02.exactInputSingle (struct flattened to tuple). */
+export const SWAP_ROUTER_ABI: Abi = parseAbi([
+  'function exactInputSingle((address tokenIn, address tokenOut, uint24 fee, address recipient, uint256 amountIn, uint256 amountOutMinimum, uint160 sqrtPriceLimitX96)) external payable returns (uint256 amountOut)',
+])
+
+/** ABI fragment for QuoterV2.quoteExactInputSingle. */
+export const QUOTER_V2_ABI: Abi = parseAbi([
+  'function quoteExactInputSingle((address tokenIn, address tokenOut, uint256 amountIn, uint24 fee, uint160 sqrtPriceLimitX96)) external returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)',
+])
+
+/** Minimal ERC20 ABI for approve + allowance + balanceOf + symbol/decimals. */
+export const ERC20_ABI: Abi = parseAbi([
+  'function approve(address spender, uint256 amount) external returns (bool)',
+  'function allowance(address owner, address spender) external view returns (uint256)',
+  'function balanceOf(address account) external view returns (uint256)',
+  'function decimals() external view returns (uint8)',
+  'function symbol() external view returns (string)',
+])
+
+/** Minimal V3 Pool ABI for liquidity reads via the Factory. */
+export const FACTORY_ABI: Abi = parseAbi([
+  'function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool)',
+])
+
+export const POOL_ABI: Abi = parseAbi(['function liquidity() external view returns (uint128)'])

--- a/src/tools/uniswap/index.ts
+++ b/src/tools/uniswap/index.ts
@@ -1,0 +1,15 @@
+export { buildApproveRoute, buildApproveTool } from './approve'
+export {
+  DEFAULT_FEE_TIER,
+  DEFAULT_SLIPPAGE_BPS,
+  ERC20_ABI,
+  QUOTER_V2_ABI,
+  SEPOLIA_UNISWAP,
+  SWAP_ROUTER_ABI,
+  V3_FEE_TIERS,
+  type V3FeeTier,
+} from './contracts'
+export { buildQuoteTool, type QuoteResult } from './quote'
+export { createUniswapToolSource } from './source'
+export { buildSwapRoute, buildSwapTool, type SwapResult } from './swap'
+export { resolveToken, SEPOLIA_TOKENS, type SepoliaToken } from './tokens'

--- a/src/tools/uniswap/quote.ts
+++ b/src/tools/uniswap/quote.ts
@@ -1,0 +1,121 @@
+import { tool } from 'ai'
+import { type Address, type PublicClient, parseUnits } from 'viem'
+import { z } from 'zod'
+import {
+  DEFAULT_FEE_TIER,
+  FACTORY_ABI,
+  POOL_ABI,
+  QUOTER_V2_ABI,
+  SEPOLIA_UNISWAP,
+  V3_FEE_TIERS,
+} from './contracts'
+import { resolveToken } from './tokens'
+
+const QuoteSchema = z.object({
+  tokenIn: z.string().describe('Token symbol (USDC, WETH, DAI, ETH) or 0x address'),
+  tokenOut: z.string().describe('Token symbol or 0x address'),
+  amountIn: z
+    .string()
+    .describe(
+      'Amount in tokenIn human units (e.g. "100" for 100 USDC, decimals applied internally)',
+    ),
+  fee: z
+    .number()
+    .optional()
+    .describe(
+      'V3 fee tier in 1e6 units (100, 500, 3000, 10000); default 3000 (deepest USDC/WETH pool on Sepolia)',
+    ),
+})
+
+export type QuoteResult = {
+  tokenIn: { symbol: string; address: Address }
+  tokenOut: { symbol: string; address: Address }
+  amountIn: string
+  amountInRaw: string
+  amountOut: string
+  amountOutRaw: string
+  fee: number
+  poolAddress: Address
+  poolLiquidity: string
+}
+
+/**
+ * Build the `uniswap_get_quote` tool. The leading `_get_` opts the tool out of
+ * KeeperHub audit by matching the `KNOWN_READONLY` regex — quotes are pure
+ * static reads against QuoterV2 + the Factory.
+ */
+export function buildQuoteTool(publicClient: PublicClient) {
+  return tool({
+    description:
+      'Get an exact-input quote on Uniswap V3 (Sepolia). Returns expected output amount, the pool address, and pool liquidity. Read-only static call; no state changes.',
+    inputSchema: QuoteSchema,
+    execute: async (args): Promise<QuoteResult> => {
+      const tokenIn = resolveToken(args.tokenIn)
+      const tokenOut = resolveToken(args.tokenOut)
+      const fee = (args.fee ?? DEFAULT_FEE_TIER) as number
+
+      if (!V3_FEE_TIERS.includes(fee as (typeof V3_FEE_TIERS)[number])) {
+        throw new Error(`invalid fee tier ${fee}; must be one of ${V3_FEE_TIERS.join(', ')}`)
+      }
+
+      const amountInRaw = parseUnits(args.amountIn, tokenIn.decimals)
+
+      const { result: quoterResult } = await publicClient.simulateContract({
+        address: SEPOLIA_UNISWAP.quoterV2 as Address,
+        abi: QUOTER_V2_ABI,
+        functionName: 'quoteExactInputSingle',
+        args: [
+          {
+            tokenIn: tokenIn.address,
+            tokenOut: tokenOut.address,
+            amountIn: amountInRaw,
+            fee,
+            sqrtPriceLimitX96: 0n,
+          },
+        ],
+      })
+
+      const [amountOutRaw] = quoterResult as readonly [bigint, bigint, number, bigint]
+
+      const poolAddress = (await publicClient.readContract({
+        address: SEPOLIA_UNISWAP.factory as Address,
+        abi: FACTORY_ABI,
+        functionName: 'getPool',
+        args: [tokenIn.address, tokenOut.address, fee],
+      })) as Address
+
+      let poolLiquidity = '0'
+      if (poolAddress && poolAddress !== '0x0000000000000000000000000000000000000000') {
+        const liquidity = (await publicClient.readContract({
+          address: poolAddress,
+          abi: POOL_ABI,
+          functionName: 'liquidity',
+        })) as bigint
+        poolLiquidity = liquidity.toString()
+      }
+
+      return {
+        tokenIn: { symbol: tokenIn.symbol, address: tokenIn.address },
+        tokenOut: { symbol: tokenOut.symbol, address: tokenOut.address },
+        amountIn: args.amountIn,
+        amountInRaw: amountInRaw.toString(),
+        amountOut: formatUnits(amountOutRaw, tokenOut.decimals),
+        amountOutRaw: amountOutRaw.toString(),
+        fee,
+        poolAddress,
+        poolLiquidity,
+      }
+    },
+  })
+}
+
+/** Inlined to avoid pulling viem/utils helpers across module boundaries. */
+function formatUnits(value: bigint, decimals: number): string {
+  const negative = value < 0n
+  const v = negative ? -value : value
+  const str = v.toString().padStart(decimals + 1, '0')
+  const head = str.slice(0, str.length - decimals)
+  const tail = str.slice(str.length - decimals).replace(/0+$/, '')
+  const out = tail.length > 0 ? `${head}.${tail}` : head
+  return negative ? `-${out}` : out
+}

--- a/src/tools/uniswap/source.ts
+++ b/src/tools/uniswap/source.ts
@@ -1,0 +1,65 @@
+import type { Address, PublicClient, WalletClient } from 'viem'
+import type { MutateRoute } from '@/keeperhub'
+import { NativeToolSource } from '@/tools/native'
+import { buildApproveRoute, buildApproveTool } from './approve'
+import { buildQuoteTool } from './quote'
+import { buildSwapRoute, buildSwapTool } from './swap'
+
+/**
+ * Build the Uniswap V3 NativeToolSource. Three tools:
+ *
+ * - `uniswap_get_quote` (read; KNOWN_READONLY via `_get_`) — QuoterV2 simulation
+ *   plus pool address + liquidity from the Factory.
+ * - `uniswap_approve_router` (mutate, routed) — `ERC20.approve(SwapRouter02, amount)`.
+ * - `uniswap_swap_exact_in` (mutate, routed) — `SwapRouter02.exactInputSingle(...)`,
+ *   slippage applied from a fresh quote.
+ *
+ * Demo flow is two mutate calls (approve then swap); both are KeeperHub-routed
+ * when KH is configured. Without KH, both fall back to direct viem sends.
+ */
+export function createUniswapToolSource(opts: {
+  walletClient: WalletClient
+  publicClient: PublicClient
+  walletAddress: Address
+}): NativeToolSource {
+  const quote = buildQuoteTool(opts.publicClient)
+  const approve = buildApproveTool({
+    walletClient: opts.walletClient,
+    publicClient: opts.publicClient,
+    walletAddress: opts.walletAddress,
+  })
+  const swap = buildSwapTool({
+    walletClient: opts.walletClient,
+    publicClient: opts.publicClient,
+    walletAddress: opts.walletAddress,
+  })
+
+  const tools = {
+    uniswap_get_quote: quote,
+    uniswap_approve_router: approve,
+    uniswap_swap_exact_in: swap,
+  }
+
+  // Annotations: get_quote is read-only (also caught by KNOWN_READONLY regex —
+  // belt-and-braces), approve + swap mutate.
+  const annotations = {
+    uniswap_get_quote: { readOnly: true, mutates: false },
+    uniswap_approve_router: { mutates: true, readOnly: false },
+    uniswap_swap_exact_in: { mutates: true, readOnly: false },
+  }
+
+  const routes: Record<string, MutateRoute> = {
+    uniswap_approve_router: buildApproveRoute(),
+    uniswap_swap_exact_in: buildSwapRoute({
+      walletAddress: opts.walletAddress,
+      publicClient: opts.publicClient,
+    }),
+  }
+
+  return new NativeToolSource({
+    name: 'uniswap',
+    tools,
+    annotations,
+    routes,
+  })
+}

--- a/src/tools/uniswap/swap.ts
+++ b/src/tools/uniswap/swap.ts
@@ -1,0 +1,187 @@
+import { tool } from 'ai'
+import { type Address, type Hex, type PublicClient, parseUnits, type WalletClient } from 'viem'
+import { z } from 'zod'
+import type { MutateRoute } from '@/keeperhub'
+import {
+  DEFAULT_FEE_TIER,
+  DEFAULT_SLIPPAGE_BPS,
+  ERC20_ABI,
+  QUOTER_V2_ABI,
+  SEPOLIA_UNISWAP,
+  SWAP_ROUTER_ABI,
+  V3_FEE_TIERS,
+} from './contracts'
+import { resolveToken, type SepoliaToken } from './tokens'
+
+const SwapSchema = z.object({
+  tokenIn: z.string().describe('Token symbol (USDC, WETH, DAI) or 0x address'),
+  tokenOut: z.string().describe('Token symbol or 0x address'),
+  amountIn: z.string().describe('Input amount in tokenIn human units (e.g. "100" for 100 USDC)'),
+  fee: z.number().optional().describe('V3 fee tier (100, 500, 3000, 10000); default 3000'),
+  slippageBps: z
+    .number()
+    .optional()
+    .describe('Slippage tolerance in basis points; default 100 (1%)'),
+})
+
+type SwapInput = z.infer<typeof SwapSchema>
+
+export type SwapResult = {
+  tokenIn: { symbol: string; address: Address }
+  tokenOut: { symbol: string; address: Address }
+  amountIn: string
+  amountInRaw: string
+  amountOutMin: string
+  amountOutMinRaw: string
+  fee: number
+  txHash?: Hex
+}
+
+/**
+ * Build the `uniswap_swap_exact_in` tool. Calls SwapRouter02.exactInputSingle
+ * after computing `amountOutMinimum` from a fresh QuoterV2 call.
+ *
+ * In KeeperHub-routed mode this tool's execute is replaced by the route below;
+ * the wallet must have already called `uniswap_approve_router`. The direct
+ * execute path also assumes allowance is in place — it fails loudly when the
+ * router has no approval, mirroring the routed contract.
+ */
+export function buildSwapTool(opts: {
+  walletClient: WalletClient
+  publicClient: PublicClient
+  walletAddress: Address
+}) {
+  return tool({
+    description:
+      'Swap an exact input amount of one token for another on Uniswap V3 (Sepolia). Internally fetches a quote and applies slippage tolerance to compute amountOutMinimum. Requires the SwapRouter02 to be pre-approved for tokenIn (call uniswap_approve_router first).',
+    inputSchema: SwapSchema,
+    execute: async (args): Promise<SwapResult> => {
+      const prep = await prepareSwap(args, opts.publicClient)
+
+      // Fail-loud allowance precondition: confirm the router can pull tokenIn
+      // from the wallet before we burn gas on a swap that will revert.
+      const allowance = (await opts.publicClient.readContract({
+        address: prep.tokenIn.address,
+        abi: ERC20_ABI,
+        functionName: 'allowance',
+        args: [opts.walletAddress, SEPOLIA_UNISWAP.swapRouter02 as Address],
+      })) as bigint
+      if (allowance < prep.amountInRaw) {
+        throw new Error(
+          `insufficient allowance: SwapRouter02 has ${allowance.toString()} but needs ${prep.amountInRaw.toString()}; call uniswap_approve_router first`,
+        )
+      }
+
+      const txHash = await opts.walletClient.writeContract({
+        account: opts.walletAddress,
+        chain: opts.walletClient.chain ?? null,
+        address: SEPOLIA_UNISWAP.swapRouter02 as Address,
+        abi: SWAP_ROUTER_ABI,
+        functionName: 'exactInputSingle',
+        args: [
+          {
+            tokenIn: prep.tokenIn.address,
+            tokenOut: prep.tokenOut.address,
+            fee: prep.fee,
+            recipient: opts.walletAddress,
+            amountIn: prep.amountInRaw,
+            amountOutMinimum: prep.amountOutMinRaw,
+            sqrtPriceLimitX96: 0n,
+          },
+        ],
+      })
+
+      return {
+        tokenIn: { symbol: prep.tokenIn.symbol, address: prep.tokenIn.address },
+        tokenOut: { symbol: prep.tokenOut.symbol, address: prep.tokenOut.address },
+        amountIn: args.amountIn,
+        amountInRaw: prep.amountInRaw.toString(),
+        amountOutMin: formatUnits(prep.amountOutMinRaw, prep.tokenOut.decimals),
+        amountOutMinRaw: prep.amountOutMinRaw.toString(),
+        fee: prep.fee,
+        txHash,
+      }
+    },
+  })
+}
+
+/**
+ * KeeperHub mutate route for `uniswap_swap_exact_in`. Async so it can re-run
+ * the QuoterV2 call at route-build time — fresh quote → fresh
+ * `amountOutMinimum` → KH workflow gets the same slippage protection the
+ * direct path enforces.
+ */
+export const buildSwapRoute =
+  (opts: { walletAddress: Address; publicClient: PublicClient }): MutateRoute =>
+  async (args) => {
+    const parsed = SwapSchema.parse(args)
+    const prep = await prepareSwap(parsed, opts.publicClient)
+    return {
+      network: 'sepolia',
+      contract_address: SEPOLIA_UNISWAP.swapRouter02,
+      function_name: 'exactInputSingle',
+      function_args: [
+        {
+          tokenIn: prep.tokenIn.address,
+          tokenOut: prep.tokenOut.address,
+          fee: prep.fee,
+          recipient: opts.walletAddress,
+          amountIn: prep.amountInRaw.toString(),
+          amountOutMinimum: prep.amountOutMinRaw.toString(),
+          sqrtPriceLimitX96: '0',
+        },
+      ],
+      abi: SWAP_ROUTER_ABI,
+    }
+  }
+
+async function prepareSwap(
+  args: SwapInput,
+  publicClient: PublicClient,
+): Promise<{
+  tokenIn: SepoliaToken
+  tokenOut: SepoliaToken
+  amountInRaw: bigint
+  fee: number
+  amountOutMinRaw: bigint
+}> {
+  const tokenIn = resolveToken(args.tokenIn)
+  const tokenOut = resolveToken(args.tokenOut)
+  const fee = (args.fee ?? DEFAULT_FEE_TIER) as number
+  const slippageBps = args.slippageBps ?? DEFAULT_SLIPPAGE_BPS
+
+  if (!V3_FEE_TIERS.includes(fee as (typeof V3_FEE_TIERS)[number])) {
+    throw new Error(`invalid fee tier ${fee}; must be one of ${V3_FEE_TIERS.join(', ')}`)
+  }
+
+  const amountInRaw = parseUnits(args.amountIn, tokenIn.decimals)
+
+  const { result } = await publicClient.simulateContract({
+    address: SEPOLIA_UNISWAP.quoterV2 as Address,
+    abi: QUOTER_V2_ABI,
+    functionName: 'quoteExactInputSingle',
+    args: [
+      {
+        tokenIn: tokenIn.address,
+        tokenOut: tokenOut.address,
+        amountIn: amountInRaw,
+        fee,
+        sqrtPriceLimitX96: 0n,
+      },
+    ],
+  })
+  const [amountOutRaw] = result as readonly [bigint, bigint, number, bigint]
+  const amountOutMinRaw = (amountOutRaw * BigInt(10000 - slippageBps)) / 10000n
+
+  return { tokenIn, tokenOut, amountInRaw, fee, amountOutMinRaw }
+}
+
+function formatUnits(value: bigint, decimals: number): string {
+  const negative = value < 0n
+  const v = negative ? -value : value
+  const str = v.toString().padStart(decimals + 1, '0')
+  const head = str.slice(0, str.length - decimals)
+  const tail = str.slice(str.length - decimals).replace(/0+$/, '')
+  const out = tail.length > 0 ? `${head}.${tail}` : head
+  return negative ? `-${out}` : out
+}

--- a/src/tools/uniswap/tokens.ts
+++ b/src/tools/uniswap/tokens.ts
@@ -1,0 +1,67 @@
+import { isAddress } from 'viem'
+import { SEPOLIA_UNISWAP } from './contracts'
+
+/**
+ * Symbol -> Sepolia token table. Keep small — the tools accept either a
+ * symbol from this table OR a hex address override, so adding a token only
+ * matters when the agent should be able to refer to it by name.
+ *
+ * Sources:
+ * - USDC (Circle Sepolia): https://faucet.circle.com/
+ * - DAI (community Sepolia mock used by Uniswap pools)
+ * - WETH (canonical Sepolia WETH9, also re-exported from contracts.ts)
+ */
+export type SepoliaToken = {
+  symbol: string
+  address: `0x${string}`
+  decimals: number
+}
+
+export const SEPOLIA_TOKENS: Record<string, SepoliaToken> = {
+  USDC: {
+    symbol: 'USDC',
+    address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+    decimals: 6,
+  },
+  WETH: {
+    symbol: 'WETH',
+    address: SEPOLIA_UNISWAP.weth,
+    decimals: 18,
+  },
+  ETH: {
+    // Aliased to WETH — the agent says "ETH" and the swap is wrapped/unwrapped
+    // implicitly via WETH. v1 keeps this explicit (no auto-wrap helper yet).
+    symbol: 'ETH',
+    address: SEPOLIA_UNISWAP.weth,
+    decimals: 18,
+  },
+  DAI: {
+    symbol: 'DAI',
+    address: '0xB4F1737Af37711e9A5890D9510c9bB60e170CB0D',
+    decimals: 18,
+  },
+}
+
+/**
+ * Resolve a token reference (symbol like "USDC" or hex address) to a
+ * SepoliaToken record. Symbols are case-insensitive; addresses are checksummed
+ * by viem `isAddress` and normalized to lowercase.
+ *
+ * Throws when the symbol is unknown and the input isn't a valid address.
+ */
+export function resolveToken(input: string): SepoliaToken {
+  const upper = input.toUpperCase()
+  if (SEPOLIA_TOKENS[upper]) return SEPOLIA_TOKENS[upper]
+  // strict: false — accept any 0x-prefixed 40-hex address shape; we don't
+  // require EIP-55 checksum from the agent, which often gets case wrong.
+  if (isAddress(input, { strict: false })) {
+    return {
+      symbol: input,
+      address: input.toLowerCase() as `0x${string}`,
+      decimals: 18, // Best-effort default; on-chain `decimals()` is authoritative.
+    }
+  }
+  throw new Error(
+    `unknown token "${input}" (known: ${Object.keys(SEPOLIA_TOKENS).join(', ')}, or pass a 0x address)`,
+  )
+}

--- a/tests/integration/uniswap-tools.test.ts
+++ b/tests/integration/uniswap-tools.test.ts
@@ -1,0 +1,314 @@
+import {
+  type Address,
+  createPublicClient,
+  createWalletClient,
+  type Hex,
+  http,
+  type PublicClient,
+  parseUnits,
+  type WalletClient,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { sepolia } from 'viem/chains'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  type ContractCallInput,
+  createKeeperHubMiddleware,
+  type ExecutionResult,
+  type KeeperHubClient,
+} from '@/keeperhub'
+import { createDb, type DbHandle, openRun, runMigrations, upsertThread } from '@/persistence'
+import {
+  buildApproveRoute,
+  buildQuoteTool,
+  buildSwapRoute,
+  createUniswapToolSource,
+  resolveToken,
+  SEPOLIA_TOKENS,
+  SEPOLIA_UNISWAP,
+} from '@/tools/uniswap'
+
+// ---------------------------------------------------------------------------
+// resolveToken
+// ---------------------------------------------------------------------------
+
+describe('resolveToken', () => {
+  it('resolves canonical symbols (case-insensitive)', () => {
+    expect(resolveToken('USDC').address).toBe(SEPOLIA_TOKENS.USDC?.address)
+    expect(resolveToken('usdc').address).toBe(SEPOLIA_TOKENS.USDC?.address)
+    expect(resolveToken('WETH').decimals).toBe(18)
+    expect(resolveToken('ETH').address).toBe(SEPOLIA_TOKENS.WETH?.address)
+  })
+
+  it('passes through hex addresses', () => {
+    const t = resolveToken('0x1234567890abCDEF1234567890ABCDEF12345678')
+    expect(t.address).toBe('0x1234567890abcdef1234567890abcdef12345678')
+    expect(t.decimals).toBe(18)
+  })
+
+  it('throws on unknown reference', () => {
+    expect(() => resolveToken('NOTATOKEN')).toThrow(/unknown token/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Quote tool
+// ---------------------------------------------------------------------------
+
+describe('uniswap_get_quote', () => {
+  it('reads QuoterV2 + factory and returns the expected shape', async () => {
+    const simulateContract = vi.fn().mockResolvedValue({
+      result: [parseUnits('0.04', 18), 0n, 0, 0n] as const,
+    })
+    const readContract = vi
+      .fn()
+      .mockResolvedValueOnce('0x6418eec70f50913ff0d756b48d32ce7c02b47c47') // pool
+      .mockResolvedValueOnce(123_456_789n) // liquidity
+
+    const publicClient = {
+      simulateContract,
+      readContract,
+    } as unknown as PublicClient
+
+    const tool = buildQuoteTool(publicClient)
+    const out = (await tool.execute!(
+      { tokenIn: 'USDC', tokenOut: 'WETH', amountIn: '100' },
+      { toolCallId: 'qc-1', messages: [] },
+    )) as { amountOut: string; fee: number; poolLiquidity: string; poolAddress: string }
+
+    expect(out.amountOut).toBe('0.04')
+    expect(out.fee).toBe(3000)
+    expect(out.poolAddress).toBe('0x6418eec70f50913ff0d756b48d32ce7c02b47c47')
+    expect(out.poolLiquidity).toBe('123456789')
+    expect(simulateContract).toHaveBeenCalledOnce()
+    const simArgs = simulateContract.mock.calls[0]?.[0] as {
+      address: string
+      args: [{ tokenIn: string; tokenOut: string; amountIn: bigint; fee: number }]
+    }
+    expect(simArgs.address).toBe(SEPOLIA_UNISWAP.quoterV2)
+    expect(simArgs.args[0].tokenIn).toBe(SEPOLIA_TOKENS.USDC?.address)
+    expect(simArgs.args[0].amountIn).toBe(parseUnits('100', 6))
+  })
+
+  it('rejects unknown fee tier', async () => {
+    const publicClient = {
+      simulateContract: vi.fn(),
+      readContract: vi.fn(),
+    } as unknown as PublicClient
+
+    const tool = buildQuoteTool(publicClient)
+    await expect(
+      tool.execute!(
+        { tokenIn: 'USDC', tokenOut: 'WETH', amountIn: '100', fee: 1234 },
+        { toolCallId: 'qc-2', messages: [] },
+      ),
+    ).rejects.toThrow(/invalid fee tier/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Approve route shape
+// ---------------------------------------------------------------------------
+
+describe('uniswap_approve_router route', () => {
+  it('encodes ContractCallInput pointing at the token contract', async () => {
+    const route = buildApproveRoute()
+    const input = (await route({ token: 'USDC', amount: '100' })) as ContractCallInput
+    expect(input.network).toBe('sepolia')
+    expect(input.contract_address).toBe(SEPOLIA_TOKENS.USDC?.address)
+    expect(input.function_name).toBe('approve')
+    expect(input.function_args?.[0]).toBe(SEPOLIA_UNISWAP.swapRouter02)
+    expect(input.function_args?.[1]).toBe(parseUnits('100', 6).toString())
+  })
+
+  it('rejects malformed input', () => {
+    const route = buildApproveRoute()
+    expect(() => route({ token: 'USDC', amount: 100 })).toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Swap route shape
+// ---------------------------------------------------------------------------
+
+describe('uniswap_swap_exact_in route', () => {
+  const walletAddress = '0xAbCdEf0123456789aBcDeF0123456789ABCdEf01' as Address
+
+  it('builds ContractCallInput with slippage-applied amountOutMinimum', async () => {
+    const expectedOut = parseUnits('0.04', 18)
+    const simulateContract = vi.fn().mockResolvedValue({
+      result: [expectedOut, 0n, 0, 0n] as const,
+    })
+    const publicClient = {
+      simulateContract,
+    } as unknown as PublicClient
+
+    const route = buildSwapRoute({ walletAddress, publicClient })
+    const input = (await route({
+      tokenIn: 'USDC',
+      tokenOut: 'WETH',
+      amountIn: '100',
+      slippageBps: 100,
+    })) as ContractCallInput
+
+    expect(input.network).toBe('sepolia')
+    expect(input.contract_address).toBe(SEPOLIA_UNISWAP.swapRouter02)
+    expect(input.function_name).toBe('exactInputSingle')
+
+    const params = input.function_args?.[0] as {
+      tokenIn: string
+      tokenOut: string
+      fee: number
+      recipient: string
+      amountIn: string
+      amountOutMinimum: string
+    }
+    expect(params.tokenIn).toBe(SEPOLIA_TOKENS.USDC?.address)
+    expect(params.tokenOut).toBe(SEPOLIA_TOKENS.WETH?.address)
+    expect(params.fee).toBe(3000)
+    expect(params.recipient).toBe(walletAddress)
+    expect(params.amountIn).toBe(parseUnits('100', 6).toString())
+
+    // 1% slippage applied: 0.04 * 0.99
+    const expectedMin = (expectedOut * 9900n) / 10000n
+    expect(params.amountOutMinimum).toBe(expectedMin.toString())
+  })
+
+  it('uses 100 bps slippage by default', async () => {
+    const expectedOut = parseUnits('1', 18)
+    const publicClient = {
+      simulateContract: vi.fn().mockResolvedValue({
+        result: [expectedOut, 0n, 0, 0n] as const,
+      }),
+    } as unknown as PublicClient
+
+    const route = buildSwapRoute({ walletAddress, publicClient })
+    const input = (await route({
+      tokenIn: 'USDC',
+      tokenOut: 'WETH',
+      amountIn: '1',
+    })) as ContractCallInput
+    const params = input.function_args?.[0] as { amountOutMinimum: string }
+    expect(params.amountOutMinimum).toBe(((expectedOut * 9900n) / 10000n).toString())
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Source integration
+// ---------------------------------------------------------------------------
+
+describe('createUniswapToolSource', () => {
+  const walletAddress = '0xAbCdEf0123456789aBcDeF0123456789ABCdEf01' as Address
+  const dummyKey = `0x${'11'.repeat(32)}` as Hex
+  const account = privateKeyToAccount(dummyKey)
+  const walletClient: WalletClient = createWalletClient({
+    account,
+    chain: sepolia,
+    transport: http('http://localhost:1'),
+  })
+  const publicClient = createPublicClient({
+    chain: sepolia,
+    transport: http('http://localhost:1'),
+  })
+
+  it('exposes 3 tools with the expected names + annotations + routes', () => {
+    const source = createUniswapToolSource({ walletClient, publicClient, walletAddress })
+
+    expect(source.toolNames().sort()).toEqual([
+      'uniswap_approve_router',
+      'uniswap_get_quote',
+      'uniswap_swap_exact_in',
+    ])
+    expect(source.annotations('uniswap_get_quote')).toMatchObject({ readOnly: true })
+    expect(source.annotations('uniswap_approve_router')).toMatchObject({ mutates: true })
+    expect(source.annotations('uniswap_swap_exact_in')).toMatchObject({ mutates: true })
+
+    const routes = source.routes()
+    expect(Object.keys(routes).sort()).toEqual(['uniswap_approve_router', 'uniswap_swap_exact_in'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-to-end through the KeeperHub middleware
+// ---------------------------------------------------------------------------
+
+describe('uniswap mutate routing through middleware', () => {
+  let handle: DbHandle
+  let runId: string
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+    await upsertThread(handle.db, { id: 't-uni', channel: 'cli', agentId: 'talos-eth' })
+    const run = await openRun(handle.db, { threadId: 't-uni', prompt: 'swap' })
+    runId = run.id
+  })
+
+  afterEach(async () => {
+    await handle.close()
+  })
+
+  function fakeKhClient(impl: {
+    executeContractCall: (input: ContractCallInput) => Promise<ExecutionResult>
+  }): KeeperHubClient {
+    return {
+      ensureToken: async () => 'token',
+      listTools: async () => ({}),
+      callTool: async () => undefined,
+      executeContractCall: impl.executeContractCall,
+      executeTransfer: async () => ({ executionId: 'noop', status: 'success' }),
+      getExecutionStatus: async () => ({ executionId: 'noop', status: 'success' }),
+      close: async () => {},
+    }
+  }
+
+  it('routes uniswap_approve_router through KH client with the token contract address', async () => {
+    const calls: ContractCallInput[] = []
+    const client = fakeKhClient({
+      executeContractCall: async (input) => {
+        calls.push(input)
+        return { executionId: 'exec-approve', status: 'success', txHash: '0xaabb' }
+      },
+    })
+
+    const walletAddress = '0xAbCdEf0123456789aBcDeF0123456789ABCdEf01' as Address
+    const dummyKey = `0x${'22'.repeat(32)}` as Hex
+    const account = privateKeyToAccount(dummyKey)
+    const walletClient = createWalletClient({
+      account,
+      chain: sepolia,
+      transport: http('http://localhost:1'),
+    })
+    const publicClient = createPublicClient({
+      chain: sepolia,
+      transport: http('http://localhost:1'),
+    })
+
+    const source = createUniswapToolSource({ walletClient, publicClient, walletAddress })
+    const tools = await source.getTools()
+    const middleware = createKeeperHubMiddleware({
+      db: handle.db,
+      runContext: () => ({ runId }),
+      annotations: (name) => source.annotations(name),
+      kh: { client, routes: new Map(Object.entries(source.routes())) },
+    })
+    const wrapped = middleware(tools)
+
+    const result = await wrapped.uniswap_approve_router?.execute?.(
+      { token: 'USDC', amount: '100' },
+      { toolCallId: 'tc-approve', messages: [] },
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.contract_address).toBe(SEPOLIA_TOKENS.USDC?.address)
+    expect(calls[0]?.function_name).toBe('approve')
+    expect(result).toMatchObject({ executionId: 'exec-approve', txHash: '0xaabb' })
+
+    const rows = await handle.pg.query<{
+      audit: { reason: string; executionId?: string; txHash?: string }
+    }>(`SELECT audit FROM tool_calls WHERE tool_call_id = $1`, ['tc-approve'])
+    expect(rows.rows[0]?.audit.reason).toBe('annotation_mutates')
+    expect(rows.rows[0]?.audit.executionId).toBe('exec-approve')
+    expect(rows.rows[0]?.audit.txHash).toBe('0xaabb')
+  })
+})


### PR DESCRIPTION
## Summary

Lands PR-6 of #10 — Uniswap V3 on Sepolia exposed as three native tools, plus the `NativeToolSource.routes()` plumbing that lets every protocol source declare its own KeeperHub mutate routes. Daemon now assembles the route Map at boot and wires it into the middleware factory.

Three commits, kept small + cohesive.

## Why V3, not V2 or V4

Researched current state (Apr 2026):

| Version | Sepolia liquidity | KH fit | SDK |
|---|---|---|---|
| V2 | ~$2.9M TVL on USDC/WETH | Good (single Router call) | Stable, dated |
| **V3** | **$935K – $12.8M TVL across fee tiers** | **Excellent — flat struct, one call** | **`@uniswap/v3-sdk@3.30.0` mature** |
| V4 | Contracts deployed, **zero indexed liquidity** | Poor — Universal Router commands are opaque ABI byte blobs | `@uniswap/v4-sdk@2.0.0` recent breaking bump |

V3 ships by May 6, V4 doesn't (no liquidity = demo reverts). V4 would matter if Talos's thesis were *demonstrating hooks* — it isn't; the thesis is agent-driven DeFi via KeeperHub.

## Three commits

### 1. `feat(tools): native source supports MutateRoute registration` (91c4f93)

`NativeToolSource` gains an optional `routes` constructor field plus a `routes()` getter so every protocol source can declare per-tool KeeperHub mutate routes alongside its tools and annotations.

`MutateRoute` is widened to allow async — `(args) => ContractCallInput | Promise<ContractCallInput>` — so routes that need fresh chain state (quotes for slippage, allowance reads) can fetch it before encoding the contract call. The middleware awaits via `Promise.resolve` so existing sync routes keep working untouched.

### 2. `feat(tools): uniswap V3 quote + approve + swap on sepolia` (3365dd4)

Three native tools backed by SwapRouter02 + QuoterV2 + Factory on Sepolia:

- **`uniswap_get_quote`** — read-only, KNOWN_READONLY-bypassed via `_get_`. Returns `{ amountOut, fee, poolAddress, poolLiquidity }` from QuoterV2 + Factory reads.
- **`uniswap_approve_router`** — mutate, audited, routed. `ERC20.approve(SwapRouter02, amount)` on tokenIn.
- **`uniswap_swap_exact_in`** — mutate, audited, routed. `SwapRouter02.exactInputSingle(...)` with `amountOutMinimum` derived from a fresh QuoterV2 call. Default 100 bps slippage.

Both swap paths fail loud on missing allowance instead of silently reverting on chain.

Symbol resolver handles **USDC, WETH (alias ETH), DAI** on Sepolia plus hex addresses (no checksum required — `isAddress(input, { strict: false })`). Default fee tier `3000` (deepest USDC/WETH pool, ~$12.8M TVL).

### 3. `feat(daemon): assemble keeperhub routes from native sources` (8d1de93)

Boot constructs a Sepolia public client + binds the wallet, registers the Uniswap source alongside Li.Fi + AgentKit, and unions all native sources' `routes()` into a single Map passed to the middleware factory.

KeeperHub client is built lazily — when `~/.config/talos/keeperhub.token` is missing the daemon logs an info line and skips the `kh` deps so mutate tools fall through to direct execute. With a session present (post `talos init`), all routed tools call KH workflow execution and audit rows record the `executionId` + `txHash`. Client closed on shutdown alongside MCP host + DB.

## What's NOT in this PR

- **PR-5 Aave** — separate; landing skipped per request, will follow with the same shape (mutate routes registered on the source).
- **Forked-Sepolia E2E tests** — `#12` demo-flow eval covers the live flow once it lands; this PR ships unit tests with mocked viem.
- **`talos init` OAuth wizard** — `#14`. Without it, KH session must be provisioned manually for the demo (see PR description on KH session).
- **Multi-hop routing / Permit2 / V3 LP positions / mainnet** — out of scope.

## Test plan

- [x] `pnpm vitest run tests/integration/uniswap-tools.test.ts` — 11 passing
- [x] `pnpm vitest run tests/integration/uniswap-tools.test.ts tests/integration/runtime.test.ts tests/integration/keeperhub.test.ts tests/integration/daemon.test.ts tests/integration/native-tool-source.test.ts` — 102 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors, 31 warnings (all pre-existing `noNonNullAssertion` style in test files)

### New test coverage
- Token resolver: canonical symbols (case-insensitive), hex address passthrough (no checksum), unknown rejection
- Quote tool: shape from mocked QuoterV2 + Factory + Pool reads, invalid fee tier rejection
- Approve route: `ContractCallInput` shape, malformed input rejection
- Swap route: `ContractCallInput` shape with slippage math, default slippage application
- Source assembly: 3 tools registered with right names + annotations + routes
- End-to-end: `uniswap_approve_router` through `createKeeperHubMiddleware` with a fake KH client — asserts route fired, audit row populated with `executionId` + `txHash`

References #10 (PR-6 of tool wiring).