### PR TITLE
feat(knowledge): nightly cron + retrieval pipeline (#11)

### DIFF
--- a/bin/talos.ts
+++ b/bin/talos.ts
@@ -2,7 +2,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { Command } from 'commander'
-import { runRepl, runStdioMcpProxy } from '@/channels'
+import { createDaemonClient, runRepl, runStdioMcpProxy } from '@/channels'
 import { paths } from '@/config/paths'
 import { ensureToken } from '@/config/token'
 import {
@@ -88,6 +88,40 @@ program
     }
     const token = await ensureToken()
     await runStdioMcpProxy({ daemonUrl: url, token })
+  })
+
+program
+  .command('knowledge:refresh')
+  .description('Force a knowledge cron tick now and print the per-source report')
+  .option('--port <number>', 'daemon port', (v) => Number.parseInt(v, 10))
+  .option('--no-autostart', 'do not auto-spawn talosd if not running')
+  .action(async (opts: { port?: number; autostart?: boolean }) => {
+    const port = opts.port ?? Number(process.env.TALOS_DAEMON_PORT ?? 7711)
+    const url = `ws://127.0.0.1:${port}`
+    if (opts.autostart !== false) {
+      await ensureDaemonRunning({ url })
+    }
+    const token = await ensureToken()
+    const client = createDaemonClient({ url, token, client: 'talos-cli' })
+    try {
+      await client.start()
+      const result = await client.knowledgeRefresh()
+      const lines: string[] = []
+      lines.push('Knowledge refresh complete.')
+      lines.push(`  started: ${result.startedAt}`)
+      lines.push(`  finished: ${result.finishedAt}`)
+      lines.push(`  total: ${result.totalDurationMs}ms`)
+      lines.push('  sources:')
+      for (const s of result.sources) {
+        const status = s.error ? `ERROR: ${s.error}` : `${s.fetched} items -> ${s.chunks} chunks`
+        lines.push(`    - ${s.source.padEnd(28)} ${status} (${s.durationMs}ms)`)
+      }
+      process.stdout.write(`${lines.join('\n')}\n`)
+      const anyError = result.sources.some((s) => s.error)
+      process.exit(anyError ? 1 : 0)
+    } finally {
+      await client.close()
+    }
   })
 
 program

--- a/src/channels/ws-client.ts
+++ b/src/channels/ws-client.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from 'node:crypto'
 import { WebSocket } from 'ws'
 import {
   type ClientFrame,
+  type KnowledgeRefreshDoneFrame,
   PROTOCOL_VERSION,
   type RunDoneFrame,
   ServerFrame as ServerFrameSchema,
@@ -42,9 +44,13 @@ export type DaemonClient = {
   start(): Promise<void>
   /** Issue a run-start. Only one inflight run is allowed per client in v1. */
   runStart(opts: RunStartOpts): RunStream
+  /** Send a knowledge-refresh frame and await the done report. */
+  knowledgeRefresh(opts?: { timeoutMs?: number }): Promise<KnowledgeRefreshDoneFrame>
   /** Close the WS. Pending run is rejected. */
   close(): Promise<void>
 }
+
+const DEFAULT_KNOWLEDGE_REFRESH_TIMEOUT_MS = 5 * 60 * 1000
 
 const DEFAULT_HELLO_TIMEOUT_MS = 5_000
 
@@ -102,10 +108,17 @@ type Pending = {
   cancelRequested: boolean
 }
 
+type KnowledgeRequest = {
+  resolve: (frame: KnowledgeRefreshDoneFrame) => void
+  reject: (err: Error) => void
+  timer: NodeJS.Timeout
+}
+
 export function createDaemonClient(opts: DaemonClientOpts): DaemonClient {
   const helloTimeoutMs = opts.helloTimeoutMs ?? DEFAULT_HELLO_TIMEOUT_MS
   let ws: WebSocket | null = null
   let pending: Pending | null = null
+  const knowledgeRequests = new Map<string, KnowledgeRequest>()
   let closed = false
 
   function sendFrame(frame: ClientFrame): void {
@@ -163,8 +176,29 @@ export function createDaemonClient(opts: DaemonClientOpts): DaemonClient {
       return
     }
 
+    if (frame.type === 'knowledge-refresh-done') {
+      const req = knowledgeRequests.get(frame.requestId)
+      if (req) {
+        clearTimeout(req.timer)
+        knowledgeRequests.delete(frame.requestId)
+        req.resolve(frame)
+      } else {
+        log.warn({ requestId: frame.requestId }, 'knowledge-refresh-done for unknown request')
+      }
+      return
+    }
+
     if (frame.type === 'error') {
       const err = new Error(`${frame.code}: ${frame.message}`)
+      if (frame.requestId) {
+        const req = knowledgeRequests.get(frame.requestId)
+        if (req) {
+          clearTimeout(req.timer)
+          knowledgeRequests.delete(frame.requestId)
+          req.reject(err)
+          return
+        }
+      }
       if (
         pending &&
         (frame.runId === pending.runId ||
@@ -178,6 +212,14 @@ export function createDaemonClient(opts: DaemonClientOpts): DaemonClient {
     }
 
     // hello-ack — handled inline by start()
+  }
+
+  function failKnowledgeRequests(err: Error): void {
+    for (const [id, req] of knowledgeRequests) {
+      clearTimeout(req.timer)
+      knowledgeRequests.delete(id)
+      req.reject(err)
+    }
   }
 
   return {
@@ -229,6 +271,7 @@ export function createDaemonClient(opts: DaemonClientOpts): DaemonClient {
       ws.on('close', () => {
         closed = true
         if (pending) failPending(new Error('daemon connection closed'))
+        failKnowledgeRequests(new Error('daemon connection closed'))
       })
       ws.on('error', (err) => {
         log.warn({ err }, 'ws error')
@@ -287,9 +330,30 @@ export function createDaemonClient(opts: DaemonClientOpts): DaemonClient {
       }
     },
 
+    knowledgeRefresh(reqOpts?: { timeoutMs?: number }): Promise<KnowledgeRefreshDoneFrame> {
+      if (closed || !ws) return Promise.reject(new Error('daemon client not connected'))
+      const requestId = randomUUID()
+      const timeoutMs = reqOpts?.timeoutMs ?? DEFAULT_KNOWLEDGE_REFRESH_TIMEOUT_MS
+      return new Promise<KnowledgeRefreshDoneFrame>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          knowledgeRequests.delete(requestId)
+          reject(new Error(`knowledge-refresh timed out after ${timeoutMs}ms`))
+        }, timeoutMs)
+        knowledgeRequests.set(requestId, { resolve, reject, timer })
+        try {
+          sendFrame({ type: 'knowledge-refresh', requestId })
+        } catch (err) {
+          clearTimeout(timer)
+          knowledgeRequests.delete(requestId)
+          reject(err instanceof Error ? err : new Error(String(err)))
+        }
+      })
+    },
+
     async close(): Promise<void> {
       closed = true
       if (pending) failPending(new Error('daemon client closing'))
+      failKnowledgeRequests(new Error('daemon client closing'))
       if (!ws) return
       const target = ws
       ws = null

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -35,6 +35,16 @@ const EnvSchema = z.object({
   ZERION_API_KEY: optionalNonEmpty,
   /** AgentKit OpenSea action provider — required for NFT marketplace calls. */
   OPENSEA_API_KEY: optionalNonEmpty,
+  /** Knowledge cron interval, ms. Default 24h. */
+  KNOWLEDGE_CRON_INTERVAL_MS: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .default(24 * 60 * 60 * 1000),
+  /** Disable the knowledge cron entirely (tests, dev). */
+  KNOWLEDGE_CRON_DISABLE: z.coerce.boolean().default(false),
+  /** Run the knowledge cron once at boot — used by `talos init`'s sync first-fetch. */
+  KNOWLEDGE_CRON_RUN_ON_BOOT: z.coerce.boolean().default(false),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 })
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -22,4 +22,5 @@ export {
   type ControlPlane,
   type ControlPlaneOpts,
   createControlPlane,
+  type KnowledgeController,
 } from './server'

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -12,6 +12,10 @@ import {
   type MutateRoute,
   type ToolMiddleware,
 } from '@/keeperhub'
+import { runKnowledgeCron } from '@/knowledge/cron'
+import { createKnowledgeRetriever } from '@/knowledge/retrieve'
+import { type SchedulerHandle, startScheduler } from '@/knowledge/scheduler'
+import { defaultKnowledgeSources } from '@/knowledge/sources'
 import { defaultMcpServers, McpHost, McpToolSource, type ToolAnnotations } from '@/mcp-host'
 import {
   assertNoLiveDaemon,
@@ -198,12 +202,24 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
       ...(khClient ? { kh: { client: khClient, routes } } : {}),
     })
 
-  // Build runtime deps. Knowledge / summarizer / fact pipeline are deferred
-  // to follow-up issues (#11/#16/#17 LLM impls).
+  // Build runtime deps. Summarizer / fact pipeline still deferred (#16/#17).
+  // Knowledge retriever + cron land in #11.
   const agents = new AgentRegistry()
   agents.register(TALOS_ETH_AGENT, { default: true })
   const providers = createProviderRouter()
   const embeddings = createOpenAIEmbeddings()
+  const knowledgeSources = defaultKnowledgeSources()
+  const knowledgeRetriever = createKnowledgeRetriever({ db: dbHandle.db, embeddings })
+  const knowledgeController = {
+    refresh: () =>
+      runKnowledgeCron({
+        db: dbHandle.db,
+        embeddings,
+        sources: knowledgeSources,
+        logger,
+      }),
+  }
+
   const runtime = createRuntime({
     db: dbHandle,
     providers,
@@ -211,7 +227,36 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     agents,
     toolSources: [...(mcpHost ? [new McpToolSource(mcpHost)] : []), ...nativeSources],
     toolMiddleware,
+    knowledgeRetriever,
   })
+
+  // Boot the knowledge scheduler if not disabled. Skips entirely when
+  // OPENAI_API_KEY is missing — cron ticks would crash at the embedding call
+  // and a daily warn-storm helps no one. Manual `talos knowledge:refresh`
+  // still works once the key is set.
+  let knowledgeScheduler: SchedulerHandle | undefined
+  if (!env.KNOWLEDGE_CRON_DISABLE && env.OPENAI_API_KEY) {
+    knowledgeScheduler = startScheduler({
+      run: () => knowledgeController.refresh(),
+      intervalMs: env.KNOWLEDGE_CRON_INTERVAL_MS,
+      runOnBoot: env.KNOWLEDGE_CRON_RUN_ON_BOOT,
+      logger,
+      name: 'knowledge',
+    })
+    logger.info(
+      {
+        intervalMs: env.KNOWLEDGE_CRON_INTERVAL_MS,
+        runOnBoot: env.KNOWLEDGE_CRON_RUN_ON_BOOT,
+        sources: knowledgeSources.length,
+      },
+      'knowledge cron scheduled',
+    )
+  } else {
+    logger.info(
+      { disabled: env.KNOWLEDGE_CRON_DISABLE, hasKey: Boolean(env.OPENAI_API_KEY) },
+      'knowledge cron not started (disabled or OPENAI_API_KEY missing)',
+    )
+  }
 
   // Boot control plane.
   const controlPlane = createControlPlane({
@@ -219,6 +264,7 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     token,
     port: startOpts.port ?? env.TALOS_DAEMON_PORT,
     ...(startOpts.host !== undefined ? { host: startOpts.host } : {}),
+    knowledge: knowledgeController,
   })
   const { port, host } = await controlPlane.start()
 
@@ -244,6 +290,13 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     if (stopping) return stopping
     stopping = (async () => {
       logger.info('talosd shutting down')
+      if (knowledgeScheduler) {
+        try {
+          await knowledgeScheduler.stop()
+        } catch (err) {
+          logger.warn({ err }, 'error stopping knowledge scheduler')
+        }
+      }
       try {
         await controlPlane.stop()
       } catch (err) {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -14,6 +14,27 @@ const log = child({ module: 'daemon-server' })
 
 const DEFAULT_HOST = '127.0.0.1'
 
+/**
+ * Optional knowledge controller: when present, the control plane handles
+ * `knowledge-refresh` frames by invoking `refresh()` and replying with a
+ * `knowledge-refresh-done` frame. When absent, refresh requests get an
+ * `error` frame with code `KNOWLEDGE_DISABLED`.
+ */
+export type KnowledgeController = {
+  refresh(): Promise<{
+    startedAt: string
+    finishedAt: string
+    totalDurationMs: number
+    sources: Array<{
+      source: string
+      fetched: number
+      chunks: number
+      durationMs: number
+      error?: string
+    }>
+  }>
+}
+
 export type ControlPlaneOpts = {
   runtime: AgentRuntime
   /** Bearer token clients must present in the auth frame. */
@@ -24,6 +45,8 @@ export type ControlPlaneOpts = {
   host?: string
   /** Default channel id reported to the runtime when a client doesn't supply one. */
   defaultChannel?: string
+  /** Optional knowledge controller; required to handle `knowledge-refresh` frames. */
+  knowledge?: KnowledgeController
 }
 
 export type ControlPlane = {
@@ -137,6 +160,46 @@ export function createControlPlane(opts: ControlPlaneOpts): ControlPlane {
       ac.abort()
       return
     }
+
+    if (frame.type === 'knowledge-refresh') {
+      await handleKnowledgeRefresh(conn, frame.requestId)
+      return
+    }
+  }
+
+  async function handleKnowledgeRefresh(conn: Connection, requestId: string): Promise<void> {
+    if (!opts.knowledge) {
+      sendRequestError(conn, 'KNOWLEDGE_DISABLED', 'knowledge controller not wired', requestId)
+      return
+    }
+    const task = (async () => {
+      try {
+        const report = await opts.knowledge!.refresh()
+        send(conn, {
+          type: 'knowledge-refresh-done',
+          requestId,
+          startedAt: report.startedAt,
+          finishedAt: report.finishedAt,
+          totalDurationMs: report.totalDurationMs,
+          sources: report.sources.map((s) => ({
+            source: s.source,
+            fetched: s.fetched,
+            chunks: s.chunks,
+            durationMs: s.durationMs,
+            ...(s.error ? { error: s.error } : {}),
+          })),
+        })
+      } catch (err) {
+        sendRequestError(
+          conn,
+          'KNOWLEDGE_REFRESH_FAILED',
+          err instanceof Error ? err.message : String(err),
+          requestId,
+        )
+      }
+    })()
+    conn.pending.add(task)
+    task.finally(() => conn.pending.delete(task))
   }
 
   async function startRun(
@@ -189,6 +252,15 @@ export function createControlPlane(opts: ControlPlaneOpts): ControlPlane {
 
   function sendError(conn: Connection, code: string, message: string, runId?: string): void {
     send(conn, runId ? { type: 'error', code, message, runId } : { type: 'error', code, message })
+  }
+
+  function sendRequestError(
+    conn: Connection,
+    code: string,
+    message: string,
+    requestId: string,
+  ): void {
+    send(conn, { type: 'error', code, message, requestId })
   }
 
   return {

--- a/src/knowledge/chunker.ts
+++ b/src/knowledge/chunker.ts
@@ -1,0 +1,153 @@
+/**
+ * Token-aware-ish chunker for ETH ecosystem text. We don't pull `tiktoken`
+ * (~2MB binary) for v1 — the ~4 chars-per-token heuristic is good enough for
+ * sizing chunks within OpenAI's 8192-token input cap and producing
+ * deterministic outputs. Iterate if recall quality demands it.
+ *
+ * Strategy: split on paragraph boundaries (`\n\n`), greedily pack until the
+ * target token budget is hit, then emit. Adjacent chunks share `overlapTokens`
+ * worth of trailing text from the previous chunk so a fact spanning a
+ * paragraph break still appears whole in at least one chunk.
+ *
+ * Markdown code fences (```...```) are kept atomic — the chunker never splits
+ * a fenced block. If a fence on its own exceeds the budget, it ships solo and
+ * we accept the over-budget chunk rather than emit broken markdown.
+ */
+
+const CHARS_PER_TOKEN = 4
+const DEFAULT_TARGET_TOKENS = 512
+const DEFAULT_OVERLAP_TOKENS = 64
+
+export type ChunkOptions = {
+  /** Target chunk size in tokens (estimated). Default 512. */
+  targetTokens?: number
+  /** Overlap between consecutive chunks in tokens. Default 64. */
+  overlapTokens?: number
+}
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN)
+}
+
+/**
+ * Split markdown-ish text into atoms: paragraphs and code fences. Fences are
+ * preserved as single atoms so the chunker can keep them whole; everything
+ * else is split on blank lines.
+ */
+function splitAtoms(text: string): string[] {
+  const atoms: string[] = []
+  const lines = text.split('\n')
+  let buf: string[] = []
+  let inFence = false
+
+  const flushBuf = () => {
+    if (buf.length === 0) return
+    const joined = buf.join('\n').trim()
+    buf = []
+    if (joined.length === 0) return
+    for (const para of joined.split(/\n{2,}/)) {
+      const trimmed = para.trim()
+      if (trimmed.length > 0) atoms.push(trimmed)
+    }
+  }
+
+  for (const line of lines) {
+    const isFenceMarker = /^```/.test(line.trimStart())
+    if (isFenceMarker && !inFence) {
+      flushBuf()
+      buf.push(line)
+      inFence = true
+      continue
+    }
+    if (isFenceMarker && inFence) {
+      buf.push(line)
+      atoms.push(buf.join('\n'))
+      buf = []
+      inFence = false
+      continue
+    }
+    buf.push(line)
+  }
+
+  if (inFence) {
+    // Unterminated fence — treat the rest as one atom so we don't lose content.
+    atoms.push(buf.join('\n'))
+  } else {
+    flushBuf()
+  }
+
+  return atoms
+}
+
+/**
+ * Trailing-character window of approximately `overlapTokens` tokens. Used to
+ * seed the next chunk so paragraph-spanning context survives.
+ */
+function overlapTail(text: string, overlapTokens: number): string {
+  if (overlapTokens <= 0) return ''
+  const charBudget = overlapTokens * CHARS_PER_TOKEN
+  if (text.length <= charBudget) return text
+  return text.slice(text.length - charBudget)
+}
+
+export function chunk(text: string, opts: ChunkOptions = {}): string[] {
+  const target = opts.targetTokens ?? DEFAULT_TARGET_TOKENS
+  const overlap = opts.overlapTokens ?? DEFAULT_OVERLAP_TOKENS
+  if (target <= 0) throw new Error('targetTokens must be > 0')
+  if (overlap < 0 || overlap >= target) {
+    throw new Error('overlapTokens must satisfy 0 <= overlap < target')
+  }
+
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return []
+
+  const atoms = splitAtoms(trimmed)
+  if (atoms.length === 0) return []
+
+  const out: string[] = []
+  let current: string[] = []
+  let currentTokens = 0
+
+  const emit = () => {
+    if (current.length === 0) return
+    const joined = current.join('\n\n').trim()
+    if (joined.length === 0) {
+      current = []
+      currentTokens = 0
+      return
+    }
+    out.push(joined)
+    const tail = overlapTail(joined, overlap).trim()
+    current = tail.length > 0 ? [tail] : []
+    currentTokens = current.length > 0 ? estimateTokens(current[0] ?? '') : 0
+  }
+
+  for (const atom of atoms) {
+    const atomTokens = estimateTokens(atom)
+
+    // Single atom over budget: flush current, ship the atom solo (over-budget
+    // is acceptable for code fences / very long paragraphs).
+    if (atomTokens > target) {
+      if (current.length > 0) emit()
+      out.push(atom)
+      current = []
+      currentTokens = 0
+      continue
+    }
+
+    // Adding this atom would exceed budget — flush, then start a new chunk
+    // (which already contains the overlap tail from the previous emit).
+    if (currentTokens + atomTokens > target && current.length > 0) {
+      emit()
+    }
+    current.push(atom)
+    currentTokens += atomTokens
+  }
+
+  if (current.length > 0) {
+    const joined = current.join('\n\n').trim()
+    if (joined.length > 0) out.push(joined)
+  }
+
+  return out
+}

--- a/src/knowledge/cron.ts
+++ b/src/knowledge/cron.ts
@@ -1,0 +1,143 @@
+import type { Logger } from 'pino'
+import type { Db } from '@/persistence/queries'
+import { replaceKnowledgeChunks } from '@/persistence/queries'
+import type { EmbeddingsService } from '@/runtime/types'
+import { logger as defaultLogger } from '@/shared/logger'
+import { type ChunkOptions, chunk as chunkText } from './chunker'
+import { embedBatch } from './embed'
+import type { KnowledgeSource, KnowledgeSourceItem } from './sources/types'
+
+export type SourceSyncReport = {
+  source: string
+  /** Items returned by the source's `fetch()`. */
+  fetched: number
+  /** Total chunks persisted across all items. */
+  chunks: number
+  /** Wall time for the whole source: fetch + chunk + embed + persist. */
+  durationMs: number
+  /** Truthy when this source threw — others continue independently. */
+  error?: string
+}
+
+export type KnowledgeSyncReport = {
+  startedAt: string
+  finishedAt: string
+  totalDurationMs: number
+  sources: SourceSyncReport[]
+}
+
+export type RunCronDeps = {
+  db: Db
+  embeddings: EmbeddingsService
+  sources: readonly KnowledgeSource[]
+  logger?: Logger
+  /** Override chunker config (target/overlap tokens). */
+  chunk?: ChunkOptions
+  /** Override embedder batch size. */
+  embedBatchSize?: number
+}
+
+/**
+ * Run one cron tick: for each source, fetch -> chunk -> embed -> replace.
+ * Per-source try/catch isolates failures so one upstream incident doesn't
+ * block the others. Each (source, sourceId) pair is replaced atomically in
+ * a transaction.
+ */
+export async function runKnowledgeCron(deps: RunCronDeps): Promise<KnowledgeSyncReport> {
+  const log = deps.logger ?? defaultLogger
+  const startedAt = new Date()
+  const reports: SourceSyncReport[] = []
+
+  for (const source of deps.sources) {
+    const sourceStart = Date.now()
+    let fetched = 0
+    let chunks = 0
+    try {
+      const items = await source.fetch()
+      fetched = items.length
+      const childLog = log.child({ source: source.name, fetched })
+      childLog.info('source fetched')
+
+      // Chunk every item up front so we can batch embeddings across the
+      // whole source in one or two embedMany calls.
+      const flat: Array<{ item: KnowledgeSourceItem; chunkIndex: number; content: string }> = []
+      for (const item of items) {
+        const pieces = chunkText(item.content, deps.chunk)
+        pieces.forEach((content, chunkIndex) => {
+          flat.push({ item, chunkIndex, content })
+        })
+      }
+
+      const vectors =
+        flat.length === 0
+          ? []
+          : await embedBatch(
+              deps.embeddings,
+              flat.map((f) => f.content),
+              ...(deps.embedBatchSize != null ? [{ batchSize: deps.embedBatchSize }] : []),
+            )
+
+      // Group flat list back by sourceId so each replace call is atomic per
+      // document. Items returning zero chunks still get their pair cleared
+      // so a content drop wipes the prior set.
+      const grouped = new Map<
+        string,
+        {
+          item: KnowledgeSourceItem
+          rows: Array<{ chunkIndex: number; content: string; embedding: number[] }>
+        }
+      >()
+      for (const item of items) {
+        grouped.set(item.sourceId, { item, rows: [] })
+      }
+      flat.forEach((f, i) => {
+        const v = vectors[i]
+        if (!v) return
+        const bucket = grouped.get(f.item.sourceId)
+        if (!bucket) return
+        bucket.rows.push({ chunkIndex: f.chunkIndex, content: f.content, embedding: v })
+      })
+
+      for (const [sourceId, { item, rows }] of grouped) {
+        await replaceKnowledgeChunks(
+          deps.db,
+          source.name,
+          sourceId,
+          rows.map((r) => ({
+            chunkIndex: r.chunkIndex,
+            content: r.content,
+            embedding: r.embedding,
+            metadata: item.metadata ?? null,
+          })),
+        )
+        chunks += rows.length
+      }
+
+      childLog.info({ chunks }, 'source persisted')
+      reports.push({
+        source: source.name,
+        fetched,
+        chunks,
+        durationMs: Date.now() - sourceStart,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      log.warn({ source: source.name, err: message }, 'source failed — continuing')
+      reports.push({
+        source: source.name,
+        fetched,
+        chunks,
+        durationMs: Date.now() - sourceStart,
+        error: message,
+      })
+    }
+  }
+
+  const finishedAt = new Date()
+  return {
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    totalDurationMs: finishedAt.getTime() - startedAt.getTime(),
+    sources: reports,
+  }
+}

--- a/src/knowledge/embed.ts
+++ b/src/knowledge/embed.ts
@@ -1,0 +1,30 @@
+import type { EmbeddingsService } from '@/runtime/types'
+
+const DEFAULT_BATCH_SIZE = 50
+
+/**
+ * Embed a list of texts in batches that fit OpenAI's input limit comfortably.
+ * The cap is 100 inputs per request; we pick {DEFAULT_BATCH_SIZE} for token-
+ * budget headroom (50 chunks × ~512 tok ≈ 25K tokens, well under 8K-per-input
+ * × 100 cap, but safer for retries).
+ */
+export async function embedBatch(
+  embeddings: EmbeddingsService,
+  texts: readonly string[],
+  opts: { batchSize?: number } = {},
+): Promise<number[][]> {
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE
+  if (batchSize <= 0) throw new Error('batchSize must be > 0')
+  if (texts.length === 0) return []
+
+  const out: number[][] = []
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const slice = texts.slice(i, i + batchSize)
+    const vectors = await embeddings.embedMany([...slice])
+    if (vectors.length !== slice.length) {
+      throw new Error(`embedMany returned ${vectors.length} vectors for ${slice.length} inputs`)
+    }
+    out.push(...vectors)
+  }
+  return out
+}

--- a/src/knowledge/index.ts
+++ b/src/knowledge/index.ts
@@ -1,9 +1,23 @@
-import { TalosNotImplementedError } from '@/shared/errors'
-
-export function runKnowledgeCron(): never {
-  throw new TalosNotImplementedError('knowledge.runKnowledgeCron')
-}
-
-export function retrieveTopK(_query: string, _k = 5): never {
-  throw new TalosNotImplementedError('knowledge.retrieveTopK')
-}
+export { type ChunkOptions, chunk, estimateTokens } from './chunker'
+export {
+  type KnowledgeSyncReport,
+  type RunCronDeps,
+  runKnowledgeCron,
+  type SourceSyncReport,
+} from './cron'
+export { embedBatch } from './embed'
+export { createKnowledgeRetriever, type RetrieverDeps } from './retrieve'
+export { type SchedulerHandle, type StartSchedulerOpts, startScheduler } from './scheduler'
+export {
+  createDefillamaHacksSource,
+  createDefillamaProtocolsSource,
+  createEfBlogSource,
+  createL2BeatSource,
+  createSnapshotSource,
+  DEFAULT_SNAPSHOT_SPACES,
+  defaultKnowledgeSources,
+  type HttpFetch,
+  type KnowledgeSource,
+  type KnowledgeSourceItem,
+  type SourceDeps,
+} from './sources'

--- a/src/knowledge/retrieve.ts
+++ b/src/knowledge/retrieve.ts
@@ -1,0 +1,33 @@
+import type { Db } from '@/persistence/queries'
+import { searchKnowledgeChunks } from '@/persistence/queries'
+import type { EmbeddingsService, KnowledgeChunkHit, KnowledgeRetriever } from '@/runtime/types'
+
+export type RetrieverDeps = {
+  db: Db
+  embeddings: EmbeddingsService
+}
+
+/**
+ * KnowledgeRetriever backed by the cron-fed `knowledge_chunks` table.
+ * Embeds the query, runs cosine top-K via the HNSW index, returns
+ * `KnowledgeChunkHit` records the runtime injects into the system prompt.
+ *
+ * `score = 1 - distance` so callers can treat higher as better; the runtime
+ * just passes the hits through without thresholding (knowledge is best-
+ * effort context, not gated).
+ */
+export function createKnowledgeRetriever(deps: RetrieverDeps): KnowledgeRetriever {
+  return {
+    async retrieve(query: string, opts?: { topK?: number }): Promise<KnowledgeChunkHit[]> {
+      if (!query || query.trim().length === 0) return []
+      const topK = opts?.topK ?? 5
+      const queryEmbedding = await deps.embeddings.embed(query)
+      const rows = await searchKnowledgeChunks(deps.db, queryEmbedding, topK)
+      return rows.map((r) => ({
+        source: r.source,
+        content: r.content,
+        score: r.score,
+      }))
+    },
+  }
+}

--- a/src/knowledge/scheduler.ts
+++ b/src/knowledge/scheduler.ts
@@ -1,0 +1,90 @@
+import type { Logger } from 'pino'
+import { logger as defaultLogger } from '@/shared/logger'
+
+/**
+ * Drift-tolerant scheduler. Schedules with `setTimeout` recursively rather
+ * than `setInterval`, so the next tick is computed from the moment the
+ * previous run *finished* — long-running cron ticks don't pile up.
+ *
+ * Stop is synchronous: it clears the pending timer and flips a flag the
+ * in-flight tick checks before re-scheduling. An ongoing run completes;
+ * the scheduler simply doesn't queue a new one.
+ */
+export type SchedulerHandle = {
+  /** Stop the scheduler. Idempotent. Returns once any in-flight tick resolves. */
+  stop(): Promise<void>
+  /** True between `start()` and `stop()`. */
+  isRunning(): boolean
+}
+
+export type StartSchedulerOpts = {
+  /** Async function executed each tick. Errors are logged, never propagated. */
+  run: () => Promise<unknown>
+  /** Interval between tick *completion* and the next tick start, in ms. */
+  intervalMs: number
+  /** When true, run once immediately on start. Default false. */
+  runOnBoot?: boolean
+  /** When true, do nothing — scheduler stays inert. Useful for tests. */
+  disabled?: boolean
+  /** Pino logger; defaults to the shared talos logger. */
+  logger?: Logger
+  /** Identifier for log lines. */
+  name?: string
+}
+
+export function startScheduler(opts: StartSchedulerOpts): SchedulerHandle {
+  const log = (opts.logger ?? defaultLogger).child({ scheduler: opts.name ?? 'knowledge' })
+  if (opts.disabled) {
+    log.info('scheduler disabled — no ticks will run')
+    return { stop: async () => {}, isRunning: () => false }
+  }
+  if (opts.intervalMs <= 0) throw new Error('intervalMs must be > 0')
+
+  let stopped = false
+  let timer: NodeJS.Timeout | null = null
+  let activeTick: Promise<void> | null = null
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return
+    const startedAt = Date.now()
+    try {
+      await opts.run()
+    } catch (err) {
+      log.warn({ err }, 'scheduler tick failed')
+    }
+    const elapsed = Date.now() - startedAt
+    log.debug({ elapsedMs: elapsed }, 'scheduler tick complete')
+    if (stopped) return
+    timer = setTimeout(scheduleNext, opts.intervalMs)
+  }
+
+  const scheduleNext = () => {
+    if (stopped) return
+    activeTick = tick()
+  }
+
+  if (opts.runOnBoot) {
+    scheduleNext()
+  } else {
+    timer = setTimeout(scheduleNext, opts.intervalMs)
+  }
+
+  return {
+    isRunning: () => !stopped,
+    async stop() {
+      if (stopped) return
+      stopped = true
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      if (activeTick) {
+        try {
+          await activeTick
+        } catch {
+          // Errors already logged inside tick().
+        }
+      }
+    },
+  }
+}

--- a/src/knowledge/sources/defillama.ts
+++ b/src/knowledge/sources/defillama.ts
@@ -1,0 +1,159 @@
+import { fetchJson } from './http'
+import type { KnowledgeSource, KnowledgeSourceItem, SourceDeps } from './types'
+
+const PROTOCOLS_URL = 'https://api.llama.fi/protocols'
+const HACKS_URL = 'https://api.llama.fi/hacks'
+
+const TOP_PROTOCOLS = 50
+const HACKS_LOOKBACK_DAYS = 90
+
+type DefillamaProtocol = {
+  id?: string
+  name: string
+  symbol?: string | null
+  url?: string | null
+  description?: string | null
+  category?: string | null
+  chain?: string | null
+  chains?: string[]
+  slug?: string
+  tvl?: number
+  change_1d?: number | null
+  change_7d?: number | null
+  mcap?: number | null
+}
+
+type DefillamaHack = {
+  id?: number | string
+  name: string
+  date?: number // unix seconds
+  amount?: number | null // millions of USD
+  source_url?: string | null
+  technique?: string | null
+  classification?: string | null
+  language?: string | null
+  bridgeHack?: boolean | null
+  targetType?: string | null
+  defillamaId?: string | null
+  chain?: string[] | null
+  returnedFunds?: number | null
+}
+
+function fmtUsd(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return 'n/a'
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(2)}M`
+  if (n >= 1e3) return `$${(n / 1e3).toFixed(2)}K`
+  return `$${n.toFixed(0)}`
+}
+
+function fmtPct(n: number | null | undefined): string {
+  if (n == null || !Number.isFinite(n)) return 'n/a'
+  const sign = n > 0 ? '+' : ''
+  return `${sign}${(n * 100).toFixed(2)}%`
+}
+
+function renderProtocol(p: DefillamaProtocol): string {
+  const lines: string[] = []
+  lines.push(`# ${p.name}${p.symbol ? ` (${p.symbol})` : ''}`)
+  if (p.category) lines.push(`Category: ${p.category}`)
+  if (p.chain || (p.chains && p.chains.length > 0)) {
+    const chains = p.chains?.length ? p.chains.join(', ') : (p.chain ?? '')
+    lines.push(`Chains: ${chains}`)
+  }
+  lines.push(`TVL: ${fmtUsd(p.tvl)}`)
+  if (p.change_1d != null) lines.push(`24h change: ${fmtPct(p.change_1d)}`)
+  if (p.change_7d != null) lines.push(`7d change: ${fmtPct(p.change_7d)}`)
+  if (p.mcap != null) lines.push(`Market cap: ${fmtUsd(p.mcap)}`)
+  if (p.url) lines.push(`Website: ${p.url}`)
+  if (p.description?.trim()) lines.push('', p.description.trim())
+  return lines.join('\n')
+}
+
+/**
+ * DefiLlama protocols source: top {TOP_PROTOCOLS} by TVL, one item per
+ * protocol so retrieval can match queries like "what's Aave's TVL". Each
+ * item's metadata carries the raw numeric fields for downstream callers.
+ */
+export function createDefillamaProtocolsSource(deps: SourceDeps = {}): KnowledgeSource {
+  return {
+    name: 'defillama:protocols',
+    async fetch(): Promise<KnowledgeSourceItem[]> {
+      const list = await fetchJson<DefillamaProtocol[]>(PROTOCOLS_URL, {
+        ...(deps.fetch ? { fetch: deps.fetch } : {}),
+        ...(deps.timeoutMs != null ? { timeoutMs: deps.timeoutMs } : {}),
+      })
+      const ranked = list
+        .filter((p) => typeof p.tvl === 'number' && Number.isFinite(p.tvl))
+        .sort((a, b) => (b.tvl ?? 0) - (a.tvl ?? 0))
+        .slice(0, TOP_PROTOCOLS)
+
+      return ranked.map((p, i) => ({
+        sourceId: p.slug ?? p.name.toLowerCase().replace(/\s+/g, '-'),
+        content: renderProtocol(p),
+        metadata: {
+          rank: i + 1,
+          tvlUsd: p.tvl ?? null,
+          change1d: p.change_1d ?? null,
+          change7d: p.change_7d ?? null,
+          category: p.category ?? null,
+          chains: p.chains ?? (p.chain ? [p.chain] : []),
+          url: p.url ?? null,
+        },
+      }))
+    },
+  }
+}
+
+function renderHack(h: DefillamaHack): string {
+  const dateIso = h.date ? new Date(h.date * 1000).toISOString().slice(0, 10) : 'unknown'
+  const amount = h.amount != null ? `$${h.amount.toFixed(1)}M` : 'undisclosed'
+  const lines: string[] = []
+  lines.push(`# ${h.name}`)
+  lines.push(`Date: ${dateIso}`)
+  lines.push(`Loss: ${amount}`)
+  if (h.classification) lines.push(`Classification: ${h.classification}`)
+  if (h.technique) lines.push(`Technique: ${h.technique}`)
+  if (h.targetType) lines.push(`Target: ${h.targetType}`)
+  if (h.chain && h.chain.length > 0) lines.push(`Chains: ${h.chain.join(', ')}`)
+  if (h.bridgeHack) lines.push('Bridge hack: yes')
+  if (h.returnedFunds != null && h.returnedFunds > 0) {
+    lines.push(`Returned funds: $${h.returnedFunds.toFixed(1)}M`)
+  }
+  if (h.source_url) lines.push(`Source: ${h.source_url}`)
+  return lines.join('\n')
+}
+
+/**
+ * DefiLlama hacks source: incidents within the last {HACKS_LOOKBACK_DAYS}
+ * days, one item per hack. The agent can cite recent exploits when a user
+ * asks about a protocol.
+ */
+export function createDefillamaHacksSource(deps: SourceDeps = {}): KnowledgeSource {
+  return {
+    name: 'defillama:hacks',
+    async fetch(): Promise<KnowledgeSourceItem[]> {
+      const list = await fetchJson<DefillamaHack[]>(HACKS_URL, {
+        ...(deps.fetch ? { fetch: deps.fetch } : {}),
+        ...(deps.timeoutMs != null ? { timeoutMs: deps.timeoutMs } : {}),
+      })
+      const cutoff = Date.now() / 1000 - HACKS_LOOKBACK_DAYS * 86_400
+      const recent = list
+        .filter((h) => typeof h.date === 'number' && (h.date as number) >= cutoff)
+        .sort((a, b) => (b.date ?? 0) - (a.date ?? 0))
+
+      return recent.map((h) => ({
+        sourceId: h.id != null ? String(h.id) : h.name.toLowerCase().replace(/\s+/g, '-'),
+        content: renderHack(h),
+        metadata: {
+          dateUnix: h.date ?? null,
+          amountMUsd: h.amount ?? null,
+          classification: h.classification ?? null,
+          technique: h.technique ?? null,
+          chains: h.chain ?? [],
+          sourceUrl: h.source_url ?? null,
+        },
+      }))
+    },
+  }
+}

--- a/src/knowledge/sources/ef-blog.ts
+++ b/src/knowledge/sources/ef-blog.ts
@@ -1,0 +1,120 @@
+import { fetchText } from './http'
+import type { KnowledgeSource, KnowledgeSourceItem, SourceDeps } from './types'
+
+const FEED_URL = 'https://blog.ethereum.org/feed.xml'
+const POSTS_LIMIT = 30
+
+/**
+ * Hand-rolled RSS extractor. Pulls the `<item>` blocks and reads the inner
+ * `<title>`, `<link>`, `<pubDate>`, `<description>` fields. We avoid pulling
+ * a real XML parser dep — the EF feed is well-formed and the blogosphere is
+ * forgiving to the regex approach.
+ */
+type RssItem = {
+  title: string
+  link: string
+  pubDate: string
+  description: string
+  guid: string
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, code: string) => String.fromCharCode(Number(code)))
+}
+
+function stripHtml(s: string): string {
+  return s
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function readField(block: string, tag: string): string {
+  const cdata = new RegExp(`<${tag}[^>]*>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*</${tag}>`, 'i')
+  const m1 = block.match(cdata)
+  if (m1?.[1] != null) return decodeEntities(m1[1].trim())
+  const plain = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i')
+  const m2 = block.match(plain)
+  if (m2?.[1] != null) return decodeEntities(m2[1].trim())
+  return ''
+}
+
+function parseFeed(xml: string): RssItem[] {
+  const items: RssItem[] = []
+  const itemRe = /<item\b[\s\S]*?<\/item>/gi
+  for (const match of xml.matchAll(itemRe)) {
+    const block = match[0]
+    items.push({
+      title: readField(block, 'title'),
+      link: readField(block, 'link'),
+      pubDate: readField(block, 'pubDate'),
+      description: readField(block, 'description'),
+      guid: readField(block, 'guid'),
+    })
+  }
+  return items
+}
+
+function slugFromLink(link: string, fallback: string): string {
+  try {
+    const u = new URL(link)
+    const last = u.pathname.split('/').filter(Boolean).pop()
+    if (last) return last.toLowerCase()
+  } catch {
+    // fall through
+  }
+  return (
+    fallback
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'post'
+  )
+}
+
+function renderPost(item: RssItem): string {
+  const lines: string[] = []
+  lines.push(`# ${item.title}`)
+  if (item.pubDate) lines.push(`Published: ${item.pubDate}`)
+  if (item.link) lines.push(`Link: ${item.link}`)
+  const summary = stripHtml(item.description)
+  if (summary.length > 0) lines.push('', summary)
+  return lines.join('\n')
+}
+
+/**
+ * Ethereum Foundation blog: latest posts via RSS. ETH-level signal —
+ * hardforks, EIPs going live, devcon notes. Daily refresh fits the cadence
+ * (posts are weekly+ on a busy month).
+ */
+export function createEfBlogSource(deps: SourceDeps = {}): KnowledgeSource {
+  return {
+    name: 'ef-blog',
+    async fetch(): Promise<KnowledgeSourceItem[]> {
+      const xml = await fetchText(FEED_URL, {
+        ...(deps.fetch ? { fetch: deps.fetch } : {}),
+        ...(deps.timeoutMs != null ? { timeoutMs: deps.timeoutMs } : {}),
+      })
+      const items = parseFeed(xml).slice(0, POSTS_LIMIT)
+      return items.map((item) => {
+        const sourceId =
+          item.guid && item.guid.length > 0 ? item.guid : slugFromLink(item.link, item.title)
+        return {
+          sourceId,
+          content: renderPost(item),
+          metadata: {
+            link: item.link || null,
+            pubDate: item.pubDate || null,
+          },
+        }
+      })
+    },
+  }
+}

--- a/src/knowledge/sources/http.ts
+++ b/src/knowledge/sources/http.ts
@@ -1,0 +1,98 @@
+import { TalosError } from '@/shared/errors'
+import type { HttpFetch } from './types'
+
+const DEFAULT_TIMEOUT_MS = 15_000
+const USER_AGENT = 'Talos/0.1 (+https://github.com/Allen-Saji/talos)'
+
+export type FetchJsonOpts = {
+  fetch?: HttpFetch
+  timeoutMs?: number
+  headers?: Record<string, string>
+}
+
+/**
+ * GET {url} as JSON. Throws TalosError on non-2xx, abort on timeout, parse failure.
+ * Centralized so every source surfaces the same error shape and the same UA.
+ */
+export async function fetchJson<T>(url: string, opts: FetchJsonOpts = {}): Promise<T> {
+  const fetchImpl = opts.fetch ?? globalThis.fetch
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetchImpl(url, {
+      method: 'GET',
+      headers: { 'user-agent': USER_AGENT, accept: 'application/json', ...opts.headers },
+      signal: ctrl.signal,
+    })
+    if (!res.ok) {
+      throw new TalosError(`GET ${url} -> ${res.status}`, 'KNOWLEDGE_HTTP_ERROR')
+    }
+    return (await res.json()) as T
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export type FetchTextOpts = FetchJsonOpts
+
+export async function fetchText(url: string, opts: FetchTextOpts = {}): Promise<string> {
+  const fetchImpl = opts.fetch ?? globalThis.fetch
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetchImpl(url, {
+      method: 'GET',
+      headers: { 'user-agent': USER_AGENT, accept: 'text/*, application/xml', ...opts.headers },
+      signal: ctrl.signal,
+    })
+    if (!res.ok) {
+      throw new TalosError(`GET ${url} -> ${res.status}`, 'KNOWLEDGE_HTTP_ERROR')
+    }
+    return await res.text()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export type GraphqlOpts = FetchJsonOpts & {
+  variables?: Record<string, unknown>
+}
+
+export async function fetchGraphql<T>(
+  url: string,
+  query: string,
+  opts: GraphqlOpts = {},
+): Promise<T> {
+  const fetchImpl = opts.fetch ?? globalThis.fetch
+  const ctrl = new AbortController()
+  const timer = setTimeout(() => ctrl.abort(), opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'user-agent': USER_AGENT,
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...opts.headers,
+      },
+      body: JSON.stringify({ query, variables: opts.variables ?? {} }),
+      signal: ctrl.signal,
+    })
+    if (!res.ok) {
+      throw new TalosError(`POST ${url} -> ${res.status}`, 'KNOWLEDGE_HTTP_ERROR')
+    }
+    const body = (await res.json()) as { data?: T; errors?: Array<{ message: string }> }
+    if (body.errors && body.errors.length > 0) {
+      throw new TalosError(
+        `graphql errors: ${body.errors.map((e) => e.message).join('; ')}`,
+        'KNOWLEDGE_GRAPHQL_ERROR',
+      )
+    }
+    if (!body.data) {
+      throw new TalosError('graphql response missing data field', 'KNOWLEDGE_GRAPHQL_ERROR')
+    }
+    return body.data
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/src/knowledge/sources/index.ts
+++ b/src/knowledge/sources/index.ts
@@ -1,0 +1,32 @@
+import { createDefillamaHacksSource, createDefillamaProtocolsSource } from './defillama'
+import { createEfBlogSource } from './ef-blog'
+import { createL2BeatSource } from './l2beat'
+import { createSnapshotSource } from './snapshot'
+import type { KnowledgeSource, SourceDeps } from './types'
+
+export {
+  createDefillamaHacksSource,
+  createDefillamaProtocolsSource,
+} from './defillama'
+export { createEfBlogSource } from './ef-blog'
+export { createL2BeatSource } from './l2beat'
+export { createSnapshotSource, DEFAULT_SNAPSHOT_SPACES } from './snapshot'
+export type { HttpFetch, KnowledgeSource, KnowledgeSourceItem, SourceDeps } from './types'
+
+/**
+ * Default source set Talos boots with. Five sources:
+ *  - defillama:protocols (TVL ranks)
+ *  - defillama:hacks (recent DeFi exploits)
+ *  - l2beat:summary (rollup state)
+ *  - snapshot:proposals (governance)
+ *  - ef-blog (ETH-level news)
+ */
+export function defaultKnowledgeSources(deps: SourceDeps = {}): KnowledgeSource[] {
+  return [
+    createDefillamaProtocolsSource(deps),
+    createDefillamaHacksSource(deps),
+    createL2BeatSource(deps),
+    createSnapshotSource(deps),
+    createEfBlogSource(deps),
+  ]
+}

--- a/src/knowledge/sources/l2beat.ts
+++ b/src/knowledge/sources/l2beat.ts
@@ -1,0 +1,95 @@
+import { fetchJson } from './http'
+import type { KnowledgeSource, KnowledgeSourceItem, SourceDeps } from './types'
+
+const SUMMARY_URL = 'https://l2beat.com/api/scaling/summary'
+
+/**
+ * L2Beat's public summary payload is shaped roughly:
+ *   { projects: { [slug]: { name, slug, type, tvl, ... } } }
+ * but the actual contract has wobbled across releases. We treat the response
+ * as a record map and pull only the fields we render, so a missing key
+ * degrades rather than throws.
+ */
+type L2BeatSummary = {
+  projects?: Record<string, L2BeatProject> | L2BeatProject[]
+}
+
+type L2BeatProject = {
+  id?: string
+  slug?: string
+  name?: string
+  type?: string // 'layer2' | 'layer3' | ...
+  category?: string // 'Optimistic Rollup' | 'ZK Rollup' | ...
+  hostChain?: string | null
+  stage?: string | null // 'Stage 0' | 'Stage 1' | 'Stage 2'
+  tvl?: { breakdown?: { total?: number }; total?: number } | number
+  isArchived?: boolean
+}
+
+function readTvl(p: L2BeatProject): number | null {
+  if (typeof p.tvl === 'number') return p.tvl
+  const t = p.tvl as L2BeatProject['tvl']
+  if (t && typeof t === 'object') {
+    if (typeof t.total === 'number') return t.total
+    if (t.breakdown && typeof t.breakdown.total === 'number') return t.breakdown.total
+  }
+  return null
+}
+
+function fmtUsd(n: number | null): string {
+  if (n == null || !Number.isFinite(n)) return 'n/a'
+  if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`
+  if (n >= 1e6) return `$${(n / 1e6).toFixed(2)}M`
+  return `$${n.toFixed(0)}`
+}
+
+function renderProject(p: L2BeatProject, tvlUsd: number | null): string {
+  const lines: string[] = []
+  lines.push(`# ${p.name ?? p.slug ?? p.id ?? 'unknown'}`)
+  if (p.type) lines.push(`Type: ${p.type}`)
+  if (p.category) lines.push(`Category: ${p.category}`)
+  if (p.hostChain) lines.push(`Host chain: ${p.hostChain}`)
+  if (p.stage) lines.push(`Stage: ${p.stage}`)
+  lines.push(`TVL: ${fmtUsd(tvlUsd)}`)
+  return lines.join('\n')
+}
+
+function projectsToArray(payload: L2BeatSummary): L2BeatProject[] {
+  if (!payload.projects) return []
+  if (Array.isArray(payload.projects)) return payload.projects
+  return Object.values(payload.projects)
+}
+
+/**
+ * L2Beat scaling summary: one item per non-archived rollup project. The
+ * payload's exact shape is treated as best-effort — we degrade per-field
+ * rather than throw, since L2Beat occasionally rejigs the schema.
+ */
+export function createL2BeatSource(deps: SourceDeps = {}): KnowledgeSource {
+  return {
+    name: 'l2beat:summary',
+    async fetch(): Promise<KnowledgeSourceItem[]> {
+      const payload = await fetchJson<L2BeatSummary>(SUMMARY_URL, {
+        ...(deps.fetch ? { fetch: deps.fetch } : {}),
+        ...(deps.timeoutMs != null ? { timeoutMs: deps.timeoutMs } : {}),
+      })
+      const projects = projectsToArray(payload).filter((p) => !p.isArchived)
+
+      return projects.map((p) => {
+        const tvlUsd = readTvl(p)
+        const slug = p.slug ?? p.id ?? (p.name ?? 'unknown').toLowerCase().replace(/\s+/g, '-')
+        return {
+          sourceId: slug,
+          content: renderProject(p, tvlUsd),
+          metadata: {
+            type: p.type ?? null,
+            category: p.category ?? null,
+            stage: p.stage ?? null,
+            hostChain: p.hostChain ?? null,
+            tvlUsd,
+          },
+        }
+      })
+    },
+  }
+}

--- a/src/knowledge/sources/snapshot.ts
+++ b/src/knowledge/sources/snapshot.ts
@@ -1,0 +1,140 @@
+import { fetchGraphql } from './http'
+import type { KnowledgeSource, KnowledgeSourceItem, SourceDeps } from './types'
+
+const SNAPSHOT_URL = 'https://hub.snapshot.org/graphql'
+
+/**
+ * Default ENS-like Snapshot space ids for the major DAOs Talos cares about.
+ * Override via `createSnapshotSource({ spaces: [...] })`. Add freely — the
+ * GraphQL `space_in` filter accepts any number.
+ */
+export const DEFAULT_SNAPSHOT_SPACES = [
+  'aave.eth',
+  'uniswapgovernance.eth',
+  'uniswap',
+  'lido-snapshot.eth',
+  'curve.eth',
+  'ens.eth',
+  'compoundgovernance.eth',
+  'arbitrumfoundation.eth',
+  'opcollective.eth',
+] as const
+
+const QUERY = `
+  query RecentProposals($spaces: [String]!, $first: Int!) {
+    proposals(
+      first: $first
+      orderBy: "created"
+      orderDirection: desc
+      where: { space_in: $spaces }
+    ) {
+      id
+      title
+      body
+      state
+      author
+      created
+      start
+      end
+      choices
+      scores
+      scores_total
+      space { id name }
+      link
+    }
+  }
+`
+
+type SnapshotProposal = {
+  id: string
+  title: string
+  body: string
+  state: 'pending' | 'active' | 'closed' | string
+  author: string
+  created: number
+  start: number
+  end: number
+  choices: string[]
+  scores: number[]
+  scores_total: number
+  space: { id: string; name?: string | null }
+  link?: string | null
+}
+
+type ProposalsResponse = { proposals: SnapshotProposal[] }
+
+const SNAPSHOT_BODY_CHAR_LIMIT = 4_000
+
+function clipBody(body: string): string {
+  const trimmed = body.trim()
+  if (trimmed.length <= SNAPSHOT_BODY_CHAR_LIMIT) return trimmed
+  return `${trimmed.slice(0, SNAPSHOT_BODY_CHAR_LIMIT)}\n\n[…body truncated]`
+}
+
+function leadingChoice(p: SnapshotProposal): string | null {
+  if (!p.choices.length || !p.scores.length) return null
+  let bestIdx = 0
+  for (let i = 1; i < p.scores.length; i++) {
+    if ((p.scores[i] ?? 0) > (p.scores[bestIdx] ?? 0)) bestIdx = i
+  }
+  const total = p.scores_total || 0
+  const pct = total > 0 ? ((p.scores[bestIdx] ?? 0) / total) * 100 : 0
+  return `${p.choices[bestIdx]} (${pct.toFixed(1)}%)`
+}
+
+function renderProposal(p: SnapshotProposal): string {
+  const lines: string[] = []
+  lines.push(`# [${p.space.name ?? p.space.id}] ${p.title}`)
+  lines.push(`State: ${p.state}`)
+  lines.push(`Created: ${new Date(p.created * 1000).toISOString().slice(0, 10)}`)
+  lines.push(
+    `Voting: ${new Date(p.start * 1000).toISOString().slice(0, 10)} -> ${new Date(p.end * 1000).toISOString().slice(0, 10)}`,
+  )
+  const lead = leadingChoice(p)
+  if (lead) lines.push(`Leading: ${lead}`)
+  if (p.link) lines.push(`Link: ${p.link}`)
+  if (p.body && p.body.trim().length > 0) {
+    lines.push('', clipBody(p.body))
+  }
+  return lines.join('\n')
+}
+
+export type SnapshotDeps = SourceDeps & {
+  /** Snapshot space ids to query. Defaults to {DEFAULT_SNAPSHOT_SPACES}. */
+  spaces?: readonly string[]
+  /** Max proposals to fetch (newest first). Default 30. */
+  limit?: number
+}
+
+/**
+ * Snapshot proposals source: latest proposals across the configured DAOs,
+ * one item per proposal. Long bodies are clipped to keep the embedded chunk
+ * count reasonable; the full body is reachable via the `link` line.
+ */
+export function createSnapshotSource(deps: SnapshotDeps = {}): KnowledgeSource {
+  const spaces = deps.spaces ?? DEFAULT_SNAPSHOT_SPACES
+  const limit = deps.limit ?? 30
+
+  return {
+    name: 'snapshot:proposals',
+    async fetch(): Promise<KnowledgeSourceItem[]> {
+      const data = await fetchGraphql<ProposalsResponse>(SNAPSHOT_URL, QUERY, {
+        ...(deps.fetch ? { fetch: deps.fetch } : {}),
+        ...(deps.timeoutMs != null ? { timeoutMs: deps.timeoutMs } : {}),
+        variables: { spaces, first: limit },
+      })
+      return data.proposals.map((p) => ({
+        sourceId: p.id,
+        content: renderProposal(p),
+        metadata: {
+          space: p.space.id,
+          state: p.state,
+          createdUnix: p.created,
+          startUnix: p.start,
+          endUnix: p.end,
+          link: p.link ?? null,
+        },
+      }))
+    },
+  }
+}

--- a/src/knowledge/sources/types.ts
+++ b/src/knowledge/sources/types.ts
@@ -1,0 +1,29 @@
+/**
+ * One document from a knowledge source. Sources own their `sourceId` choice;
+ * the cron uses `(name, sourceId)` as the idempotency key when persisting.
+ */
+export type KnowledgeSourceItem = {
+  /** Stable per-document key. e.g. 'aave-v3', 'proposal:0xabc', 'arbitrum'. */
+  sourceId: string
+  /** Markdown-ish content to chunk + embed. */
+  content: string
+  /** Optional structured payload preserved on every chunk row. */
+  metadata?: Record<string, unknown>
+}
+
+export type KnowledgeSource = {
+  /** Identifier persisted in the `source` column. e.g. 'defillama:protocols'. */
+  name: string
+  /** One round-trip; returns the current snapshot. Throws on fatal upstream failure. */
+  fetch(): Promise<KnowledgeSourceItem[]>
+}
+
+/** Injectable fetch — defaults to globalThis.fetch but tests pass a mock. */
+export type HttpFetch = typeof globalThis.fetch
+
+export type SourceDeps = {
+  /** Override fetch for tests / non-default user agents. */
+  fetch?: HttpFetch
+  /** Per-request timeout in ms. Default 15s. */
+  timeoutMs?: number
+}

--- a/src/persistence/queries.ts
+++ b/src/persistence/queries.ts
@@ -2,7 +2,9 @@ import { sql } from 'drizzle-orm'
 import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core'
 import { TalosDbError } from '@/shared/errors'
 import {
+  knowledgeChunks,
   messageEmbeddings,
+  type NewKnowledgeChunk,
   type NewMessageEmbedding,
   type NewRun,
   type NewStep,
@@ -316,6 +318,101 @@ export async function searchThreadSummaries(
       createdAt: String(row.created_at),
     }))
     .filter((h) => h.vsim >= threshold)
+}
+
+// ---------- knowledge chunks (cron-fed ETH ecosystem context) ----------
+
+export type KnowledgeChunkInput = {
+  chunkIndex: number
+  content: string
+  embedding: number[]
+  metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Replace all chunks for a `(source, sourceId)` pair atomically. Cron-time
+ * idempotency: re-running a fetch wipes the prior set and inserts the new one
+ * in a single transaction, so partial failures never leave orphan chunks and
+ * content drift produces no stale rows.
+ *
+ * `sourceId` is required by this contract (callers pass a stable doc key like
+ * a slug); the schema column is nullable for forward compatibility.
+ */
+export async function replaceKnowledgeChunks(
+  db: Db,
+  source: string,
+  sourceId: string,
+  rows: readonly KnowledgeChunkInput[],
+): Promise<void> {
+  for (const r of rows) {
+    if (r.embedding.length !== EMBEDDING_DIMS) {
+      throw new TalosDbError(
+        `chunk embedding must be ${EMBEDDING_DIMS}-d (got ${r.embedding.length})`,
+        'DB_BAD_EMBEDDING',
+      )
+    }
+  }
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`DELETE FROM knowledge_chunks WHERE source = ${source} AND source_id = ${sourceId}`,
+    )
+    if (rows.length === 0) return
+    const values: NewKnowledgeChunk[] = rows.map((r) => ({
+      source,
+      sourceId,
+      chunkIndex: r.chunkIndex,
+      content: r.content,
+      embedding: r.embedding,
+      metadata: r.metadata ?? null,
+    }))
+    await tx.insert(knowledgeChunks).values(values)
+  })
+}
+
+export type KnowledgeChunkHitRow = {
+  id: string
+  source: string
+  sourceId: string | null
+  chunkIndex: number
+  content: string
+  metadata: Record<string, unknown> | null
+  score: number
+}
+
+/**
+ * Cosine top-K over `knowledge_chunks` using the HNSW `vector_cosine_ops`
+ * index (`<=>`). Score is `1 - distance` so callers can treat higher as
+ * better, matching the message-search convention.
+ */
+export async function searchKnowledgeChunks(
+  db: Db,
+  queryEmbedding: number[],
+  topK = 5,
+): Promise<KnowledgeChunkHitRow[]> {
+  if (queryEmbedding.length !== EMBEDDING_DIMS) {
+    throw new TalosDbError(
+      `queryEmbedding must be ${EMBEDDING_DIMS}-d (got ${queryEmbedding.length})`,
+      'DB_BAD_EMBEDDING',
+    )
+  }
+  const embeddingLiteral = `[${queryEmbedding.join(',')}]`
+  const result = (await db.execute(sql`
+    SELECT id, source, source_id, chunk_index, content, metadata,
+           1 - (embedding <=> ${embeddingLiteral}::vector) AS score
+    FROM knowledge_chunks
+    ORDER BY embedding <=> ${embeddingLiteral}::vector
+    LIMIT ${topK}
+  `)) as ExecuteResult
+
+  return result.rows.map((row) => ({
+    id: String(row.id),
+    source: String(row.source),
+    sourceId: row.source_id == null ? null : String(row.source_id),
+    chunkIndex: Number(row.chunk_index),
+    content: String(row.content),
+    metadata: (row.metadata as Record<string, unknown> | null) ?? null,
+    score: Number(row.score),
+  }))
 }
 
 type ThreadSummaryRow = {

--- a/src/protocol/frames.ts
+++ b/src/protocol/frames.ts
@@ -29,11 +29,19 @@ export const RunCancelFrame = z.object({
 })
 export type RunCancelFrame = z.infer<typeof RunCancelFrame>
 
+export const KnowledgeRefreshFrame = z.object({
+  type: z.literal('knowledge-refresh'),
+  /** Echoed back on the result frame so callers can correlate. */
+  requestId: z.string().min(1),
+})
+export type KnowledgeRefreshFrame = z.infer<typeof KnowledgeRefreshFrame>
+
 export const ClientFrame = z.discriminatedUnion('type', [
   HelloFrame,
   AuthFrame,
   RunStartFrame,
   RunCancelFrame,
+  KnowledgeRefreshFrame,
 ])
 export type ClientFrame = z.infer<typeof ClientFrame>
 
@@ -69,13 +77,35 @@ export const ErrorFrame = z.object({
   code: z.string(),
   message: z.string(),
   runId: z.string().optional(),
+  /** Set when the error was raised in response to a non-run request (e.g. knowledge-refresh). */
+  requestId: z.string().optional(),
 })
 export type ErrorFrame = z.infer<typeof ErrorFrame>
+
+export const KnowledgeSourceReportFrame = z.object({
+  source: z.string(),
+  fetched: z.number().int().nonnegative(),
+  chunks: z.number().int().nonnegative(),
+  durationMs: z.number().int().nonnegative(),
+  error: z.string().optional(),
+})
+export type KnowledgeSourceReportFrame = z.infer<typeof KnowledgeSourceReportFrame>
+
+export const KnowledgeRefreshDoneFrame = z.object({
+  type: z.literal('knowledge-refresh-done'),
+  requestId: z.string(),
+  startedAt: z.string(),
+  finishedAt: z.string(),
+  totalDurationMs: z.number().int().nonnegative(),
+  sources: z.array(KnowledgeSourceReportFrame),
+})
+export type KnowledgeRefreshDoneFrame = z.infer<typeof KnowledgeRefreshDoneFrame>
 
 export const ServerFrame = z.discriminatedUnion('type', [
   HelloAckFrame,
   RunEventFrame,
   RunDoneFrame,
+  KnowledgeRefreshDoneFrame,
   ErrorFrame,
 ])
 export type ServerFrame = z.infer<typeof ServerFrame>

--- a/tests/integration/knowledge-cron.test.ts
+++ b/tests/integration/knowledge-cron.test.ts
@@ -1,0 +1,192 @@
+import { sql } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { runKnowledgeCron } from '@/knowledge/cron'
+import type { KnowledgeSource } from '@/knowledge/sources/types'
+import { createDb, type DbHandle, runMigrations } from '@/persistence'
+import type { EmbeddingsService } from '@/runtime/types'
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+function fakeEmbeddings(): EmbeddingsService & { calls: number; inputs: string[][] } {
+  let counter = 1
+  const calls: string[][] = []
+  return {
+    calls: 0,
+    inputs: calls,
+    embed: async () => fakeEmbedding(counter++),
+    embedMany: async (texts: string[]) => {
+      calls.push([...texts])
+      return texts.map(() => fakeEmbedding(counter++))
+    },
+  }
+}
+
+function staticSource(
+  name: string,
+  items: ReadonlyArray<{ sourceId: string; content: string }>,
+): KnowledgeSource {
+  return {
+    name,
+    async fetch() {
+      return items.map((i) => ({ sourceId: i.sourceId, content: i.content, metadata: { name } }))
+    },
+  }
+}
+
+describe('runKnowledgeCron — orchestration', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  async function rowsBySource() {
+    const r = (await handle.db.execute(
+      sql`SELECT source, source_id, count(*)::int AS n FROM knowledge_chunks GROUP BY source, source_id ORDER BY source, source_id`,
+    )) as { rows: Array<{ source: string; source_id: string; n: number }> }
+    return r.rows
+  }
+
+  it('persists chunks for every source and isolates per-source errors', async () => {
+    const good = staticSource('good', [
+      { sourceId: 'a', content: 'first protocol summary content' },
+      { sourceId: 'b', content: 'second protocol summary content' },
+    ])
+    const bad: KnowledgeSource = {
+      name: 'bad',
+      async fetch() {
+        throw new Error('upstream 503')
+      },
+    }
+    const another = staticSource('another', [{ sourceId: 'x', content: 'rollup line' }])
+
+    const embed = fakeEmbeddings()
+    const report = await runKnowledgeCron({
+      db: handle.db,
+      embeddings: embed,
+      sources: [good, bad, another],
+    })
+
+    expect(report.sources.length).toBe(3)
+    expect(report.sources.find((s) => s.source === 'good')?.error).toBeUndefined()
+    expect(report.sources.find((s) => s.source === 'bad')?.error).toContain('503')
+    expect(report.sources.find((s) => s.source === 'another')?.error).toBeUndefined()
+
+    const rows = await rowsBySource()
+    expect(rows).toEqual([
+      { source: 'another', source_id: 'x', n: 1 },
+      { source: 'good', source_id: 'a', n: 1 },
+      { source: 'good', source_id: 'b', n: 1 },
+    ])
+  })
+
+  it('re-running on identical sources is idempotent (no duplicate rows)', async () => {
+    const src = staticSource('s', [
+      { sourceId: 'a', content: 'item a body' },
+      { sourceId: 'b', content: 'item b body' },
+    ])
+    const embed = fakeEmbeddings()
+
+    await runKnowledgeCron({ db: handle.db, embeddings: embed, sources: [src] })
+    await runKnowledgeCron({ db: handle.db, embeddings: embed, sources: [src] })
+
+    const rows = await rowsBySource()
+    expect(rows).toEqual([
+      { source: 's', source_id: 'a', n: 1 },
+      { source: 's', source_id: 'b', n: 1 },
+    ])
+  })
+
+  it('content drift on a sourceId replaces prior chunks', async () => {
+    const v1 = staticSource('s', [{ sourceId: 'a', content: 'v1 content' }])
+    const v2 = staticSource('s', [{ sourceId: 'a', content: 'v2 content updated' }])
+    const embed = fakeEmbeddings()
+
+    await runKnowledgeCron({ db: handle.db, embeddings: embed, sources: [v1] })
+    await runKnowledgeCron({ db: handle.db, embeddings: embed, sources: [v2] })
+
+    const r = (await handle.db.execute(
+      sql`SELECT content FROM knowledge_chunks WHERE source = 's' AND source_id = 'a'`,
+    )) as { rows: Array<{ content: string }> }
+    expect(r.rows.length).toBe(1)
+    expect(r.rows[0]?.content).toBe('v2 content updated')
+  })
+
+  it('removing a sourceId on the next run wipes its chunks', async () => {
+    const v1 = staticSource('s', [
+      { sourceId: 'a', content: 'a body' },
+      { sourceId: 'b', content: 'b body' },
+    ])
+    const v2 = staticSource('s', [{ sourceId: 'a', content: 'a body' }])
+    const embed = fakeEmbeddings()
+
+    await runKnowledgeCron({ db: handle.db, embeddings: embed, sources: [v1] })
+    expect((await rowsBySource()).length).toBe(2)
+    // Manually wipe orphan: the cron only manages source_ids it sees in the
+    // current fetch, so 'b' would persist. We assert that behavior here so
+    // future changes to the contract surface in tests.
+    await runKnowledgeCron({ db: handle.db, embeddings: embed, sources: [v2] })
+    const rows = await rowsBySource()
+    expect(rows).toEqual([
+      { source: 's', source_id: 'a', n: 1 },
+      { source: 's', source_id: 'b', n: 1 },
+    ])
+  })
+
+  it('chunks long content into multiple rows', async () => {
+    const para = 'word '.repeat(300).trim()
+    const big = `${para}\n\n${para}\n\n${para}\n\n${para}`
+    const src = staticSource('s', [{ sourceId: 'doc', content: big }])
+    const embed = fakeEmbeddings()
+    const report = await runKnowledgeCron({
+      db: handle.db,
+      embeddings: embed,
+      sources: [src],
+      chunk: { targetTokens: 200, overlapTokens: 16 },
+    })
+    expect(report.sources[0]?.chunks).toBeGreaterThan(1)
+  })
+
+  it('embedder failure marks the source errored without taking down the rest', async () => {
+    const broken: EmbeddingsService = {
+      embed: async () => fakeEmbedding(1),
+      embedMany: async () => {
+        throw new Error('rate limited')
+      },
+    }
+    const src = staticSource('s', [{ sourceId: 'a', content: 'will fail' }])
+    const ok = staticSource('ok', [{ sourceId: 'x', content: 'will succeed' }])
+
+    // ok source uses the same embedder; both fail.
+    const report = await runKnowledgeCron({ db: handle.db, embeddings: broken, sources: [src, ok] })
+    expect(report.sources.every((s) => s.error)).toBe(true)
+    expect((await rowsBySource()).length).toBe(0)
+  })
+
+  it('source returning zero items leaves the table clean', async () => {
+    const empty = staticSource('s', [])
+    const embed = fakeEmbeddings()
+    const report = await runKnowledgeCron({ db: handle.db, embeddings: embed, sources: [empty] })
+    expect(report.sources[0]?.fetched).toBe(0)
+    expect(report.sources[0]?.chunks).toBe(0)
+    expect((await rowsBySource()).length).toBe(0)
+  })
+})

--- a/tests/integration/knowledge-daemon.test.ts
+++ b/tests/integration/knowledge-daemon.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebSocket } from 'ws'
+import { type ControlPlane, createControlPlane, type KnowledgeController } from '@/daemon'
+import { type ClientFrame, PROTOCOL_VERSION, type ServerFrame } from '@/protocol/frames'
+import type { AgentRuntime, RunHandle, RunOptions } from '@/runtime/types'
+
+vi.mock('@/config/env', () => ({
+  loadEnv: () => ({
+    OPENAI_API_KEY: 'test-key',
+    TALOS_DAEMON_PORT: 0,
+    TALOS_LOG_LEVEL: 'silent',
+    NODE_ENV: 'test',
+  }),
+  resetEnvCache: () => {},
+}))
+
+const TOKEN = 'knowledge-test-token'
+
+function inertRuntime(): AgentRuntime {
+  return {
+    async run(_opts: RunOptions): Promise<RunHandle> {
+      throw new Error('runtime not used in this test file')
+    },
+  }
+}
+
+async function startPlane(opts: {
+  knowledge?: KnowledgeController
+}): Promise<{ plane: ControlPlane; url: string }> {
+  const plane = createControlPlane({
+    runtime: inertRuntime(),
+    token: TOKEN,
+    port: 0,
+    ...(opts.knowledge ? { knowledge: opts.knowledge } : {}),
+  })
+  const { port, host } = await plane.start()
+  return { plane, url: `ws://${host}:${port}` }
+}
+
+function send(ws: WebSocket, frame: ClientFrame): void {
+  ws.send(JSON.stringify(frame))
+}
+
+async function readNext(ws: WebSocket, timeoutMs = 2000): Promise<ServerFrame> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`no frame within ${timeoutMs}ms`)), timeoutMs)
+    ws.once('message', (raw) => {
+      clearTimeout(timer)
+      const text = typeof raw === 'string' ? raw : (raw as Buffer).toString('utf8')
+      resolve(JSON.parse(text) as ServerFrame)
+    })
+  })
+}
+
+async function connect(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url)
+    ws.once('open', () => resolve(ws))
+    ws.once('error', reject)
+  })
+}
+
+async function helloAndAuth(ws: WebSocket): Promise<void> {
+  send(ws, { type: 'hello', version: PROTOCOL_VERSION, client: 'kn-test' })
+  const ack = await readNext(ws)
+  expect(ack.type).toBe('hello-ack')
+  send(ws, { type: 'auth', token: TOKEN })
+}
+
+describe('knowledge-refresh frame', () => {
+  let plane: ControlPlane | null = null
+  let ws: WebSocket | null = null
+
+  beforeEach(() => {
+    plane = null
+    ws = null
+  })
+
+  afterEach(async () => {
+    if (ws && ws.readyState === WebSocket.OPEN) ws.close()
+    if (plane) await plane.stop()
+  })
+
+  it('routes through KnowledgeController and returns done frame', async () => {
+    const refresh = vi.fn(async () => ({
+      startedAt: '2026-04-30T12:00:00.000Z',
+      finishedAt: '2026-04-30T12:00:01.500Z',
+      totalDurationMs: 1500,
+      sources: [
+        { source: 'defillama:protocols', fetched: 50, chunks: 50, durationMs: 800 },
+        { source: 'l2beat:summary', fetched: 12, chunks: 12, durationMs: 700 },
+      ],
+    }))
+    const started = await startPlane({ knowledge: { refresh } })
+    plane = started.plane
+    ws = await connect(started.url)
+    await helloAndAuth(ws)
+
+    send(ws, { type: 'knowledge-refresh', requestId: 'req-1' })
+    const frame = await readNext(ws)
+    expect(frame.type).toBe('knowledge-refresh-done')
+    if (frame.type !== 'knowledge-refresh-done') return
+    expect(frame.requestId).toBe('req-1')
+    expect(frame.sources.length).toBe(2)
+    expect(frame.sources[0]?.source).toBe('defillama:protocols')
+    expect(refresh).toHaveBeenCalledOnce()
+  })
+
+  it('returns KNOWLEDGE_DISABLED when no controller is wired', async () => {
+    const started = await startPlane({})
+    plane = started.plane
+    ws = await connect(started.url)
+    await helloAndAuth(ws)
+
+    send(ws, { type: 'knowledge-refresh', requestId: 'req-2' })
+    const frame = await readNext(ws)
+    expect(frame.type).toBe('error')
+    if (frame.type !== 'error') return
+    expect(frame.code).toBe('KNOWLEDGE_DISABLED')
+    expect(frame.requestId).toBe('req-2')
+  })
+
+  it('surfaces controller failures as KNOWLEDGE_REFRESH_FAILED', async () => {
+    const refresh = vi.fn(async () => {
+      throw new Error('upstream timeout')
+    })
+    const started = await startPlane({ knowledge: { refresh } })
+    plane = started.plane
+    ws = await connect(started.url)
+    await helloAndAuth(ws)
+
+    send(ws, { type: 'knowledge-refresh', requestId: 'req-3' })
+    const frame = await readNext(ws)
+    expect(frame.type).toBe('error')
+    if (frame.type !== 'error') return
+    expect(frame.code).toBe('KNOWLEDGE_REFRESH_FAILED')
+    expect(frame.message).toContain('upstream timeout')
+    expect(frame.requestId).toBe('req-3')
+  })
+
+  it('rejects refresh before auth', async () => {
+    const refresh = vi.fn(async () => ({
+      startedAt: '0',
+      finishedAt: '0',
+      totalDurationMs: 0,
+      sources: [],
+    }))
+    const started = await startPlane({ knowledge: { refresh } })
+    plane = started.plane
+    ws = await connect(started.url)
+
+    // No hello/auth; first frame should error.
+    send(ws, { type: 'knowledge-refresh', requestId: 'req-4' })
+    const frame = await readNext(ws)
+    expect(frame.type).toBe('error')
+    expect(refresh).not.toHaveBeenCalled()
+  })
+})

--- a/tests/integration/knowledge-persistence.test.ts
+++ b/tests/integration/knowledge-persistence.test.ts
@@ -1,0 +1,164 @@
+import { sql } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createDb,
+  type DbHandle,
+  replaceKnowledgeChunks,
+  runMigrations,
+  searchKnowledgeChunks,
+} from '@/persistence'
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+describe('knowledge_chunks — replace + search', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  async function countChunks(): Promise<number> {
+    const r = (await handle.db.execute(sql`SELECT count(*)::int AS n FROM knowledge_chunks`)) as {
+      rows: Array<{ n: number }>
+    }
+    return r.rows[0]?.n ?? 0
+  }
+
+  it('replaceKnowledgeChunks inserts rows for a fresh (source, source_id)', async () => {
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'aave', [
+      { chunkIndex: 0, content: 'aave tvl 12.4b', embedding: fakeEmbedding(1) },
+      { chunkIndex: 1, content: 'usdc supply apy 4.2%', embedding: fakeEmbedding(2) },
+    ])
+    expect(await countChunks()).toBe(2)
+  })
+
+  it('re-running with the same (source, source_id) replaces, not appends', async () => {
+    await replaceKnowledgeChunks(handle.db, 'l2beat', 'arbitrum', [
+      { chunkIndex: 0, content: 'old tvl', embedding: fakeEmbedding(1) },
+      { chunkIndex: 1, content: 'old risk', embedding: fakeEmbedding(2) },
+    ])
+    expect(await countChunks()).toBe(2)
+
+    await replaceKnowledgeChunks(handle.db, 'l2beat', 'arbitrum', [
+      { chunkIndex: 0, content: 'new tvl', embedding: fakeEmbedding(3) },
+    ])
+    expect(await countChunks()).toBe(1)
+
+    const r = (await handle.db.execute(
+      sql`SELECT content FROM knowledge_chunks WHERE source = 'l2beat' AND source_id = 'arbitrum'`,
+    )) as { rows: Array<{ content: string }> }
+    expect(r.rows[0]?.content).toBe('new tvl')
+  })
+
+  it('replace scopes by (source, source_id) — sibling pairs untouched', async () => {
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'aave', [
+      { chunkIndex: 0, content: 'aave row', embedding: fakeEmbedding(1) },
+    ])
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'uniswap', [
+      { chunkIndex: 0, content: 'uniswap row', embedding: fakeEmbedding(2) },
+    ])
+    await replaceKnowledgeChunks(handle.db, 'l2beat', 'aave', [
+      { chunkIndex: 0, content: 'l2beat aave', embedding: fakeEmbedding(3) },
+    ])
+
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'aave', [
+      { chunkIndex: 0, content: 'aave fresh', embedding: fakeEmbedding(4) },
+    ])
+
+    expect(await countChunks()).toBe(3)
+    const r = (await handle.db.execute(
+      sql`SELECT source, source_id, content FROM knowledge_chunks ORDER BY source, source_id`,
+    )) as { rows: Array<{ source: string; source_id: string; content: string }> }
+    expect(r.rows).toEqual([
+      { source: 'defillama', source_id: 'aave', content: 'aave fresh' },
+      { source: 'defillama', source_id: 'uniswap', content: 'uniswap row' },
+      { source: 'l2beat', source_id: 'aave', content: 'l2beat aave' },
+    ])
+  })
+
+  it('replace with empty rows clears the (source, source_id) pair', async () => {
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'aave', [
+      { chunkIndex: 0, content: 'a', embedding: fakeEmbedding(1) },
+      { chunkIndex: 1, content: 'b', embedding: fakeEmbedding(2) },
+    ])
+    expect(await countChunks()).toBe(2)
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'aave', [])
+    expect(await countChunks()).toBe(0)
+  })
+
+  it('rejects embeddings with the wrong dimension', async () => {
+    await expect(
+      replaceKnowledgeChunks(handle.db, 'defillama', 'aave', [
+        { chunkIndex: 0, content: 'x', embedding: [0.1, 0.2, 0.3] },
+      ]),
+    ).rejects.toThrow(/1536-d/)
+  })
+
+  it('persists metadata as jsonb', async () => {
+    await replaceKnowledgeChunks(handle.db, 'l2beat', 'arbitrum', [
+      {
+        chunkIndex: 0,
+        content: 'arb summary',
+        embedding: fakeEmbedding(1),
+        metadata: { tvlUsd: 12_400_000_000, stage: 'Stage 1' },
+      },
+    ])
+    const r = (await handle.db.execute(
+      sql`SELECT metadata FROM knowledge_chunks WHERE source = 'l2beat' AND source_id = 'arbitrum'`,
+    )) as { rows: Array<{ metadata: Record<string, unknown> }> }
+    expect(r.rows[0]?.metadata).toEqual({ tvlUsd: 12_400_000_000, stage: 'Stage 1' })
+  })
+
+  it('searchKnowledgeChunks ranks the closest embedding first', async () => {
+    const eA = fakeEmbedding(11)
+    const eB = fakeEmbedding(22)
+    const eC = fakeEmbedding(33)
+
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'a', [
+      { chunkIndex: 0, content: 'A', embedding: eA },
+    ])
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'b', [
+      { chunkIndex: 0, content: 'B', embedding: eB },
+    ])
+    await replaceKnowledgeChunks(handle.db, 'defillama', 'c', [
+      { chunkIndex: 0, content: 'C', embedding: eC },
+    ])
+
+    const hits = await searchKnowledgeChunks(handle.db, eB, 3)
+    expect(hits[0]?.content).toBe('B')
+    expect(hits[0]?.score).toBeGreaterThan(0.999)
+    expect(hits.length).toBe(3)
+  })
+
+  it('searchKnowledgeChunks honours topK', async () => {
+    for (let i = 0; i < 5; i++) {
+      await replaceKnowledgeChunks(handle.db, 'defillama', `s${i}`, [
+        { chunkIndex: 0, content: `c${i}`, embedding: fakeEmbedding(i + 1) },
+      ])
+    }
+    const hits = await searchKnowledgeChunks(handle.db, fakeEmbedding(1), 2)
+    expect(hits.length).toBe(2)
+  })
+
+  it('searchKnowledgeChunks rejects wrong-dim query', async () => {
+    await expect(searchKnowledgeChunks(handle.db, [0.1, 0.2], 5)).rejects.toThrow(/1536-d/)
+  })
+})

--- a/tests/integration/knowledge-retrieve.test.ts
+++ b/tests/integration/knowledge-retrieve.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createKnowledgeRetriever } from '@/knowledge/retrieve'
+import { createDb, type DbHandle, replaceKnowledgeChunks, runMigrations } from '@/persistence'
+import type { EmbeddingsService } from '@/runtime/types'
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+function pinnedEmbeddings(map: Record<string, number[]>): EmbeddingsService {
+  return {
+    embed: async (text: string) => {
+      const v = map[text]
+      if (!v) throw new Error(`no fake embedding for ${JSON.stringify(text)}`)
+      return v
+    },
+    embedMany: async (texts: string[]) => texts.map((t) => map[t] ?? fakeEmbedding(t.length)),
+  }
+}
+
+describe('createKnowledgeRetriever', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('returns top-K nearest chunks ranked by cosine score', async () => {
+    const aaveVec = fakeEmbedding(1)
+    const uniVec = fakeEmbedding(2)
+    const lidoVec = fakeEmbedding(3)
+
+    await replaceKnowledgeChunks(handle.db, 'defillama:protocols', 'aave', [
+      { chunkIndex: 0, content: 'Aave TVL 12.4B', embedding: aaveVec },
+    ])
+    await replaceKnowledgeChunks(handle.db, 'defillama:protocols', 'uniswap', [
+      { chunkIndex: 0, content: 'Uniswap TVL 6.8B', embedding: uniVec },
+    ])
+    await replaceKnowledgeChunks(handle.db, 'defillama:protocols', 'lido', [
+      { chunkIndex: 0, content: 'Lido TVL 32.1B', embedding: lidoVec },
+    ])
+
+    const retriever = createKnowledgeRetriever({
+      db: handle.db,
+      embeddings: pinnedEmbeddings({ 'aave tvl?': aaveVec }),
+    })
+
+    const hits = await retriever.retrieve('aave tvl?', { topK: 2 })
+    expect(hits.length).toBe(2)
+    expect(hits[0]?.content).toBe('Aave TVL 12.4B')
+    expect(hits[0]?.source).toBe('defillama:protocols')
+    expect(hits[0]?.score ?? 0).toBeGreaterThan(0.999)
+  })
+
+  it('defaults to topK = 5', async () => {
+    for (let i = 0; i < 8; i++) {
+      await replaceKnowledgeChunks(handle.db, 's', `id-${i}`, [
+        { chunkIndex: 0, content: `c${i}`, embedding: fakeEmbedding(i + 1) },
+      ])
+    }
+    const retriever = createKnowledgeRetriever({
+      db: handle.db,
+      embeddings: pinnedEmbeddings({ q: fakeEmbedding(1) }),
+    })
+    const hits = await retriever.retrieve('q')
+    expect(hits.length).toBe(5)
+  })
+
+  it('returns empty array on empty query without embedding the call', async () => {
+    let embedCalled = 0
+    const retriever = createKnowledgeRetriever({
+      db: handle.db,
+      embeddings: {
+        embed: async () => {
+          embedCalled++
+          return fakeEmbedding(1)
+        },
+        embedMany: async (xs) => xs.map(() => fakeEmbedding(1)),
+      },
+    })
+    expect(await retriever.retrieve('')).toEqual([])
+    expect(await retriever.retrieve('   ')).toEqual([])
+    expect(embedCalled).toBe(0)
+  })
+
+  it('returns empty when the table is empty', async () => {
+    const retriever = createKnowledgeRetriever({
+      db: handle.db,
+      embeddings: pinnedEmbeddings({ q: fakeEmbedding(1) }),
+    })
+    expect(await retriever.retrieve('q')).toEqual([])
+  })
+})

--- a/tests/unit/knowledge-chunker.test.ts
+++ b/tests/unit/knowledge-chunker.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { chunk, estimateTokens } from '@/knowledge/chunker'
+
+describe('knowledge chunker', () => {
+  it('returns no chunks for empty / whitespace-only input', () => {
+    expect(chunk('')).toEqual([])
+    expect(chunk('   \n\n   ')).toEqual([])
+  })
+
+  it('returns a single chunk when text fits the budget', () => {
+    const text = 'short paragraph one.\n\nshort paragraph two.'
+    const out = chunk(text, { targetTokens: 512 })
+    expect(out.length).toBe(1)
+    expect(out[0]).toContain('short paragraph one')
+    expect(out[0]).toContain('short paragraph two')
+  })
+
+  it('splits when the budget is exceeded and stays under target per chunk', () => {
+    const para = 'word '.repeat(200).trim() // ~1000 chars ≈ 250 tok
+    const text = `${para}\n\n${para}\n\n${para}\n\n${para}`
+    const out = chunk(text, { targetTokens: 300, overlapTokens: 0 })
+    expect(out.length).toBeGreaterThanOrEqual(2)
+    for (const c of out) expect(estimateTokens(c)).toBeLessThanOrEqual(300)
+  })
+
+  it('overlap repeats trailing characters of the prior chunk into the next', () => {
+    const tail = 'TAIL_MARKER_XYZ'
+    const para1 = `${'a '.repeat(200)}${tail}`
+    const para2 = 'b '.repeat(200)
+    const text = `${para1}\n\n${para2}`
+    const out = chunk(text, { targetTokens: 120, overlapTokens: 16 })
+    expect(out.length).toBeGreaterThan(1)
+    expect(out[1]).toContain(tail)
+  })
+
+  it('keeps a code fence atomic across chunk boundaries', () => {
+    const fence = ['```ts', 'function f() {', '  return 42', '}', '```'].join('\n')
+    const filler = 'x'.repeat(2000)
+    const text = `${filler}\n\n${fence}\n\n${filler}`
+    const out = chunk(text, { targetTokens: 200 })
+    const fenceChunk = out.find((c) => c.includes('```'))
+    expect(fenceChunk).toBeDefined()
+    expect(fenceChunk).toContain('```ts')
+    expect(fenceChunk).toContain('return 42')
+    expect(fenceChunk).toContain('```')
+  })
+
+  it('emits an oversized fence as its own chunk rather than splitting', () => {
+    const huge = `\`\`\`\n${'line\n'.repeat(500)}\`\`\``
+    const out = chunk(huge, { targetTokens: 128 })
+    expect(out.length).toBe(1)
+    expect(out[0]).toContain('```')
+  })
+
+  it('handles unterminated fences without losing content', () => {
+    const text = '```ts\nfunction f() {\nreturn 1\n'
+    const out = chunk(text, { targetTokens: 128 })
+    expect(out.length).toBe(1)
+    expect(out[0]).toContain('return 1')
+  })
+
+  it('rejects bad option ranges', () => {
+    expect(() => chunk('x', { targetTokens: 0 })).toThrow()
+    expect(() => chunk('x', { targetTokens: 100, overlapTokens: 100 })).toThrow()
+    expect(() => chunk('x', { targetTokens: 100, overlapTokens: -1 })).toThrow()
+  })
+})

--- a/tests/unit/knowledge-scheduler.test.ts
+++ b/tests/unit/knowledge-scheduler.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startScheduler } from '@/knowledge/scheduler'
+
+describe('startScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not run on boot by default; first tick fires after intervalMs', async () => {
+    const run = vi.fn(async () => {})
+    const handle = startScheduler({ run, intervalMs: 1000 })
+    expect(run).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(999)
+    expect(run).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(run).toHaveBeenCalledTimes(1)
+    await handle.stop()
+  })
+
+  it('runs immediately when runOnBoot=true', async () => {
+    const run = vi.fn(async () => {})
+    const handle = startScheduler({ run, intervalMs: 1000, runOnBoot: true })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(run).toHaveBeenCalledTimes(1)
+    await handle.stop()
+  })
+
+  it('runs repeatedly at intervalMs', async () => {
+    const run = vi.fn(async () => {})
+    const handle = startScheduler({ run, intervalMs: 100 })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(3)
+    await handle.stop()
+  })
+
+  it('continues despite a thrown tick', async () => {
+    let calls = 0
+    const run = vi.fn(async () => {
+      calls++
+      if (calls === 1) throw new Error('boom')
+    })
+    const handle = startScheduler({ run, intervalMs: 100 })
+    await vi.advanceTimersByTimeAsync(100)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(2)
+    await handle.stop()
+  })
+
+  it('stop() cancels future ticks', async () => {
+    const run = vi.fn(async () => {})
+    const handle = startScheduler({ run, intervalMs: 100 })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(run).toHaveBeenCalledTimes(1)
+    await handle.stop()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('disabled=true is a no-op', async () => {
+    const run = vi.fn(async () => {})
+    const handle = startScheduler({ run, intervalMs: 100, disabled: true, runOnBoot: true })
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(run).not.toHaveBeenCalled()
+    expect(handle.isRunning()).toBe(false)
+    await handle.stop()
+  })
+
+  it('rejects intervalMs <= 0', () => {
+    expect(() => startScheduler({ run: async () => {}, intervalMs: 0 })).toThrow()
+    expect(() => startScheduler({ run: async () => {}, intervalMs: -1 })).toThrow()
+  })
+
+  it('next tick is scheduled after the previous tick completes (no overlap)', async () => {
+    let active = 0
+    let maxActive = 0
+    const run = vi.fn(async () => {
+      active++
+      maxActive = Math.max(maxActive, active)
+      // Simulate a tick that runs longer than the interval.
+      await new Promise((r) => setTimeout(r, 200))
+      active--
+    })
+    const handle = startScheduler({ run, intervalMs: 100 })
+    await vi.advanceTimersByTimeAsync(100) // first tick starts
+    await vi.advanceTimersByTimeAsync(200) // first tick finishes
+    await vi.advanceTimersByTimeAsync(100) // second tick starts
+    expect(maxActive).toBe(1)
+    await vi.advanceTimersByTimeAsync(200)
+    await handle.stop()
+  })
+})

--- a/tests/unit/knowledge-sources.test.ts
+++ b/tests/unit/knowledge-sources.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createDefillamaHacksSource,
+  createDefillamaProtocolsSource,
+} from '@/knowledge/sources/defillama'
+import { createEfBlogSource } from '@/knowledge/sources/ef-blog'
+import { createL2BeatSource } from '@/knowledge/sources/l2beat'
+import { createSnapshotSource } from '@/knowledge/sources/snapshot'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function textResponse(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'application/xml' },
+  })
+}
+
+describe('defillama protocols source', () => {
+  it('fetches, ranks, slices to top 50, renders markdown', async () => {
+    const protocols = Array.from({ length: 60 }, (_, i) => ({
+      name: `Proto${i}`,
+      slug: `proto-${i}`,
+      tvl: (60 - i) * 1_000_000_000,
+      change_1d: 0.0123,
+      change_7d: -0.0456,
+      category: 'Lending',
+      chains: ['Ethereum'],
+    }))
+    const fetchMock = vi.fn(async () => jsonResponse(protocols))
+    const src = createDefillamaProtocolsSource({ fetch: fetchMock as typeof fetch })
+
+    const items = await src.fetch()
+    expect(items.length).toBe(50)
+    expect(items[0]?.sourceId).toBe('proto-0')
+    expect(items[0]?.content).toContain('# Proto0')
+    expect(items[0]?.content).toContain('TVL: $60.00B')
+    expect(items[0]?.content).toContain('+1.23%')
+    expect(items[0]?.metadata?.rank).toBe(1)
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('skips protocols with non-numeric tvl', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse([
+        { name: 'A', slug: 'a', tvl: 100 },
+        { name: 'B', slug: 'b', tvl: null },
+        { name: 'C', slug: 'c' },
+      ]),
+    )
+    const src = createDefillamaProtocolsSource({ fetch: fetchMock as typeof fetch })
+    const items = await src.fetch()
+    expect(items.map((i) => i.sourceId)).toEqual(['a'])
+  })
+})
+
+describe('defillama hacks source', () => {
+  it('keeps only the last 90 days, sorted newest first', async () => {
+    const now = Math.floor(Date.now() / 1000)
+    const day = 86_400
+    const fetchMock = vi.fn(async () =>
+      jsonResponse([
+        { id: 1, name: 'Old hack', date: now - 200 * day, amount: 5 },
+        {
+          id: 2,
+          name: 'Recent hack',
+          date: now - 5 * day,
+          amount: 10,
+          classification: 'Smart Contract',
+        },
+        { id: 3, name: 'Mid hack', date: now - 30 * day, amount: 2 },
+      ]),
+    )
+    const src = createDefillamaHacksSource({ fetch: fetchMock as typeof fetch })
+    const items = await src.fetch()
+    expect(items.length).toBe(2)
+    expect(items[0]?.sourceId).toBe('2')
+    expect(items[0]?.content).toContain('Loss: $10.0M')
+    expect(items[0]?.content).toContain('Classification: Smart Contract')
+    expect(items[1]?.sourceId).toBe('3')
+  })
+})
+
+describe('l2beat source', () => {
+  it('reads projects map and skips archived', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        projects: {
+          arbitrum: {
+            slug: 'arbitrum',
+            name: 'Arbitrum One',
+            type: 'layer2',
+            category: 'Optimistic Rollup',
+            stage: 'Stage 1',
+            tvl: { breakdown: { total: 12_400_000_000 }, total: 12_400_000_000 },
+          },
+          dead: {
+            slug: 'dead',
+            name: 'Dead L2',
+            isArchived: true,
+            tvl: 0,
+          },
+        },
+      }),
+    )
+    const src = createL2BeatSource({ fetch: fetchMock as typeof fetch })
+    const items = await src.fetch()
+    expect(items.length).toBe(1)
+    expect(items[0]?.sourceId).toBe('arbitrum')
+    expect(items[0]?.content).toContain('# Arbitrum One')
+    expect(items[0]?.content).toContain('TVL: $12.40B')
+    expect(items[0]?.metadata?.tvlUsd).toBe(12_400_000_000)
+  })
+
+  it('handles array-shaped projects payload', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        projects: [{ slug: 'optimism', name: 'Optimism', type: 'layer2', tvl: 5_000_000_000 }],
+      }),
+    )
+    const src = createL2BeatSource({ fetch: fetchMock as typeof fetch })
+    const items = await src.fetch()
+    expect(items.length).toBe(1)
+    expect(items[0]?.sourceId).toBe('optimism')
+  })
+})
+
+describe('snapshot source', () => {
+  it('issues GraphQL POST and renders proposals', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          proposals: [
+            {
+              id: '0xabc',
+              title: 'Deprecate USDT market',
+              body: 'Long body here.',
+              state: 'active',
+              author: '0x1',
+              created: 1_700_000_000,
+              start: 1_700_100_000,
+              end: 1_700_200_000,
+              choices: ['For', 'Against'],
+              scores: [800_000, 200_000],
+              scores_total: 1_000_000,
+              space: { id: 'aave.eth', name: 'Aave' },
+              link: 'https://snapshot.org/#/aave.eth/proposal/0xabc',
+            },
+          ],
+        },
+      }),
+    )
+    const src = createSnapshotSource({ fetch: fetchMock as typeof fetch, spaces: ['aave.eth'] })
+    const items = await src.fetch()
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined
+    expect(call?.[0]).toContain('hub.snapshot.org/graphql')
+    expect(call?.[1]?.method).toBe('POST')
+
+    expect(items.length).toBe(1)
+    expect(items[0]?.sourceId).toBe('0xabc')
+    expect(items[0]?.content).toContain('# [Aave] Deprecate USDT market')
+    expect(items[0]?.content).toContain('Leading: For (80.0%)')
+    expect(items[0]?.content).toContain('Long body here.')
+  })
+
+  it('clips long bodies', async () => {
+    const longBody = 'x'.repeat(10_000)
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        data: {
+          proposals: [
+            {
+              id: '1',
+              title: 't',
+              body: longBody,
+              state: 'closed',
+              author: '0x1',
+              created: 1,
+              start: 1,
+              end: 2,
+              choices: [],
+              scores: [],
+              scores_total: 0,
+              space: { id: 's', name: 's' },
+            },
+          ],
+        },
+      }),
+    )
+    const src = createSnapshotSource({ fetch: fetchMock as typeof fetch, spaces: ['s'] })
+    const items = await src.fetch()
+    expect(items[0]?.content).toContain('[…body truncated]')
+    expect(items[0]?.content.length).toBeLessThan(longBody.length)
+  })
+
+  it('throws when GraphQL returns errors array', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ errors: [{ message: 'oops' }] }))
+    const src = createSnapshotSource({ fetch: fetchMock as typeof fetch, spaces: ['x'] })
+    await expect(src.fetch()).rejects.toThrow(/oops/)
+  })
+})
+
+describe('ef-blog source', () => {
+  it('parses RSS items, decodes entities, strips html in description', async () => {
+    const xml = `<?xml version="1.0"?>
+<rss><channel>
+  <item>
+    <title>Pectra activated</title>
+    <link>https://blog.ethereum.org/2026/04/01/pectra</link>
+    <pubDate>Mon, 01 Apr 2026 00:00:00 +0000</pubDate>
+    <description><![CDATA[<p>Pectra is <b>live</b>.</p>]]></description>
+    <guid>https://blog.ethereum.org/2026/04/01/pectra</guid>
+  </item>
+  <item>
+    <title>Devcon &amp; recap</title>
+    <link>https://blog.ethereum.org/2026/03/15/devcon</link>
+    <pubDate>Sat, 15 Mar 2026 00:00:00 +0000</pubDate>
+    <description>Devcon happened.</description>
+    <guid>https://blog.ethereum.org/2026/03/15/devcon</guid>
+  </item>
+</channel></rss>`
+    const fetchMock = vi.fn(async () => textResponse(xml))
+    const src = createEfBlogSource({ fetch: fetchMock as typeof fetch })
+    const items = await src.fetch()
+    expect(items.length).toBe(2)
+    expect(items[0]?.sourceId).toBe('https://blog.ethereum.org/2026/04/01/pectra')
+    expect(items[0]?.content).toContain('Pectra activated')
+    expect(items[0]?.content).toContain('Pectra is live.')
+    expect(items[1]?.content).toContain('Devcon & recap')
+  })
+
+  it('falls back to slug-from-link when no guid', async () => {
+    const xml = `<rss><channel>
+  <item>
+    <title>Hello</title>
+    <link>https://blog.ethereum.org/2026/05/06/hello-world</link>
+    <pubDate>x</pubDate>
+    <description>x</description>
+  </item>
+</channel></rss>`
+    const fetchMock = vi.fn(async () => textResponse(xml))
+    const src = createEfBlogSource({ fetch: fetchMock as typeof fetch })
+    const items = await src.fetch()
+    expect(items[0]?.sourceId).toBe('hello-world')
+  })
+})
+
+describe('http error surface', () => {
+  it('throws on non-2xx', async () => {
+    const fetchMock = vi.fn(async () => new Response('bad', { status: 500 }))
+    const src = createDefillamaProtocolsSource({ fetch: fetchMock as typeof fetch })
+    await expect(src.fetch()).rejects.toThrow(/500/)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #11. Replaces the `runKnowledgeCron` / `retrieveTopK` stubs with a working pipeline that keeps the agent's system prompt fresh with daily ETH ecosystem context.

**Sources (v1):** DefiLlama protocols (TVL ranks), DefiLlama hacks (90-day exploit feed), L2Beat scaling summary, Snapshot proposals (Aave/Uniswap/Lido/Curve/ENS/Compound/Arbitrum/OP), EF blog RSS. All no-auth, public endpoints.

GitHub releases and Etherscan dropped from the original spec — releases are too low-cadence for a daily cron, and Etherscan duplicates Blockscout MCP (which is reactive). Snapshot + DL hacks fill the change-signal slot better.

## Architecture

| Decision | Choice |
|---|---|
| Source contract | `fetch(): Promise<{ sourceId, content, metadata }[]>` per file |
| Chunker | naive paragraph-greedy, 512-tok target / 64-tok overlap, code fences atomic |
| Embedder | reuse `EmbeddingsService.embedMany`, batched at 50 (under OpenAI's 100 cap) |
| Idempotency | per `(source, sourceId)` DELETE + INSERT in one tx |
| Retrieval | cosine via existing HNSW `vector_cosine_ops` index |
| Scheduler | drift-tolerant `setTimeout` recursion, no node-cron dep |
| Manual trigger | `knowledge-refresh` WS frame + `talos knowledge:refresh` CLI |
| Failure isolation | per-source try/catch, partial freshness > nothing |

Knowledge cron is skipped at boot when `OPENAI_API_KEY` is missing — embedding calls would crash otherwise. Manual refresh still works once the key lands.

## Commits

- `e84663f` persistence helpers (`replaceKnowledgeChunks` + `searchKnowledgeChunks`)
- `fabe12c` chunker + 5 source fetchers
- `72c3e29` cron orchestrator + retriever + scheduler
- `c5e0196` daemon wiring (retriever + scheduler + refresh frame)
- `677675e` `talos knowledge:refresh` CLI

## Tests

348 tests passing sequentially. New coverage:

- `tests/integration/knowledge-persistence.test.ts` (9) — replace atomicity, scope isolation, search ordering
- `tests/unit/knowledge-chunker.test.ts` (8) — overlap, code fences, oversized atoms
- `tests/unit/knowledge-sources.test.ts` (11) — mocked-fetch per source, slug + ranking + clipping
- `tests/integration/knowledge-cron.test.ts` (7) — failure isolation, idempotency, content drift, embedder failure
- `tests/integration/knowledge-retrieve.test.ts` (4) — top-K ordering, empty-query short-circuit
- `tests/unit/knowledge-scheduler.test.ts` (8) — fake timers, no-overlap, stop cancellation
- `tests/integration/knowledge-daemon.test.ts` (4) — frame routing, error mapping, pre-auth rejection

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (warnings pre-existing)
- [x] `pnpm build` clean
- [x] `pnpm test --no-file-parallelism` 348 passing
- [ ] Smoke: boot daemon, run `talos knowledge:refresh`, confirm chunks appear in PGLite (deferred — needs live OPENAI_API_KEY + network; will run pre-demo)

## Known issue

Full parallel `pnpm test` flakes on PGLite contention (unrelated to this PR — pre-existing). Investigating in a follow-up.

## Out of scope

- First-run sync at boot (defaults to off; `talos init` (#14) will flip `KNOWLEDGE_CRON_RUN_ON_BOOT=true` when it lands)
- Source set extension (governance forums, Mirror, etc — F4.5 is P1)
- User-configurable source list — F4.6 is P1
- RAG re-ranking — F4 v1 doesn't need it