### PR TITLE
fix: make demo flow work end-to-end on real sepolia

### DIFF
--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -244,10 +244,17 @@ export function createControlPlane(opts: ControlPlaneOpts): ControlPlane {
   function send(conn: Connection, frame: ServerFrame): void {
     if (conn.ws.readyState !== WebSocket.OPEN) return
     try {
-      conn.ws.send(JSON.stringify(frame))
+      conn.ws.send(JSON.stringify(frame, bigintSafeReplacer))
     } catch (err) {
       log.warn({ err }, 'failed to send frame')
     }
+  }
+
+  function bigintSafeReplacer(_key: string, value: unknown): unknown {
+    // Viem and AI SDK can leak BigInt into tool-result/tool-error payloads
+    // (gas estimates, balances inside error metadata). JSON.stringify defaults
+    // to throwing on BigInt — coerce to decimal string at the boundary.
+    return typeof value === 'bigint' ? value.toString() : value
   }
 
   function sendError(conn: Connection, code: string, message: string, runId?: string): void {

--- a/src/runtime/agents.ts
+++ b/src/runtime/agents.ts
@@ -39,7 +39,17 @@ export class AgentRegistry {
 
 export const TALOS_ETH_AGENT: Agent = {
   id: 'talos-eth',
-  persona:
-    'You are Talos, a vertical Ethereum agent. You help the user interact with EVM chains: query balances, swap tokens, supply/borrow on lending protocols, bridge assets. You favor Arbitrum and Base for cost. When in doubt, ask before broadcasting a mutating transaction. Be concise.',
+  persona: [
+    'You are Talos, a vertical Ethereum agent.',
+    'You help the user interact with EVM chains: query balances, swap tokens, supply/borrow on lending protocols, bridge assets.',
+    '',
+    'Tool selection rules:',
+    '- For wallet balance and address on Sepolia, use `agentkit_wallet_get_wallet_details` (returns address + native ETH balance). This is THE source of truth for the connected wallet — never use `evmmcp_get_wallet_address` or `evmmcp_get_balance` to read the connected wallet, they query an unrelated default address. Use `evmmcp_*` and `blockscout_*` only for arbitrary on-chain reads (block data, contract storage, tx history of OTHER addresses).',
+    '- For same-chain ERC-20 swaps on Sepolia (e.g. ETH→USDC), use `uniswap_get_quote` then `uniswap_swap_exact_in`. ETH input does not need an approve step (sent as msg.value); ERC-20 input requires `uniswap_approve_router` first.',
+    '- Use `lifi_*` only for cross-chain bridges or swaps that span two different chains. Never for same-chain swaps.',
+    '- Use `evmmcp_*` and `blockscout_*` for arbitrary on-chain reads (block data, contract storage, tx history) — not for balances of the connected wallet.',
+    '',
+    'Confirmation policy: if the user has explicitly authorized execution in the current message (words like "execute", "do it", "go ahead", "proceed", "yes"), do NOT ask again — proceed to call the mutating tool. Only ask for confirmation when the user is exploring, hedging, or asks a question without explicit authorization. Be concise.',
+  ].join('\n'),
   modelId: 'openai/gpt-4o-mini',
 }

--- a/src/tools/agentkit/client.ts
+++ b/src/tools/agentkit/client.ts
@@ -9,6 +9,7 @@ import {
   pythActionProvider,
   sushiRouterActionProvider,
   ViemWalletProvider,
+  walletActionProvider,
   zerionActionProvider,
   zeroXActionProvider,
   zoraActionProvider,
@@ -22,7 +23,7 @@ const log = logger.child({ module: 'agentkit' })
 let cached: AgentKit | undefined
 
 /**
- * Lazy-init AgentKit with a Base-Sepolia-bound viem wallet and the cherry-pick
+ * Lazy-init AgentKit with a Sepolia-bound viem wallet and the cherry-pick
  * of action providers per spec F3.1 (minus Farcaster — separate signer model,
  * deferred to a follow-up).
  *
@@ -38,7 +39,7 @@ export async function getAgentKit(): Promise<AgentKit> {
   if (cached) return cached
 
   const env = loadEnv()
-  const walletClient = getViemWalletClient('baseSepolia')
+  const walletClient = getViemWalletClient('sepolia')
   const walletProvider = new ViemWalletProvider(
     // ViemWalletProvider's typing wants its internal `ViemWalletClient` shape;
     // viem's `WalletClient` is structurally compatible at runtime.
@@ -52,6 +53,7 @@ export async function getAgentKit(): Promise<AgentKit> {
   // their env-var key is missing. Wrap each in a try/catch so a single missing
   // key only drops that provider — not the rest of the AgentKit surface.
   const candidates: Array<{ name: string; build: () => AnyActionProvider }> = [
+    { name: 'wallet', build: walletActionProvider },
     { name: 'pyth', build: pythActionProvider },
     { name: 'compound', build: compoundActionProvider },
     { name: 'morpho', build: morphoActionProvider },

--- a/src/tools/lifi/tools.ts
+++ b/src/tools/lifi/tools.ts
@@ -70,7 +70,7 @@ const lifi_get_connections = tool({
 
 const lifi_get_quote = tool({
   description:
-    'Get the best route to swap or bridge a token amount across chains. Returns selected bridge, expected output amount, fees, gas estimate, ETA, and step-by-step transactions. The single most useful Li.Fi tool — use this whenever the user asks "what is the rate / best route" for a cross-chain transfer.',
+    'Cross-chain only. Get the best route to bridge or swap tokens between two DIFFERENT chains (e.g. Ethereum → Arbitrum). Returns selected bridge, expected output amount, fees, gas estimate, ETA, and step-by-step transactions. Do NOT use for same-chain swaps — for that use the protocol-specific tool (e.g. uniswap_get_quote on Sepolia).',
   inputSchema: z.object({
     fromChain: ChainRef,
     fromToken: z.string().describe('Token address (preferred) or symbol on the source chain'),

--- a/src/tools/uniswap/approve.ts
+++ b/src/tools/uniswap/approve.ts
@@ -56,8 +56,11 @@ export function buildApproveTool(opts: {
 
       // viem's WalletClient.sendTransaction is the lowest-friction send for an
       // arbitrary calldata; writeContract would re-encode args we already have.
+      // Pass the bound Account so viem signs locally (eth_sendRawTransaction)
+      // instead of falling back to wallet_sendTransaction (browser-wallet RPC,
+      // unsupported by public node providers).
       const txHash = await opts.walletClient.sendTransaction({
-        account: opts.walletAddress,
+        account: opts.walletClient.account ?? opts.walletAddress,
         chain: opts.walletClient.chain ?? null,
         to: token.address,
         data,

--- a/src/tools/uniswap/swap.ts
+++ b/src/tools/uniswap/swap.ts
@@ -53,27 +53,35 @@ export function buildSwapTool(opts: {
 }) {
   return tool({
     description:
-      'Swap an exact input amount of one token for another on Uniswap V3 (Sepolia). Internally fetches a quote and applies slippage tolerance to compute amountOutMinimum. Requires the SwapRouter02 to be pre-approved for tokenIn (call uniswap_approve_router first).',
+      'Swap an exact input amount of one token for another on Uniswap V3 (Sepolia). Internally fetches a quote and applies slippage tolerance to compute amountOutMinimum. Native ETH input is sent as msg.value (no approval needed); ERC-20 input requires the SwapRouter02 to be pre-approved (call uniswap_approve_router first).',
     inputSchema: SwapSchema,
     execute: async (args): Promise<SwapResult> => {
       const prep = await prepareSwap(args, opts.publicClient)
+      const isNativeIn = prep.tokenIn.symbol === 'ETH'
 
       // Fail-loud allowance precondition: confirm the router can pull tokenIn
       // from the wallet before we burn gas on a swap that will revert.
-      const allowance = (await opts.publicClient.readContract({
-        address: prep.tokenIn.address,
-        abi: ERC20_ABI,
-        functionName: 'allowance',
-        args: [opts.walletAddress, SEPOLIA_UNISWAP.swapRouter02 as Address],
-      })) as bigint
-      if (allowance < prep.amountInRaw) {
-        throw new Error(
-          `insufficient allowance: SwapRouter02 has ${allowance.toString()} but needs ${prep.amountInRaw.toString()}; call uniswap_approve_router first`,
-        )
+      // Native ETH input bypasses this — tokens are sent via msg.value.
+      if (!isNativeIn) {
+        const allowance = (await opts.publicClient.readContract({
+          address: prep.tokenIn.address,
+          abi: ERC20_ABI,
+          functionName: 'allowance',
+          args: [opts.walletAddress, SEPOLIA_UNISWAP.swapRouter02 as Address],
+        })) as bigint
+        if (allowance < prep.amountInRaw) {
+          throw new Error(
+            `insufficient allowance: SwapRouter02 has ${allowance.toString()} but needs ${prep.amountInRaw.toString()}; call uniswap_approve_router first`,
+          )
+        }
       }
 
+      // Pass the bound Account (PrivateKeyAccount) so viem signs locally and
+      // uses eth_sendRawTransaction. Falling through to a bare Address makes
+      // viem think this is an EIP-1193 wallet and try wallet_sendTransaction,
+      // which public RPCs don't support.
       const txHash = await opts.walletClient.writeContract({
-        account: opts.walletAddress,
+        account: opts.walletClient.account ?? opts.walletAddress,
         chain: opts.walletClient.chain ?? null,
         address: SEPOLIA_UNISWAP.swapRouter02 as Address,
         abi: SWAP_ROUTER_ABI,
@@ -89,6 +97,7 @@ export function buildSwapTool(opts: {
             sqrtPriceLimitX96: 0n,
           },
         ],
+        value: isNativeIn ? prep.amountInRaw : 0n,
       })
 
       return {


### PR DESCRIPTION
## Summary

Smoke tested the locked F12.16 demo prompt (`"what's my eth balance, then quote me 0.003 ETH -> USDC on Sepolia, then execute"`) against a real LLM + real Sepolia. Five issues only the live run could catch (mock fixture pre-coded the happy path) plus one daemon-side serialization bug.

After these, the full path runs clean and the swap lands on chain. Verified tx: [`0x17643319...`](https://sepolia.etherscan.io/tx/0x17643319f8766f5b4573f36aee352201ac1eb58c908ddb5340abccc35884752f) (block 10762242, 25.92 USDC received).

### Bugs fixed

- **`daemon/server`** — JSON.stringify on a frame containing a BigInt (viem error metadata) crashed the WS send. Added a BigInt-safe replacer.
- **`tools/agentkit/client`** — bound to Base Sepolia; flipped to Sepolia so balance reads agree with the swap chain.
- **`tools/agentkit/client`** — registered `walletActionProvider` so `agentkit_wallet_get_wallet_details` + `agentkit_wallet_native_transfer` exist (was 2 tools, now 4 — the wallet ones are what the LLM actually needs for "what's my balance").
- **`runtime/agents`** — persona now spells out tool-selection rules (Uniswap for same-chain, Lifi for cross-chain, AgentKit for the connected wallet) and an explicit-execute policy (don't re-confirm when the user already said "execute").
- **`tools/lifi`** — `lifi_get_quote` description tightened to cross-chain only. Was beating `uniswap_get_quote` in tool selection because of "single most useful Li.Fi tool" framing.
- **`tools/uniswap/swap`** — handle native ETH input. Router accepts via `msg.value`; tool was checking WETH allowance and failing pre-broadcast. Skip allowance check when `tokenIn.symbol === 'ETH'` and pass `value: amountIn`.
- **`tools/uniswap/{swap,approve}`** — pass bound `Account` (PrivateKeyAccount) instead of bare `Address`. With only an Address viem assumes EIP-1193 external wallet and calls `wallet_sendTransaction`, which public RPCs reject. Bound Account → viem signs locally and uses `eth_sendRawTransaction`.

### Outstanding (follow-ups, not blocking)

- evm-mcp boot stderr ("Starting EVM MCP Server v2.0.0...") is parsed as JSON by `@ai-sdk/mcp` stdio transport — cosmetic ERROR log at boot, then recovers and registers normally.
- evm-mcp's wallet tools (`get_wallet_address`, `get_balance`) return its own internal default address, not the daemon's signer. Persona steers the LLM away from them; eventual fix is to filter at registration.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (32 pre-existing warnings)
- [x] `pnpm test` — 349/349 passing on the branch (F12.16 mock eval still green)
- [x] Manual end-to-end: real Sepolia, real LLM, locked demo prompt → tx lands, balances reconcile