### PR TITLE
feat(test): demo-flow eval (regression gate, F12.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:eval": "vitest run tests/eval",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/tests/eval/demo-flow.test.ts
+++ b/tests/eval/demo-flow.test.ts
@@ -1,9 +1,162 @@
-import { describe, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createDb, type DbHandle, runMigrations } from '@/persistence'
+import { AgentRegistry, createRuntime, TALOS_ETH_AGENT } from '@/runtime'
+import type { EmbeddingsService } from '@/runtime/types'
+import { createFixtureToolSource, FIXTURE_TOOL_NAMES, type FixtureCallLog } from './fixture-tools'
+import { formatTrace } from './format-trace'
+import { createDemoMockProvider, DEMO_FINAL_TEXT } from './mock-provider'
 
 /**
  * F12.16 — demo-flow eval (regression gate, P0 CRITICAL).
- * Wire this BEFORE adding the 4th MCP server.
+ *
+ * End-to-end agent run on the locked demo prompt against a mock LLM and
+ * fixture tools. Asserts:
+ *   1. Tool-call sequence equals [balance, quote, swap]
+ *   2. Final assistant message contains the balance, quoted USDC, and tx hash
+ *   3. Step count matches the recorded 4-step conversation
+ *   4. `runs.status` is `completed` and at least the user + assistant
+ *      message_embeddings landed
+ *
+ * The eval is fully deterministic: no live OpenAI, no live Sepolia, no
+ * real AgentKit init. Future PRs that change tool naming, drop a tool,
+ * regress the runtime loop, or break persistence on the happy path will
+ * fail here before merge.
  */
-describe('demo-flow eval', () => {
-  it.todo('end-to-end demo: balance → quote → swap on Sepolia')
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS)
+  let x = seed || 1
+  for (let i = 0; i < EMBEDDING_DIMS; i++) {
+    x = (x * 9301 + 49297) % 233280
+    v[i] = x / 233280 - 0.5
+  }
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm)
+  return v.map((n) => n / norm)
+}
+
+function deterministicEmbeddings(): EmbeddingsService {
+  let counter = 0
+  return {
+    embed: async () => fakeEmbedding(++counter),
+    embedMany: async (texts) => texts.map(() => fakeEmbedding(++counter)),
+  }
+}
+
+function withRegistry(): AgentRegistry {
+  const reg = new AgentRegistry()
+  reg.register(TALOS_ETH_AGENT, { default: true })
+  return reg
+}
+
+async function drain(handle: { fullStream: AsyncIterable<unknown>; done: Promise<void> }) {
+  const events: unknown[] = []
+  for await (const part of handle.fullStream) events.push(part)
+  await handle.done
+  return events
+}
+
+describe('demo-flow eval — F12.16', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+  })
+
+  afterEach(async () => {
+    await handle?.close()
+  })
+
+  it('emits balance -> quote -> swap and surfaces all three results in the final message', async () => {
+    const fixtureSource = createFixtureToolSource()
+    const runtime = createRuntime({
+      db: handle,
+      providers: createDemoMockProvider(),
+      embeddings: deterministicEmbeddings(),
+      agents: withRegistry(),
+      toolSources: [fixtureSource],
+      // No tool middleware — eval focuses on the demo path itself, not
+      // KeeperHub audit. `tool_calls` rows therefore stay empty (single-
+      // writer rule), but `steps` + `runs` are still written.
+    })
+
+    const run = await runtime.run({
+      threadId: 'eval:demo-flow',
+      channel: 'cli',
+      intent: "what's my eth balance, then quote me 0.01 ETH -> USDC on Sepolia, then execute",
+    })
+
+    await drain(run)
+
+    // 1. Tool-call sequence — fixture source records every execute() call.
+    const expectedSequence = [
+      FIXTURE_TOOL_NAMES.balance,
+      FIXTURE_TOOL_NAMES.quote,
+      FIXTURE_TOOL_NAMES.swap,
+    ]
+    const actualSequence = fixtureSource.calls
+    assertSequence(expectedSequence, actualSequence)
+
+    // 2. Tool-call args — sanity-check the agent forwarded the prompt's
+    //    numbers so a future regression that scrambles JSON wiring fails here.
+    expect(actualSequence[1]?.args).toMatchObject({
+      tokenIn: 'ETH',
+      tokenOut: 'USDC',
+      amountIn: '0.01',
+    })
+    expect(actualSequence[2]?.args).toMatchObject({
+      tokenIn: 'ETH',
+      tokenOut: 'USDC',
+      amountIn: '0.01',
+    })
+
+    // 3. Final assistant message — must mention balance, quoted USDC, tx hash.
+    const finalText = await readRunSummary(handle, run.runId)
+    expect(finalText, 'final assistant message empty').toBe(DEMO_FINAL_TEXT)
+    expect(finalText).toContain('1.0 ETH')
+    expect(finalText).toContain('25.00 USDC')
+    expect(finalText).toContain('0xabc')
+
+    // 4. Persistence — runs row completed, steps written, user + assistant
+    //    embeddings landed. Catches "agent looks fine in stream but fails
+    //    silently to persist" regressions.
+    const runRow = await handle.pg.query<{ status: string }>(
+      'SELECT status FROM runs WHERE id = $1',
+      [run.runId],
+    )
+    expect(runRow.rows[0]?.status).toBe('completed')
+
+    const stepRows = await handle.pg.query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM steps WHERE run_id = $1',
+      [run.runId],
+    )
+    expect(Number(stepRows.rows[0]?.count ?? '0')).toBe(4)
+
+    const embRows = await handle.pg.query<{ role: string; count: string }>(
+      `SELECT role, COUNT(*)::text AS count
+       FROM message_embeddings WHERE thread_id = 'eval:demo-flow'
+       GROUP BY role`,
+    )
+    expect(embRows.rows.find((r) => r.role === 'user')?.count).toBe('1')
+    expect(embRows.rows.find((r) => r.role === 'assistant')?.count).toBe('1')
+  })
 })
+
+function assertSequence(expected: readonly string[], actual: readonly FixtureCallLog[]): void {
+  const ok =
+    actual.length === expected.length && expected.every((name, i) => actual[i]?.name === name)
+  if (ok) return
+  throw new Error(`tool-call sequence mismatch\n${formatTrace(expected, actual)}`)
+}
+
+async function readRunSummary(handle: DbHandle, runId: string): Promise<string> {
+  const r = await handle.pg.query<{ summary: string | null }>(
+    'SELECT summary FROM runs WHERE id = $1',
+    [runId],
+  )
+  return r.rows[0]?.summary ?? ''
+}

--- a/tests/eval/fixture-tools.ts
+++ b/tests/eval/fixture-tools.ts
@@ -1,0 +1,105 @@
+import { type Tool, tool } from 'ai'
+import { z } from 'zod'
+import type { ToolSource } from '@/runtime/types'
+
+/**
+ * Fixture tool source for the demo-flow eval. Exposes the three tools the
+ * agent should call on the locked demo prompt — `agentkit_wallet_get_balance`,
+ * `uniswap_get_quote`, `uniswap_swap_exact_in` — each with a canned
+ * deterministic response so the eval is decoupled from real chain state,
+ * AgentKit init, and Uniswap pool liquidity.
+ *
+ * Names are chosen to match what the production tool sources expose:
+ *   - `uniswap_get_quote` and `uniswap_swap_exact_in` come from
+ *     `src/tools/uniswap/source.ts` directly.
+ *   - `agentkit_wallet_get_balance` follows AgentKit's
+ *     `WalletActionProvider_get_balance` after Talos's normalization
+ *     (`<Provider>ActionProvider_<rest>` -> `<provider>_<rest>`, then
+ *     namespaced with `agentkit_`).
+ *
+ * If production tool names drift, this file is the canonical place to
+ * realign — the eval asserts the names this source registers.
+ */
+
+export type FixtureCallLog = {
+  name: string
+  args: unknown
+}
+
+export const FIXTURE_TOOL_NAMES = {
+  balance: 'agentkit_wallet_get_balance',
+  quote: 'uniswap_get_quote',
+  swap: 'uniswap_swap_exact_in',
+} as const
+
+export const FIXTURE_BALANCE = {
+  ethBalance: '1.0',
+  address: '0xE11A4f4F4f5d2d4b5C6f3D2E1f0A9B8C7D6E5F4a',
+}
+
+export const FIXTURE_QUOTE = {
+  amountOut: '25000000', // 25 USDC (6 decimals)
+  fee: 3000,
+  poolAddress: '0xPoolDeadBeef',
+  poolLiquidity: '987654321000',
+}
+
+export const FIXTURE_SWAP = {
+  hash: '0xabc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+  status: 'success' as const,
+}
+
+/**
+ * Tool source surfacing the three demo tools with canned responses. The
+ * `calls` array on the returned source records every invocation in order so
+ * the eval can assert the precise tool-call sequence — independent of how
+ * the runtime emits stream events.
+ */
+export function createFixtureToolSource(): ToolSource & { calls: FixtureCallLog[] } {
+  const calls: FixtureCallLog[] = []
+
+  const tools: Record<string, Tool> = {
+    [FIXTURE_TOOL_NAMES.balance]: tool({
+      description: 'Read the wallet ETH balance on Sepolia (fixture).',
+      inputSchema: z.object({}).passthrough(),
+      execute: async (args) => {
+        calls.push({ name: FIXTURE_TOOL_NAMES.balance, args })
+        return FIXTURE_BALANCE
+      },
+    }),
+    [FIXTURE_TOOL_NAMES.quote]: tool({
+      description: 'Quote an exact-input swap on Uniswap V3 (fixture).',
+      inputSchema: z.object({
+        tokenIn: z.string(),
+        tokenOut: z.string(),
+        amountIn: z.string(),
+        fee: z.number().optional(),
+      }),
+      execute: async (args) => {
+        calls.push({ name: FIXTURE_TOOL_NAMES.quote, args })
+        return FIXTURE_QUOTE
+      },
+    }),
+    [FIXTURE_TOOL_NAMES.swap]: tool({
+      description: 'Execute an exact-input swap on Uniswap V3 (fixture).',
+      inputSchema: z.object({
+        tokenIn: z.string(),
+        tokenOut: z.string(),
+        amountIn: z.string(),
+        amountOutMinimum: z.string(),
+        fee: z.number().optional(),
+      }),
+      execute: async (args) => {
+        calls.push({ name: FIXTURE_TOOL_NAMES.swap, args })
+        return FIXTURE_SWAP
+      },
+    }),
+  }
+
+  return {
+    calls,
+    async getTools(): Promise<Record<string, Tool>> {
+      return tools
+    },
+  }
+}

--- a/tests/eval/format-trace.ts
+++ b/tests/eval/format-trace.ts
@@ -1,0 +1,41 @@
+import type { FixtureCallLog } from './fixture-tools'
+
+/**
+ * Pretty-prints a side-by-side diff of expected vs actual tool-call sequences.
+ * Used in the demo-flow eval's failure message so a regression points
+ * directly at the divergence (which call drifted, what args differed).
+ */
+export function formatTrace(
+  expected: readonly string[],
+  actual: readonly FixtureCallLog[],
+): string {
+  const lines: string[] = []
+  lines.push('expected vs actual tool-call sequence:')
+  const max = Math.max(expected.length, actual.length)
+  const padCol = 36
+  for (let i = 0; i < max; i++) {
+    const exp = expected[i] ?? '<missing>'
+    const got = actual[i]?.name ?? '<missing>'
+    const marker = exp === got ? ' ' : '!'
+    const entry = actual[i]
+    const argsTail = entry !== undefined ? `  args=${safeStringify(entry.args)}` : ''
+    lines.push(
+      `  ${marker} ${pad(`${i + 1}.`, 4)}${pad(`expected: ${exp}`, padCol)}` +
+        `actual: ${got}${argsTail}`,
+    )
+  }
+  return lines.join('\n')
+}
+
+function pad(s: string, n: number): string {
+  if (s.length >= n) return s
+  return s + ' '.repeat(n - s.length)
+}
+
+function safeStringify(v: unknown): string {
+  try {
+    return JSON.stringify(v)
+  } catch {
+    return String(v)
+  }
+}

--- a/tests/eval/mock-provider.ts
+++ b/tests/eval/mock-provider.ts
@@ -1,0 +1,106 @@
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test'
+import type { ProviderRouter } from '@/runtime/types'
+
+/**
+ * Mock LLM that replays the demo conversation deterministically. AI SDK v6
+ * calls `doStream` once per agent step (between tool-call resolutions); each
+ * call here returns the chunk set the agent should emit at that step.
+ *
+ * The recorded conversation matches the demo prompt:
+ *   "what's my eth balance, then quote me 0.01 ETH -> USDC on Sepolia, then execute"
+ *
+ * Step 1: tool-call `agentkit_wallet_get_balance`
+ * Step 2: tool-call `uniswap_get_quote`
+ * Step 3: tool-call `uniswap_swap_exact_in`
+ * Step 4: final text containing balance + quoted USDC + tx hash
+ *
+ * The shape of `StreamChunk` mirrors `LanguageModelV3StreamPart` but is kept
+ * structural so we don't take a transitive `@ai-sdk/provider` dependency in
+ * this test directory.
+ */
+
+type StreamChunk =
+  | { type: 'stream-start'; warnings: unknown[] }
+  | { type: 'text-start'; id: string }
+  | { type: 'text-delta'; id: string; delta: string }
+  | { type: 'text-end'; id: string }
+  | {
+      type: 'tool-call'
+      toolCallId: string
+      toolName: string
+      input: string
+    }
+  | {
+      type: 'finish'
+      usage: { inputTokens: number; outputTokens: number; totalTokens: number }
+      finishReason: 'tool-calls' | 'stop'
+    }
+
+const USAGE = { inputTokens: 12, outputTokens: 6, totalTokens: 18 }
+
+function toolCallStep(toolName: string, toolCallId: string, args: unknown): StreamChunk[] {
+  return [
+    { type: 'stream-start', warnings: [] },
+    {
+      type: 'tool-call',
+      toolCallId,
+      toolName,
+      input: JSON.stringify(args),
+    },
+    { type: 'finish', usage: USAGE, finishReason: 'tool-calls' },
+  ]
+}
+
+function textStep(text: string): StreamChunk[] {
+  return [
+    { type: 'stream-start', warnings: [] },
+    { type: 'text-start', id: 't-final' },
+    { type: 'text-delta', id: 't-final', delta: text },
+    { type: 'text-end', id: 't-final' },
+    { type: 'finish', usage: USAGE, finishReason: 'stop' },
+  ]
+}
+
+export const DEMO_FINAL_TEXT =
+  'Your wallet holds 1.0 ETH on Sepolia. ' +
+  '0.01 ETH quotes for 25.00 USDC at the 3000 bps fee tier. ' +
+  'Swap submitted: 0xabc123def456abc123def456abc123def456abc123def456abc123def456abc1.'
+
+export const DEMO_TOOL_ARGS = {
+  quote: {
+    tokenIn: 'ETH',
+    tokenOut: 'USDC',
+    amountIn: '0.01',
+    fee: 3000,
+  },
+  swap: {
+    tokenIn: 'ETH',
+    tokenOut: 'USDC',
+    amountIn: '0.01',
+    amountOutMinimum: '24750000', // 25.0 USDC * (1 - 1% slippage), 6 decimals
+    fee: 3000,
+  },
+} as const
+
+/**
+ * Build a `ProviderRouter` whose only model is the recorded demo conversation.
+ * Every call to `provider.resolve(...)` returns the same model so an agent
+ * configured with any `modelId` ends up here.
+ */
+export function createDemoMockProvider(): ProviderRouter {
+  const chunkSets: StreamChunk[][] = [
+    toolCallStep('agentkit_wallet_get_balance', 'tc-balance-1', {}),
+    toolCallStep('uniswap_get_quote', 'tc-quote-2', DEMO_TOOL_ARGS.quote),
+    toolCallStep('uniswap_swap_exact_in', 'tc-swap-3', DEMO_TOOL_ARGS.swap),
+    textStep(DEMO_FINAL_TEXT),
+  ]
+  let call = 0
+  const model = new MockLanguageModelV3({
+    doStream: async () => {
+      const chunks = chunkSets[call] ?? chunkSets[chunkSets.length - 1] ?? []
+      call++
+      return { stream: simulateReadableStream({ chunks }) } as never
+    },
+  })
+  return { resolve: () => model }
+}


### PR DESCRIPTION
## Summary

Closes #12. Replaces the `it.todo` placeholder in `tests/eval/demo-flow.test.ts` with a deterministic end-to-end eval on the locked demo prompt. From now on, any PR that breaks the demo path fails CI before merge.

## What it locks

**Prompt:** `"what's my eth balance, then quote me 0.01 ETH -> USDC on Sepolia, then execute"`

**Assertions:**
1. Tool-call sequence: `agentkit_wallet_get_balance` → `uniswap_get_quote` → `uniswap_swap_exact_in`
2. Tool args carry the prompt's numbers (`tokenIn`, `tokenOut`, `amountIn`)
3. Final assistant message contains balance, quoted USDC amount, tx hash
4. Step count = 4 (matches recorded conversation)
5. `runs.status = 'completed'` + user/assistant `message_embeddings` written

3 tools, not 4 — the prompt is `ETH -> USDC` and native ETH doesn't require an `approve` (sent as `msg.value` on the swap). Approve coverage lands in a follow-up if/when we add an ERC-20 → ERC-20 demo path.

## Architecture

| Decision | Choice |
|---|---|
| LLM | `MockLanguageModelV3` from `ai/test`, replays 4 chunk sets per `doStream` call |
| Tools | local `FixtureToolSource` with canned responses; records every `execute()` call for sequence assertion |
| DB | PGLite ephemeral, no middleware (eval focuses on demo path, not audit) |
| Embeddings | deterministic `fakeEmbedding(seed)` (matches existing pattern) |
| Failure surface | `formatTrace()` prints side-by-side diff with arg payloads on assertion fail |

## Files

```
tests/eval/
  demo-flow.test.ts      # the eval
  mock-provider.ts       # 4-step recorded conversation
  fixture-tools.ts       # 3-tool ToolSource w/ canned responses
  format-trace.ts        # pretty diff helper
```

Plus `package.json` script: `"test:eval": "vitest run tests/eval"`.

## Test plan

- [x] `pnpm test:eval` passes (~2s)
- [x] `pnpm test` passes — 349 passing (was 348 + 1 todo)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (32 pre-existing warnings unchanged)
- [x] `pnpm build` clean

## Out of scope

- Real OpenAI / live Sepolia testing — that's a separate manual smoke test before demo
- Approve coverage — relevant only when input token is ERC-20, not ETH
- Concurrent run + abort coverage — F12.13 / F12.19 (separate tests)