### PR TITLE
chore(persistence): tsv as STORED generated column + GIN index (closes #15)

### DIFF
--- a/drizzle/0003_typical_senator_kelly.sql
+++ b/drizzle/0003_typical_senator_kelly.sql
@@ -1,0 +1,12 @@
+-- The previous schema declared `tsv` as plain `text` with a TODO. Replace it
+-- with a Postgres-managed STORED generated column of type `tsvector`, backed
+-- by a GIN index for the lexical half of hybrid retrieval.
+--
+-- drizzle-kit 0.31 emits a broken first ALTER for customType migrations
+-- (`"undefined"."tsvector"`). The drop-then-add pair below replaces the
+-- column outright, which is what we want — generated columns can't be
+-- altered in place anyway.
+
+ALTER TABLE "message_embeddings" drop column "tsv";--> statement-breakpoint
+ALTER TABLE "message_embeddings" ADD COLUMN "tsv" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;--> statement-breakpoint
+CREATE INDEX "message_embeddings_tsv_gin_idx" ON "message_embeddings" USING gin ("tsv");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1134 @@
+{
+  "id": "f3dc9f27-a3e6-4ac2-b128-3c001be1d9dd",
+  "prevId": "b866fe24-5a3b-4847-aa38-2c817a777600",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.fact_history": {
+      "name": "fact_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "fact_id": {
+          "name": "fact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "fact_event",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_text": {
+          "name": "old_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_text": {
+          "name": "new_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fact_history_fact_idx": {
+          "name": "fact_history_fact_idx",
+          "columns": [
+            {
+              "expression": "fact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fact_history_run_idx": {
+          "name": "fact_history_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fact_history_fact_id_facts_id_fk": {
+          "name": "fact_history_fact_id_facts_id_fk",
+          "tableFrom": "fact_history",
+          "tableTo": "facts",
+          "columnsFrom": [
+            "fact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "fact_history_run_id_runs_id_fk": {
+          "name": "fact_history_run_id_runs_id_fk",
+          "tableFrom": "fact_history",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.facts": {
+      "name": "facts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attributed_to_run_id": {
+          "name": "attributed_to_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_by": {
+          "name": "superseded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "facts_scope_idx": {
+          "name": "facts_scope_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "facts_live_hash_idx": {
+          "name": "facts_live_hash_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at IS NULL AND superseded_by IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "facts_hnsw_idx": {
+          "name": "facts_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "facts_attributed_to_run_id_runs_id_fk": {
+          "name": "facts_attributed_to_run_id_runs_id_fk",
+          "tableFrom": "facts",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "attributed_to_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "facts_superseded_by_facts_id_fk": {
+          "name": "facts_superseded_by_facts_id_fk",
+          "tableFrom": "facts",
+          "tableTo": "facts",
+          "columnsFrom": [
+            "superseded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_chunks": {
+      "name": "knowledge_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "knowledge_chunks_source_idx": {
+          "name": "knowledge_chunks_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "knowledge_chunks_hnsw_idx": {
+          "name": "knowledge_chunks_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_embeddings": {
+      "name": "message_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tsv": {
+          "name": "tsv",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', content)",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_embeddings_thread_idx": {
+          "name": "message_embeddings_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_embeddings_hnsw_idx": {
+          "name": "message_embeddings_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        },
+        "message_embeddings_tsv_gin_idx": {
+          "name": "message_embeddings_tsv_gin_idx",
+          "columns": [
+            {
+              "expression": "tsv",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_embeddings_thread_id_threads_id_fk": {
+          "name": "message_embeddings_thread_id_threads_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_embeddings_run_id_runs_id_fk": {
+          "name": "message_embeddings_run_id_runs_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runs_thread_idx": {
+          "name": "runs_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runs_status_idx": {
+          "name": "runs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_thread_id_threads_id_fk": {
+          "name": "runs_thread_id_threads_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steps": {
+      "name": "steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "step_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "steps_run_idx": {
+          "name": "steps_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "steps_run_id_runs_id_fk": {
+          "name": "steps_run_id_runs_id_fk",
+          "tableFrom": "steps",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.thread_summaries": {
+      "name": "thread_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_range_start": {
+          "name": "run_range_start",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_range_end": {
+          "name": "run_range_end",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "thread_summaries_thread_idx": {
+          "name": "thread_summaries_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_summaries_hnsw_idx": {
+          "name": "thread_summaries_hnsw_idx",
+          "columns": [
+            {
+              "expression": "\"embedding\" vector_cosine_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_summaries_thread_id_threads_id_fk": {
+          "name": "thread_summaries_thread_id_threads_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_summaries_run_range_start_runs_id_fk": {
+          "name": "thread_summaries_run_range_start_runs_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_range_start"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "thread_summaries_run_range_end_runs_id_fk": {
+          "name": "thread_summaries_run_range_end_runs_id_fk",
+          "tableFrom": "thread_summaries",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_range_end"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "threads_channel_idx": {
+          "name": "threads_channel_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_calls": {
+      "name": "tool_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args": {
+          "name": "args",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit": {
+          "name": "audit",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tool_calls_run_idx": {
+          "name": "tool_calls_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tool_calls_name_idx": {
+          "name": "tool_calls_name_idx",
+          "columns": [
+            {
+              "expression": "tool_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_calls_run_id_runs_id_fk": {
+          "name": "tool_calls_run_id_runs_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tool_calls_step_id_steps_id_fk": {
+          "name": "tool_calls_step_id_steps_id_fk",
+          "tableFrom": "tool_calls",
+          "tableTo": "steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.fact_event": {
+      "name": "fact_event",
+      "schema": "public",
+      "values": [
+        "ADD",
+        "UPDATE",
+        "DELETE"
+      ]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_role": {
+      "name": "step_role",
+      "schema": "public",
+      "values": [
+        "assistant",
+        "tool"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777436294325,
       "tag": "0002_unknown_may_parker",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777556419835,
+      "tag": "0003_typical_senator_kelly",
+      "breakpoints": true
     }
   ]
 }

--- a/src/persistence/queries.ts
+++ b/src/persistence/queries.ts
@@ -183,9 +183,9 @@ export type SearchOptions = {
  * Pulls top `vectorPoolSize` (default 20) by vector distance, left-joins keyword ranks,
  * orders by combined score. Mirrors spike-2-pglite which proved 4ms vector queries.
  *
- * NOTE: tsv is computed inline via `to_tsvector('english', content)` because the
- * STORED generated column is tracked separately in issue #15. When that column
- * lands the WHERE/ORDER expressions swap to `tsv @@ ...` and `ts_rank(tsv, ...)`.
+ * Lexical match uses the `tsv` STORED generated column (Postgres maintains it
+ * via `to_tsvector('english', content)`) and the `message_embeddings_tsv_gin_idx`
+ * GIN index — `@@` and `ts_rank` consult the index instead of recomputing.
  */
 export async function searchMessages(
   db: Db,
@@ -218,10 +218,10 @@ export async function searchMessages(
     ),
     k AS (
       SELECT id,
-             ts_rank(to_tsvector('english', content), plainto_tsquery('english', ${queryText})) AS krank
+             ts_rank(tsv, plainto_tsquery('english', ${queryText})) AS krank
       FROM message_embeddings
       WHERE thread_id = ${threadId}
-        AND to_tsvector('english', content) @@ plainto_tsquery('english', ${queryText})
+        AND tsv @@ plainto_tsquery('english', ${queryText})
     )
     SELECT v.id, v.thread_id, v.run_id, v.role, v.content,
            v.vsim,

--- a/src/persistence/schema.ts
+++ b/src/persistence/schema.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm'
 import {
   type AnyPgColumn,
+  customType,
   index,
   integer,
   jsonb,
@@ -11,6 +12,15 @@ import {
   uuid,
   vector,
 } from 'drizzle-orm/pg-core'
+
+/**
+ * Postgres `tsvector` column type. drizzle 0.45 has no built-in for it; the
+ * raw type is needed because `to_tsvector(...)` returns `tsvector` and
+ * Postgres rejects the cast to `text` on a generated column.
+ */
+const tsvector = customType<{ data: string }>({
+  dataType: () => 'tsvector',
+})
 
 export const runStatus = pgEnum('run_status', ['running', 'completed', 'failed', 'cancelled'])
 
@@ -97,18 +107,18 @@ export const messageEmbeddings = pgTable(
     role: text('role').notNull(),
     content: text('content').notNull(),
     embedding: vector('embedding', { dimensions: 1536 }).notNull(),
-    // TODO(persistence-impl): wire `tsv` as a STORED generated column for hybrid
-    // retrieval (HNSW + GIN). drizzle-orm 0.45.2 rejected the 2-arg
-    // `.generatedAlwaysAs(sql, { mode: 'stored' })` signature; resolve by
-    // (1) finding the correct API for this version, (2) using a Postgres
-    // trigger via custom migration, or (3) computing in TS at insert time.
-    // Also add the GIN index on `tsv` once the column is populated.
-    tsv: text('tsv'),
+    /**
+     * Postgres maintains this column via `GENERATED ALWAYS AS (...) STORED`.
+     * Backed by the GIN index below — used for the lexical half of hybrid
+     * retrieval (`searchMessages` does `tsv @@ plainto_tsquery(...)`).
+     */
+    tsv: tsvector('tsv').generatedAlwaysAs(sql`to_tsvector('english', content)`),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     index('message_embeddings_thread_idx').on(t.threadId),
     index('message_embeddings_hnsw_idx').using('hnsw', sql`${t.embedding} vector_cosine_ops`),
+    index('message_embeddings_tsv_gin_idx').using('gin', t.tsv),
   ],
 )
 

--- a/tests/integration/persistence-tsv.test.ts
+++ b/tests/integration/persistence-tsv.test.ts
@@ -1,0 +1,140 @@
+import { sql } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  createDb,
+  type DbHandle,
+  insertMessageEmbedding,
+  runMigrations,
+  upsertThread,
+} from '@/persistence'
+
+const EMBEDDING_DIMS = 1536
+
+function fakeEmbedding(seed: number): number[] {
+  const v = new Array<number>(EMBEDDING_DIMS).fill(0)
+  v[0] = seed
+  let norm = 0
+  for (const n of v) norm += n * n
+  norm = Math.sqrt(norm) || 1
+  return v.map((n) => n / norm)
+}
+
+/**
+ * Acceptance tests for issue #15 — `message_embeddings.tsv` is a STORED
+ * generated column populated automatically by Postgres, indexed by GIN.
+ */
+describe('message_embeddings.tsv — generated column + GIN index', () => {
+  let handle: DbHandle
+
+  beforeEach(async () => {
+    handle = await createDb({ ephemeral: true })
+    await runMigrations(handle)
+    await upsertThread(handle.db, { id: 't-tsv', channel: 'cli' })
+  })
+
+  afterEach(async () => {
+    await handle.close()
+  })
+
+  it('auto-populates tsv on insert (no explicit value passed)', async () => {
+    await insertMessageEmbedding(handle.db, {
+      threadId: 't-tsv',
+      role: 'user',
+      content: 'check my wallet balance on Arbitrum',
+      embedding: fakeEmbedding(1),
+    })
+
+    const result = (await handle.db.execute(sql`
+      SELECT tsv::text AS tsv FROM message_embeddings WHERE thread_id = 't-tsv'
+    `)) as { rows: Array<{ tsv: string }> }
+
+    expect(result.rows).toHaveLength(1)
+    const tsv = result.rows[0]?.tsv ?? ''
+    // Stemmed lexemes — 'wallet', 'balanc', 'arbitrum' all show up
+    expect(tsv).toMatch(/wallet/)
+    expect(tsv).toMatch(/balanc/)
+    expect(tsv).toMatch(/arbitrum/)
+  })
+
+  it('matches via to_tsquery prefix lexeme', async () => {
+    await insertMessageEmbedding(handle.db, {
+      threadId: 't-tsv',
+      role: 'user',
+      content: 'sweep ETH from Optimism to Base',
+      embedding: fakeEmbedding(2),
+    })
+    await insertMessageEmbedding(handle.db, {
+      threadId: 't-tsv',
+      role: 'assistant',
+      content: 'supplied 100 USDC to Aave on Arbitrum',
+      embedding: fakeEmbedding(3),
+    })
+
+    const result = (await handle.db.execute(sql`
+      SELECT content
+      FROM message_embeddings
+      WHERE thread_id = 't-tsv'
+        AND tsv @@ to_tsquery('english', 'aave:*')
+    `)) as { rows: Array<{ content: string }> }
+
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0]?.content).toContain('Aave')
+  })
+
+  it('rejects manual writes to tsv (column is GENERATED ALWAYS)', async () => {
+    await insertMessageEmbedding(handle.db, {
+      threadId: 't-tsv',
+      role: 'user',
+      content: 'hello world',
+      embedding: fakeEmbedding(4),
+    })
+
+    // Postgres rejects updates to a generated column. PGLite wraps the
+    // underlying error so we only assert that it throws — the prior insert
+    // proves the column is auto-populated, this proves it can't be hijacked.
+    await expect(
+      handle.db.execute(sql`
+        UPDATE message_embeddings
+        SET tsv = to_tsvector('english', 'override')
+        WHERE thread_id = 't-tsv'
+      `),
+    ).rejects.toThrow()
+  })
+
+  it('GIN index on tsv exists', async () => {
+    const result = (await handle.db.execute(sql`
+      SELECT indexname, indexdef
+      FROM pg_indexes
+      WHERE tablename = 'message_embeddings'
+        AND indexname = 'message_embeddings_tsv_gin_idx'
+    `)) as { rows: Array<{ indexname: string; indexdef: string }> }
+
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0]?.indexdef).toMatch(/USING gin/i)
+    expect(result.rows[0]?.indexdef).toMatch(/\(tsv\)/)
+  })
+
+  it('updates tsv when content changes', async () => {
+    await insertMessageEmbedding(handle.db, {
+      threadId: 't-tsv',
+      role: 'user',
+      content: 'initial content',
+      embedding: fakeEmbedding(5),
+    })
+
+    await handle.db.execute(sql`
+      UPDATE message_embeddings
+      SET content = 'updated message about Uniswap'
+      WHERE thread_id = 't-tsv'
+    `)
+
+    const result = (await handle.db.execute(sql`
+      SELECT tsv::text AS tsv
+      FROM message_embeddings
+      WHERE thread_id = 't-tsv'
+    `)) as { rows: Array<{ tsv: string }> }
+
+    expect(result.rows[0]?.tsv).toMatch(/uniswap/)
+    expect(result.rows[0]?.tsv).not.toMatch(/initial/)
+  })
+})


### PR DESCRIPTION
## Summary

Resolves #15 — `message_embeddings.tsv` is now a Postgres-managed `STORED` generated column of type `tsvector`, backed by a GIN index. Hybrid retrieval's lexical half (`tsv @@ plainto_tsquery(...)`) finally has an index behind it.

### Path chosen: drizzle's 1-arg `generatedAlwaysAs` (issue path 1)

drizzle 0.45.2's `generatedAlwaysAs` signature is single-arg: `(as: SQL | T['data'] | (() => SQL))`. The 2-arg `(sql, { mode: 'stored' })` that #5 fell over on doesn't exist in this version. drizzle-kit's pg dialect auto-appends `STORED` when emitting (line 23097 of its bin), so the 1-arg call produces the correct DDL.

Postgres requires a `tsvector` column type for `to_tsvector(...)` output; drizzle 0.45 has no built-in for it, so a 4-line `customType<{data: string}>({dataType: () => 'tsvector'})` defines it.

### Changes

- **`src/persistence/schema.ts`** — `tsvector` customType + replace `text('tsv')` with `tsvector('tsv').generatedAlwaysAs(sql\`to_tsvector('english', content)\`)` + add `message_embeddings_tsv_gin_idx` GIN index. TODO comment block removed.
- **`drizzle/0003_typical_senator_kelly.sql`** — generated migration; one drizzle-kit-emitted line was broken (`"undefined"."tsvector"` schema-qualifier bug for customType ALTERs) so the file was hand-fixed: drop column → re-add as generated → CREATE INDEX. Result is what we want anyway since generated columns can't be altered in place.
- **`src/persistence/queries.ts`** — `searchMessages` now reads `tsv` directly instead of recomputing `to_tsvector(content)` per row. The GIN index backs the match.

### Acceptance criteria (all met)

- [x] One path chosen and implemented (path 1 — drizzle API)
- [x] GIN index on `tsv` added (was absent)
- [x] Test: insert message → query via `to_tsquery('aave:*')` → match (✓ in `persistence-tsv.test.ts`)
- [x] Inline TODO removed from `schema.ts`
- [x] All four gates green

### Tests added (5)

`tests/integration/persistence-tsv.test.ts`:
- auto-populates tsv on insert (no explicit value passed)
- matches via `to_tsquery` prefix lexeme
- rejects manual writes (column is GENERATED ALWAYS)
- GIN index on `tsv` exists in `pg_indexes`
- updates tsv when content changes (Postgres re-runs the generated expression)

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — exit 0 (33 pre-existing warnings)
- [x] `pnpm test` — 405/405 passing (was 400, +5 tsv)
- [x] `pnpm build` — clean
- [x] Existing hybrid-search test in `persistence.test.ts` still passes — proves the queries.ts swap didn't regress