### PR TITLE
feat(channels): telegram bot adapter (closes #13 partial)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "pino-pretty": "latest",
     "viem": "latest",
     "ws": "latest",
+    "yaml": "^2.8.3",
     "zod": "latest",
     "zod-to-json-schema": "^3.25.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       ws:
         specifier: latest
         version: 8.20.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
       zod:
         specifier: latest
         version: 4.3.6
@@ -86,7 +89,7 @@ importers:
         version: 2.13.1
       tsup:
         specifier: latest
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
       tsx:
         specifier: latest
         version: 4.21.0
@@ -95,7 +98,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: latest
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -5215,6 +5218,11 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -8350,13 +8358,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -10894,13 +10902,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.12
       tsx: 4.21.0
+      yaml: 2.8.3
 
   postcss@8.5.12:
     dependencies:
@@ -11398,7 +11407,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -11409,7 +11418,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.12)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -11630,7 +11639,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0):
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -11643,11 +11652,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -11664,7 +11674,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -12003,6 +12013,8 @@ snapshots:
   y18n@4.0.3: {}
 
   y18n@5.0.8: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -7,6 +7,16 @@ export {
   runStdioMcpProxy,
 } from './mcp-server/server'
 export {
+  type ChannelsConfig,
+  createTelegramBot,
+  loadChannelsConfig,
+  resetChannelsConfigCache,
+  resolveBotToken,
+  type TelegramBotHandle,
+  type TelegramBotOpts,
+  type TelegramChannelConfig,
+} from './telegram'
+export {
   createDaemonClient,
   type DaemonClient,
   type DaemonClientOpts,

--- a/src/channels/telegram/bot.ts
+++ b/src/channels/telegram/bot.ts
@@ -171,8 +171,30 @@ export function createTelegramBot(opts: TelegramBotOpts): TelegramBotHandle {
       if (running) return
       running = true
       log.info('telegram bot starting (long-poll)')
-      await bot.start({
-        onStart: () => log.info('telegram bot connected'),
+      // grammY's bot.start() returns a long-running promise that only resolves
+      // when polling stops (via bot.stop()). Resolving our start() on that
+      // would mean "start completes when the bot ends" — wrong shape. Instead
+      // we resolve once polling is actually up (via the onStart callback) and
+      // let the long-running promise continue in the background, surfacing
+      // mid-flight failures via logs. Pre-onStart errors (bad token, network
+      // unreachable) propagate to the caller normally.
+      await new Promise<void>((resolve, reject) => {
+        let started = false
+        bot
+          .start({
+            onStart: () => {
+              started = true
+              log.info('telegram bot connected')
+              resolve()
+            },
+          })
+          .catch((err) => {
+            if (started) {
+              log.warn({ err }, 'telegram bot polling errored after start')
+            } else {
+              reject(err)
+            }
+          })
       })
     },
     async stop(): Promise<void> {

--- a/src/channels/telegram/bot.ts
+++ b/src/channels/telegram/bot.ts
@@ -1,0 +1,209 @@
+import { randomUUID } from 'node:crypto'
+import type { TextStreamPart, ToolSet } from 'ai'
+import { Bot, type Context } from 'grammy'
+import type { AgentRuntime } from '@/runtime/types'
+import { child } from '@/shared/logger'
+import type { TelegramChannelConfig } from './config'
+
+const log = child({ module: 'telegram-bot' })
+
+const EDIT_THROTTLE_MS = 1_100
+const THINKING_TEXT = '↻ thinking…'
+
+export type TelegramBotOpts = {
+  token: string
+  config: TelegramChannelConfig
+  runtime: AgentRuntime
+}
+
+export type TelegramBotHandle = {
+  start(): Promise<void>
+  stop(): Promise<void>
+}
+
+export function createTelegramBot(opts: TelegramBotOpts): TelegramBotHandle {
+  const bot = new Bot(opts.token)
+  const allowedUsers = new Set(opts.config.allowed_users.map((u) => u.toLowerCase()))
+  // Per-chat reset counter. Appended to threadId so /reset creates a fresh thread.
+  const chatResetSuffix = new Map<number, string>()
+  // In-flight run per chat — abort on new message or /reset.
+  const inflightAbort = new Map<number, AbortController>()
+  let running = false
+
+  function threadIdFor(chatId: number): string {
+    const suffix = chatResetSuffix.get(chatId)
+    return suffix ? `tg:${chatId}:${suffix}` : `tg:${chatId}`
+  }
+
+  function isAllowed(username: string | undefined, numericId: string | undefined): boolean {
+    // Empty whitelist = deny all (fail-closed for single-user model).
+    if (allowedUsers.size === 0) return false
+    // Match either @username or numeric userId.
+    if (username && allowedUsers.has(username.toLowerCase())) return true
+    if (numericId && allowedUsers.has(numericId)) return true
+    return false
+  }
+
+  function resolveUser(ctx: Context): { username?: string; numericId?: string } {
+    return {
+      username: ctx.from?.username ? `@${ctx.from.username}` : undefined,
+      numericId: ctx.from?.id ? String(ctx.from.id) : undefined,
+    }
+  }
+
+  // --- slash commands ---
+
+  bot.command('start', (ctx) =>
+    ctx.reply('Welcome to Talos. Send a message to chat with your ETH agent.'),
+  )
+
+  bot.command('help', (ctx) =>
+    ctx.reply(
+      'Commands:\n' +
+        '/start — welcome message\n' +
+        '/reset — start a fresh thread\n' +
+        '/help — this help\n\n' +
+        'Send any text to chat with the Talos agent.',
+    ),
+  )
+
+  bot.command('reset', async (ctx) => {
+    const { username, numericId } = resolveUser(ctx)
+    if (!isAllowed(username, numericId)) return
+    // Abort any in-flight run for this chat.
+    const ac = inflightAbort.get(ctx.chat.id)
+    if (ac) {
+      ac.abort()
+      inflightAbort.delete(ctx.chat.id)
+    }
+    // Rotate thread suffix so next message starts a fresh thread.
+    chatResetSuffix.set(ctx.chat.id, randomUUID())
+    await ctx.reply('Thread reset. Next message starts a new conversation.')
+  })
+
+  // --- message handler ---
+
+  bot.on('message:text', async (ctx) => {
+    const { username, numericId } = resolveUser(ctx)
+    if (!isAllowed(username, numericId)) return
+
+    const chatId = ctx.chat.id
+    const threadId = threadIdFor(chatId)
+    const prompt = ctx.message.text
+
+    // Abort any previous run for this chat before starting a new one.
+    const prevAc = inflightAbort.get(chatId)
+    if (prevAc) prevAc.abort()
+
+    const ac = new AbortController()
+    inflightAbort.set(chatId, ac)
+
+    const thinkingMsg = await ctx.reply(THINKING_TEXT)
+
+    let assembled = ''
+    const trace: string[] = [THINKING_TEXT]
+    let lastEditAt = Date.now()
+    let finalReached = false
+
+    try {
+      const handle = await opts.runtime.run({
+        threadId,
+        channel: 'telegram',
+        intent: prompt,
+        abortSignal: ac.signal,
+      })
+
+      // Capture done-promise errors like CLI/MCP pattern.
+      const settledDone: Promise<unknown> = handle.done.catch((err: unknown) => err)
+
+      for await (const event of handle.fullStream) {
+        const ev = event as TextStreamPart<ToolSet> & { type: string }
+
+        if (ev.type === 'text-delta') {
+          assembled += ev.text ?? ''
+        } else if (ev.type === 'tool-call') {
+          const name = ev.toolName ?? '<tool>'
+          trace.push(`↻ ${name}`)
+        } else if (ev.type === 'tool-result') {
+          if (trace.length > 0 && trace[trace.length - 1]?.startsWith('↻ ')) {
+            trace[trace.length - 1] += '  ✓'
+          }
+        } else if (ev.type === 'tool-error') {
+          if (trace.length > 0 && trace[trace.length - 1]?.startsWith('↻ ')) {
+            trace[trace.length - 1] += '  ✗'
+          }
+        } else if (ev.type === 'finish') {
+          finalReached = true
+        }
+
+        // Build display text: during streaming show trace, on finish show answer.
+        const displayText = finalReached
+          ? assembled.trim() || '(no response)'
+          : buildStreamingDisplay(trace, assembled)
+
+        const now = Date.now()
+        // Throttle measured from edit start (not completion) — keeps cadence
+        // steady even when Telegram API latency varies.
+        if (now - lastEditAt >= EDIT_THROTTLE_MS) {
+          lastEditAt = now
+          await safeEdit(bot, chatId, thinkingMsg.message_id, displayText)
+        }
+      }
+
+      // Final edit — always write the completed answer.
+      const finalText = assembled.trim() || '(no response)'
+      await safeEdit(bot, chatId, thinkingMsg.message_id, finalText)
+
+      // Surface done-promise errors (matches CLI/MCP settledDone pattern).
+      const doneResult = await settledDone
+      if (doneResult instanceof Error) throw doneResult
+    } catch (err) {
+      log.warn({ err, chatId }, 'run failed')
+      const errMsg = `error: ${err instanceof Error ? err.message : String(err)}`
+      await safeEdit(bot, chatId, thinkingMsg.message_id, errMsg)
+    } finally {
+      inflightAbort.delete(chatId)
+    }
+  })
+
+  return {
+    async start(): Promise<void> {
+      if (running) return
+      running = true
+      log.info('telegram bot starting (long-poll)')
+      await bot.start({
+        onStart: () => log.info('telegram bot connected'),
+      })
+    },
+    async stop(): Promise<void> {
+      if (!running) return
+      running = false
+      // Abort all in-flight runs on shutdown.
+      for (const ac of inflightAbort.values()) ac.abort()
+      inflightAbort.clear()
+      bot.stop()
+      log.info('telegram bot stopped')
+    },
+  }
+}
+
+function buildStreamingDisplay(trace: string[], assembled: string): string {
+  const lines = [...trace]
+  if (assembled.length > 0) {
+    lines.push('', assembled.trim())
+  }
+  return lines.join('\n')
+}
+
+async function safeEdit(bot: Bot, chatId: number, messageId: number, text: string): Promise<void> {
+  try {
+    await bot.api.editMessageText(chatId, messageId, text)
+  } catch (err) {
+    // Telegram throws "message is not modified" if text is identical.
+    // Silently ignore that specific error.
+    const msg = err instanceof Error ? err.message : String(err)
+    if (!msg.includes('message is not modified')) {
+      log.warn({ err, chatId }, 'editMessageText failed')
+    }
+  }
+}

--- a/src/channels/telegram/config.ts
+++ b/src/channels/telegram/config.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs'
+import { parse as parseYaml } from 'yaml'
+import { z } from 'zod'
+import { paths } from '@/config/paths'
+import { child } from '@/shared/logger'
+
+const log = child({ module: 'channels-config' })
+
+const TelegramChannelConfig = z.object({
+  enabled: z.boolean().default(false),
+  bot_token_ref: z.string().min(1).optional(),
+  allowed_users: z.array(z.string()).default([]),
+})
+
+const CliChannelConfig = z.object({ enabled: z.boolean().default(true) })
+const McpServerChannelConfig = z.object({ enabled: z.boolean().default(true) })
+
+const ChannelsInner = z.object({
+  cli: CliChannelConfig.default({ enabled: true }),
+  telegram: TelegramChannelConfig.default({
+    enabled: false,
+    allowed_users: [],
+  }),
+  mcp_server: McpServerChannelConfig.default({ enabled: true }),
+})
+
+const DaemonConfig = z.object({
+  bind: z.string().default('127.0.0.1:7711'),
+  log_file: z.string().optional(),
+})
+
+const ChannelConfigSchema = z.object({
+  auto_start_daemon: z.boolean().default(true),
+  daemon: DaemonConfig.default({ bind: '127.0.0.1:7711' }),
+  channels: ChannelsInner.default({
+    cli: { enabled: true },
+    telegram: { enabled: false, allowed_users: [] },
+    mcp_server: { enabled: true },
+  }),
+})
+
+export type TelegramChannelConfig = z.infer<typeof TelegramChannelConfig>
+export type ChannelsConfig = z.infer<typeof ChannelConfigSchema>
+
+let cached: ChannelsConfig | undefined
+
+export function loadChannelsConfig(configPath?: string): ChannelsConfig {
+  if (cached) return cached
+  const filePath = configPath ?? paths.channelsConfigPath
+  if (!fs.existsSync(filePath)) {
+    log.debug({ path: filePath }, 'channels.yaml not found, using defaults')
+    cached = ChannelConfigSchema.parse({})
+    return cached
+  }
+  const raw = fs.readFileSync(filePath, 'utf8')
+  const parsed = parseYaml(raw)
+  const result = ChannelConfigSchema.safeParse(parsed)
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `  ${i.path.join('.')}: ${i.message}`).join('\n')
+    log.warn({ path: filePath, issues }, 'invalid channels.yaml — using defaults')
+    cached = ChannelConfigSchema.parse({})
+    return cached
+  }
+  cached = result.data
+  return cached
+}
+
+export function resetChannelsConfigCache(): void {
+  cached = undefined
+}
+
+/**
+ * Resolve bot_token_ref (format: `env:VAR_NAME`) to the actual token value.
+ * Returns undefined if the ref is missing or the env var is unset.
+ */
+export function resolveBotToken(ref?: string): string | undefined {
+  if (!ref) return undefined
+  if (!ref.startsWith('env:')) {
+    log.warn({ ref }, 'bot_token_ref must start with env:')
+    return undefined
+  }
+  const varName = ref.slice(4)
+  return process.env[varName] || undefined
+}

--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -1,5 +1,12 @@
-import { TalosNotImplementedError } from '@/shared/errors'
-
-export function startTelegramChannel(): never {
-  throw new TalosNotImplementedError('channels.telegram.startTelegramChannel')
-}
+export {
+  createTelegramBot,
+  type TelegramBotHandle,
+  type TelegramBotOpts,
+} from './bot'
+export {
+  type ChannelsConfig,
+  loadChannelsConfig,
+  resetChannelsConfigCache,
+  resolveBotToken,
+  type TelegramChannelConfig,
+} from './config'

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,6 +1,12 @@
 import fs from 'node:fs'
 import { createPublicClient, http } from 'viem'
 import { sepolia } from 'viem/chains'
+import {
+  createTelegramBot,
+  loadChannelsConfig,
+  resolveBotToken,
+  type TelegramBotHandle,
+} from '@/channels'
 import { loadEnv, resetEnvCache } from '@/config/env'
 import { paths } from '@/config/paths'
 import { ensureToken } from '@/config/token'
@@ -203,7 +209,6 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     })
 
   // Build runtime deps. Summarizer / fact pipeline still deferred (#16/#17).
-  // Knowledge retriever + cron land in #11.
   const agents = new AgentRegistry()
   agents.register(TALOS_ETH_AGENT, { default: true })
   const providers = createProviderRouter()
@@ -268,6 +273,28 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
   })
   const { port, host } = await controlPlane.start()
 
+  // Boot Telegram channel if enabled in channels.yaml and token is present.
+  const channelsConfig = loadChannelsConfig()
+  let telegramBot: TelegramBotHandle | null = null
+  if (channelsConfig.channels.telegram.enabled) {
+    const botToken =
+      resolveBotToken(channelsConfig.channels.telegram.bot_token_ref) ?? env.TELEGRAM_BOT_TOKEN
+    if (botToken) {
+      telegramBot = createTelegramBot({
+        token: botToken,
+        config: channelsConfig.channels.telegram,
+        runtime,
+      })
+      telegramBot.start().catch((err) => {
+        logger.warn({ err }, 'telegram bot failed to start')
+      })
+    } else {
+      logger.warn(
+        'telegram channel enabled but no bot token — set bot_token_ref or TELEGRAM_BOT_TOKEN',
+      )
+    }
+  }
+
   // Write the PID file only after we've successfully bound — avoids leaking
   // a stale PID if start fails.
   writePidFile()
@@ -290,6 +317,13 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     if (stopping) return stopping
     stopping = (async () => {
       logger.info('talosd shutting down')
+      if (telegramBot) {
+        try {
+          await telegramBot.stop()
+        } catch (err) {
+          logger.warn({ err }, 'error stopping telegram bot')
+        }
+      }
       if (knowledgeScheduler) {
         try {
           await knowledgeScheduler.stop()

--- a/tests/integration/telegram-channel.test.ts
+++ b/tests/integration/telegram-channel.test.ts
@@ -1,0 +1,365 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentRuntime, RunHandle, RunOptions } from '@/runtime/types'
+
+vi.mock('@/config/env', () => ({
+  loadEnv: () => ({
+    OPENAI_API_KEY: 'test-key',
+    TELEGRAM_BOT_TOKEN: 'test-bot-token',
+    TALOS_DAEMON_PORT: 0,
+    TALOS_LOG_LEVEL: 'silent',
+    NODE_ENV: 'test',
+  }),
+  resetEnvCache: () => {},
+}))
+
+// biome-ignore lint/suspicious/noExplicitAny: mock handler map
+const handlers = new Map<string, (...args: any[]) => any>()
+const editMessageTextMock = vi.fn().mockResolvedValue(true)
+const replyMock = vi.fn().mockResolvedValue({ message_id: 42 })
+
+vi.mock('grammy', () => {
+  return {
+    Bot: class MockBot {
+      // biome-ignore lint/suspicious/noExplicitAny: mock signature
+      command(cmd: string, handler: (...args: any[]) => any) {
+        handlers.set(`command:${cmd}`, handler)
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: mock signature
+      on(event: string, handler: (...args: any[]) => any) {
+        handlers.set(`on:${event}`, handler)
+      }
+      start = vi.fn().mockResolvedValue(undefined)
+      stop = vi.fn()
+      api = { editMessageText: editMessageTextMock }
+    },
+  }
+})
+
+type FakeRunSpec = {
+  runId?: string
+  events?: Array<Record<string, unknown>>
+  eventDelayMs?: number
+  throwOnRun?: Error
+}
+
+function createFakeRuntime(opts: { spec?: FakeRunSpec } = {}) {
+  const calls: Array<{ opts: RunOptions; aborted: () => boolean }> = []
+  let runCounter = 0
+
+  const runtime: AgentRuntime = {
+    async run(runOpts: RunOptions): Promise<RunHandle> {
+      const spec = opts.spec ?? {}
+      if (spec.throwOnRun) throw spec.throwOnRun
+      const runId = spec.runId ?? `run-${++runCounter}`
+      const aborted = () => runOpts.abortSignal?.aborted ?? false
+      calls.push({ opts: runOpts, aborted })
+
+      const events = spec.events ?? [
+        { type: 'text-delta', id: 'm1', text: 'hello from agent' },
+        { type: 'finish', finishReason: 'stop', totalUsage: { inputTokens: 1, outputTokens: 1 } },
+      ]
+      const delayMs = spec.eventDelayMs
+
+      const fullStream = (async function* () {
+        for (const ev of events) {
+          if (delayMs !== undefined) {
+            await new Promise((r) => setTimeout(r, delayMs))
+          } else {
+            await new Promise((r) => setImmediate(r))
+          }
+          if (aborted()) {
+            yield { type: 'abort', reason: 'aborted' } as never
+            return
+          }
+          yield ev as never
+        }
+      })()
+
+      return { runId, fullStream, done: Promise.resolve() }
+    },
+  }
+
+  return { runtime, calls }
+}
+
+function makeTgCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    chat: { id: 12345 },
+    from: { username: 'allensaji', id: 99999 },
+    message: { text: 'hello', message_id: 1 },
+    reply: replyMock,
+    ...overrides,
+  }
+}
+
+function getHandler(key: string) {
+  const h = handlers.get(key)
+  expect(h).toBeDefined()
+  // biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+  return h!
+}
+
+function lastEditArgs() {
+  const calls = editMessageTextMock.mock.calls
+  expect(calls.length).toBeGreaterThan(0)
+  // biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+  return calls[calls.length - 1]!
+}
+
+import { createTelegramBot } from '@/channels/telegram/bot'
+
+describe('telegram channel', () => {
+  afterEach(() => {
+    handlers.clear()
+    editMessageTextMock.mockClear()
+    replyMock.mockClear()
+    vi.restoreAllMocks()
+  })
+
+  function createBot(runtime: AgentRuntime, allowedUsers: string[] = ['@allensaji']) {
+    return createTelegramBot({
+      token: 'test-token',
+      config: {
+        enabled: true,
+        allowed_users: allowedUsers,
+      },
+      runtime,
+    })
+  }
+
+  it('registers message:text handler', () => {
+    const { runtime } = createFakeRuntime()
+    createBot(runtime)
+    expect(handlers.has('on:message:text')).toBe(true)
+  })
+
+  it('registers /start, /help, /reset commands', () => {
+    const { runtime } = createFakeRuntime()
+    createBot(runtime)
+    expect(handlers.has('command:start')).toBe(true)
+    expect(handlers.has('command:help')).toBe(true)
+    expect(handlers.has('command:reset')).toBe(true)
+  })
+
+  it('processes message from allowed user', async () => {
+    const { runtime, calls } = createFakeRuntime()
+    createBot(runtime)
+
+    await getHandler('on:message:text')(makeTgCtx())
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.opts.threadId).toBe('tg:12345')
+    expect(calls[0]?.opts.channel).toBe('telegram')
+    expect(calls[0]?.opts.intent).toBe('hello')
+  })
+
+  it('ignores message from non-allowed user', async () => {
+    const { runtime, calls } = createFakeRuntime()
+    createBot(runtime)
+
+    await getHandler('on:message:text')(makeTgCtx({ from: { username: 'stranger', id: 111 } }))
+
+    expect(calls).toHaveLength(0)
+    expect(replyMock).not.toHaveBeenCalled()
+  })
+
+  it('denies all users when whitelist is empty', async () => {
+    const { runtime, calls } = createFakeRuntime()
+    createBot(runtime, [])
+
+    await getHandler('on:message:text')(makeTgCtx({ from: { username: 'anyone', id: 222 } }))
+
+    expect(calls).toHaveLength(0)
+  })
+
+  it('supports numeric userId when username is absent', async () => {
+    const { runtime, calls } = createFakeRuntime()
+    createBot(runtime, ['99999'])
+
+    await getHandler('on:message:text')(makeTgCtx({ from: { id: 99999 } }))
+
+    expect(calls).toHaveLength(1)
+  })
+
+  it('matches numeric userId even when username is present', async () => {
+    const { runtime, calls } = createFakeRuntime()
+    // Whitelist has numeric ID, not @username.
+    createBot(runtime, ['99999'])
+
+    await getHandler('on:message:text')(makeTgCtx({ from: { username: 'allensaji', id: 99999 } }))
+
+    expect(calls).toHaveLength(1)
+  })
+
+  it('sends thinking message then edits with final answer', async () => {
+    const { runtime } = createFakeRuntime()
+    createBot(runtime)
+
+    await getHandler('on:message:text')(makeTgCtx())
+
+    expect(replyMock).toHaveBeenCalledWith('↻ thinking…')
+    const lastCall = lastEditArgs()
+    expect(lastCall[0]).toBe(12345) // chatId
+    expect(lastCall[1]).toBe(42) // messageId
+    expect(lastCall[2]).toBe('hello from agent')
+  })
+
+  it('shows tool-call trace during streaming', async () => {
+    const { runtime } = createFakeRuntime({
+      spec: {
+        events: [
+          { type: 'tool-call', toolName: 'aave_supply' },
+          { type: 'tool-result', result: 'ok' },
+          { type: 'text-delta', id: 'm1', text: 'supplied' },
+          { type: 'finish', finishReason: 'stop' },
+        ],
+      },
+    })
+    createBot(runtime)
+
+    await getHandler('on:message:text')(makeTgCtx())
+
+    const lastCall = lastEditArgs()
+    expect(lastCall[2]).toBe('supplied')
+  })
+
+  it('handles runtime errors gracefully', async () => {
+    const { runtime } = createFakeRuntime({ spec: { throwOnRun: new Error('boom') } })
+    createBot(runtime)
+
+    await getHandler('on:message:text')(makeTgCtx())
+
+    const lastCall = lastEditArgs()
+    expect(lastCall[2]).toContain('error: boom')
+  })
+
+  it('uses thread id tg:{chatId}', async () => {
+    const { runtime, calls } = createFakeRuntime()
+    createBot(runtime)
+
+    await getHandler('on:message:text')(makeTgCtx({ chat: { id: 99999 } }))
+
+    expect(calls[0]?.opts.threadId).toBe('tg:99999')
+  })
+
+  it('/start replies with welcome', async () => {
+    const { runtime } = createFakeRuntime()
+    createBot(runtime)
+
+    const replyFn = vi.fn().mockResolvedValue(undefined)
+    await getHandler('command:start')({
+      reply: replyFn,
+      from: { username: 'allensaji', id: 99999 },
+    })
+
+    expect(replyFn).toHaveBeenCalledWith(expect.stringContaining('Welcome'))
+  })
+
+  it('/help replies with commands', async () => {
+    const { runtime } = createFakeRuntime()
+    createBot(runtime)
+
+    const replyFn = vi.fn().mockResolvedValue(undefined)
+    await getHandler('command:help')({ reply: replyFn, from: { username: 'allensaji', id: 99999 } })
+
+    expect(replyFn).toHaveBeenCalledWith(expect.stringContaining('/reset'))
+  })
+
+  it('/reset rotates thread id', async () => {
+    const { runtime, calls } = createFakeRuntime()
+    createBot(runtime)
+
+    // First message uses default thread id.
+    await getHandler('on:message:text')(makeTgCtx())
+    expect(calls[0]?.opts.threadId).toBe('tg:12345')
+
+    // Reset rotates the thread.
+    const replyFn = vi.fn().mockResolvedValue(undefined)
+    await getHandler('command:reset')({
+      chat: { id: 12345 },
+      reply: replyFn,
+      from: { username: 'allensaji', id: 99999 },
+    })
+    expect(replyFn).toHaveBeenCalledWith(expect.stringContaining('Thread reset'))
+
+    // Next message uses a new thread id (has UUID suffix).
+    await getHandler('on:message:text')(makeTgCtx())
+    expect(calls[1]?.opts.threadId).toMatch(/^tg:12345:/)
+    expect(calls[1]?.opts.threadId).not.toBe(calls[0]?.opts.threadId)
+  })
+
+  it('aborts previous run when new message arrives', async () => {
+    let resolveFirst!: () => void
+    const firstRunBlocked = new Promise<void>((r) => {
+      resolveFirst = r
+    })
+
+    const calls: Array<{ opts: RunOptions; aborted: () => boolean }> = []
+    let runCounter = 0
+
+    const runtime: AgentRuntime = {
+      async run(runOpts: RunOptions): Promise<RunHandle> {
+        const runId = `run-${++runCounter}`
+        const aborted = () => runOpts.abortSignal?.aborted ?? false
+        calls.push({ opts: runOpts, aborted })
+
+        const isFirst = runCounter === 1
+        const fullStream = (async function* () {
+          if (isFirst) {
+            // First run blocks until we resolve it.
+            await firstRunBlocked
+            yield { type: 'text-delta', id: 'm1', text: 'first' } as never
+          } else {
+            yield { type: 'text-delta', id: 'm2', text: 'second' } as never
+          }
+          yield { type: 'finish', finishReason: 'stop' } as never
+        })()
+
+        return { runId, fullStream, done: Promise.resolve() }
+      },
+    }
+
+    createBot(runtime)
+
+    // Start first message (will block).
+    const handler = getHandler('on:message:text')
+    const p1 = handler(makeTgCtx())
+
+    // Give first run time to start.
+    await new Promise((r) => setImmediate(r))
+    expect(calls).toHaveLength(1)
+
+    // Send second message — should abort first run.
+    const p2 = handler(makeTgCtx())
+
+    // First run should be aborted.
+    expect(calls[0]?.aborted()).toBe(true)
+
+    // Unblock first run.
+    resolveFirst()
+
+    await Promise.all([p1, p2])
+    expect(calls).toHaveLength(2)
+  })
+
+  it('throttles edits — fast events produce fewer edits than events', async () => {
+    // Generate many events quickly. Throttle should suppress most edits.
+    const events = []
+    for (let i = 0; i < 20; i++) {
+      events.push({ type: 'text-delta', id: `m${i}`, text: `word${i} ` })
+    }
+    events.push({ type: 'finish', finishReason: 'stop' })
+
+    const { runtime } = createFakeRuntime({ spec: { events } })
+    createBot(runtime)
+
+    await getHandler('on:message:text')(makeTgCtx())
+
+    // With 20 events arriving instantly, throttle should produce far fewer edits.
+    // We get: one "thinking" reply + a few throttled edits + final edit.
+    // The key property: edit count < event count (21 events, ~2-3 edits).
+    const editCount = editMessageTextMock.mock.calls.length
+    expect(editCount).toBeLessThan(events.length)
+    expect(editCount).toBeGreaterThanOrEqual(1) // at least the final edit
+  })
+})


### PR DESCRIPTION
## Summary
- In-process Telegram channel using grammY long-polling, calls `runtime.run()` directly (no WS hop)
- Edit-in-place streaming with 1.1s throttle per Telegram rate limit
- Whitelist enforcement via `allowed_users` in `channels.yaml` (fail-closed, dual username+numericId match)
- Slash commands: `/start`, `/help`, `/reset`
- Thread keying: `tg:{chatId}`, `/reset` rotates with UUID suffix
- Per-chat `AbortController`: abort on new message, abort all on stop
- `channels.yaml` config loader with Zod validation
- Auto-starts in daemon lifecycle when `telegram.enabled` + token present

## Acceptance criteria (from #13)
- [x] grammY long-poll bot using `TELEGRAM_BOT_TOKEN`
- [x] Each chat → thread `tg:{chatId}` (persistent)
- [x] Streaming = edit-in-place: one bot message per run, edited as `run-event` frames arrive
- [x] Throttle to 1.1s per edit (Telegram rate limit)
- [x] `/start`, `/reset`, `/help` slash commands
- [x] `channels.yaml` config at `paths.channelsConfigPath` toggles which channels start

## Review fixes applied
- [x] Rebased onto main — recovers knowledge cron (#35), vitest config (#36), demo eval (#37)
- [x] Empty whitelist → deny all (fail-closed)
- [x] Whitelist matches both `@username` AND numeric userId
- [x] Reverted zero-vector embedding fallback (let caller decide)
- [x] Dropped scope creep: `OPENAI_MODEL` getter, `EMBEDDING_MODEL` env var, `!`→`?.` test changes
- [x] Removed `polling_interval_ms` dead config field
- [x] Removed `CLAUDE.md` from `.gitignore`

## Test plan
- [x] 16 integration tests pass (whitelist, streaming, slash commands, thread id, abort, throttle, dual-match)
- [x] Full suite: 365/365 pass (29 files)
- [x] Typecheck clean, biome lint clean (pre-existing warnings only)