### PR TITLE
chore(test): fix PGLite contention in parallel test runs

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,14 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
+    // PGLite WASM init contends under high parallelism — each fresh ephemeral
+    // instance takes ~10x longer when 8+ workers race to initialize the WASM
+    // module simultaneously, blowing past the default 10s hook timeout. Cap
+    // workers to 4 (well under most CPU counts) and give beforeEach a 20s
+    // budget so transient pressure doesn't flake the suite.
+    pool: 'forks',
+    maxWorkers: 4,
+    hookTimeout: 20_000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary

Default vitest forks pool spawns ~half-CPU workers. On a 16-core box that's 8 concurrent forks each cold-importing PGLite WASM. Under that pressure, `PGlite.create()` takes ~10x longer than sequential and `beforeEach` blows past the 10s default hook timeout.

| Mode | Wall time | Result |
|---|---|---|
| Default (8 workers) | ~7m | 17 fail (hook timeout) |
| threads pool | ~7m | 17 fail (same) |
| `--max-workers=2` | 57s | ✅ all pass |
| `--max-workers=4` | 34s | ✅ all pass |
| sequential | 107s | ✅ all pass |

Cap to 4 workers (still 4x parallelism) + bump hook timeout to 20s for transient pressure.

## Root cause

`@electric-sql/pglite` ships a WASM module that's compiled fresh per-process. With N concurrent forks doing `PGlite.create()` simultaneously, each WASM JIT contends and per-call latency balloons from <1s to ~10s.

`maxWorkers: 4` keeps the suite well-utilized while staying under the contention threshold.

## Test plan

- [x] `pnpm test` → 348 passing, 43s wall
- [x] `pnpm typecheck` clean