### PR TITLE
fix(keeperhub): parse live API response shape for direct executions

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -31,7 +31,7 @@ Runtime design (frameworks, schemas, flows): see [[architecture]].
 - **F2.1** P0 KeeperHub MCP wired in via `https://app.keeperhub.com/mcp`
 - **F2.2** P0 Every agent tx routed through `create_workflow` + `execute_workflow` for audit trail
 - **F2.3** P0 `@keeperhub/wallet` x402 hook installed for outbound paid API calls (Base)
-- **F2.4** P0 Audit log surface: `get_execution_logs` exposed via CLI command
+- **F2.4** P0 Audit log surface: `get_direct_execution_status` exposed via CLI for direct executions (the path the audit middleware uses; arg `execution_id`, snake_case). `get_execution_logs` is workflow-only and uses `executionId` (camelCase).
 - **F2.5** P1 Daily knowledge cron uses KeeperHub Schedule trigger instead of local cron
 - **F2.6** P1 Spending guardrails: per-day cap, per-tx cap, configurable
 - **F2.7** P2 Submit feedback bounty entry ($500 builder feedback prize)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:eval": "vitest run tests/eval",
+    "smoke:kh": "tsx scripts/smoke-keeperhub.ts",
     "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -80,5 +81,6 @@
     "tsx": "latest",
     "typescript": "latest",
     "vitest": "latest"
-  }
+  },
+  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017"
 }

--- a/scripts/debug-kh-status.ts
+++ b/scripts/debug-kh-status.ts
@@ -1,0 +1,160 @@
+/**
+ * KeeperHub status-query debug.
+ *
+ * Re-runs OAuth, lists ALL tools, then probes status-query tools with
+ * multiple name + arg-shape variants and dumps raw JSON for each.
+ *
+ * Goal: determine the canonical name + arg shape + status string KH uses
+ * for direct executions, so we can fix `getExecutionStatus` in
+ * src/keeperhub/client.ts.
+ *
+ * Usage:
+ *   pnpm tsx scripts/debug-kh-status.ts <execution_id>
+ *   # default execution_id is the one from the failed smoke run
+ */
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { openInBrowser } from '@/init/browser'
+import { startLoopback } from '@/init/loopback'
+import { createKeeperHubClient } from '@/keeperhub/client'
+import {
+  buildAuthorizeUrl,
+  discoverAuthServer,
+  exchangeCode,
+  generatePkce,
+  generateState,
+  registerClient,
+} from '@/keeperhub/oauth'
+import { saveSession, sessionFromResponse } from '@/keeperhub/token'
+
+const PREFIX = '[debug:kh]'
+const LOOPBACK_TIMEOUT_MS = 180_000
+
+const DEFAULT_EXEC_ID = 'spgrp6oi4d5ea2fdugdny'
+
+function log(line: string): void {
+  process.stdout.write(`${PREFIX} ${line}\n`)
+}
+function ok(line: string): void {
+  process.stdout.write(`${PREFIX} OK   ${line}\n`)
+}
+function divider(label: string): void {
+  process.stdout.write(`\n${PREFIX} ===== ${label} =====\n`)
+}
+
+async function authenticate(tokenPath: string): Promise<void> {
+  log('OAuth: discovering auth server')
+  const meta = await discoverAuthServer()
+
+  const expectedState = generateState()
+  const lb = await startLoopback({ expectedState, timeoutMs: LOOPBACK_TIMEOUT_MS })
+  log(`OAuth: loopback listening at ${lb.redirectUri}`)
+
+  try {
+    const registered = await registerClient({
+      meta,
+      redirectUri: lb.redirectUri,
+      clientName: 'talos-debug',
+    })
+    const pkce = generatePkce()
+    const authorizeUrl = buildAuthorizeUrl({
+      meta,
+      clientId: registered.client_id,
+      redirectUri: lb.redirectUri,
+      pkce,
+      state: expectedState,
+    })
+    const opener = await openInBrowser(authorizeUrl)
+    if (!opener.opened) {
+      log('OAuth: could not open browser; paste this URL manually:')
+      log(`  ${authorizeUrl}`)
+    } else {
+      log('OAuth: browser opened, complete consent')
+    }
+
+    const { code } = await lb.result
+    const tokenRes = await exchangeCode({
+      meta,
+      clientId: registered.client_id,
+      ...(registered.client_secret !== undefined ? { clientSecret: registered.client_secret } : {}),
+      redirectUri: lb.redirectUri,
+      code,
+      pkceVerifier: pkce.verifier,
+    })
+    const session = sessionFromResponse(registered, tokenRes)
+    await saveSession(tokenPath, session)
+    ok(`OAuth complete; session saved -> ${tokenPath}`)
+  } finally {
+    await lb.close()
+  }
+}
+
+async function probe(
+  client: Awaited<ReturnType<typeof createKeeperHubClient>>,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<void> {
+  divider(`probe: ${toolName} args=${JSON.stringify(args)}`)
+  try {
+    const result = await client.callTool(toolName, args)
+    log('RAW RESULT:')
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+  } catch (err) {
+    log(`ERROR: ${err instanceof Error ? err.message : String(err)}`)
+  }
+}
+
+async function main(): Promise<void> {
+  const execId = process.argv[2] || DEFAULT_EXEC_ID
+  const tokenPath = path.join(os.tmpdir(), `talos-debug-kh-${process.pid}-${Date.now()}.json`)
+  log(`execution_id: ${execId}`)
+  log(`temp token path: ${tokenPath}`)
+
+  let client: Awaited<ReturnType<typeof createKeeperHubClient>> | undefined
+  try {
+    await authenticate(tokenPath)
+
+    client = await createKeeperHubClient({ tokenPath })
+    const tools = await client.listTools()
+    const toolNames = Object.keys(tools).sort()
+
+    divider(`all ${toolNames.length} KH tools`)
+    for (const name of toolNames) {
+      const t = tools[name]
+      const desc = (t as { description?: string })?.description ?? ''
+      log(`  ${name}${desc ? ` — ${desc.slice(0, 80)}` : ''}`)
+    }
+
+    const candidates = toolNames.filter(
+      (n) => n.includes('execution') || n.includes('status') || n.includes('run'),
+    )
+    divider(`candidate status-query tools (${candidates.length})`)
+    for (const c of candidates) log(`  ${c}`)
+
+    const argShapes: Array<Record<string, unknown>> = [
+      { execution_id: execId },
+      { executionId: execId },
+      { id: execId },
+      { run_id: execId },
+    ]
+
+    for (const name of candidates) {
+      for (const args of argShapes) {
+        await probe(client, name, args)
+      }
+    }
+  } catch (err) {
+    process.stderr.write(
+      `${PREFIX} FATAL: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+    )
+    process.exitCode = 1
+  } finally {
+    if (client) await client.close().catch(() => undefined)
+    await fs.unlink(tokenPath).catch(() => undefined)
+    log(`(cleanup) temp token removed`)
+  }
+}
+
+main()

--- a/scripts/smoke-keeperhub.ts
+++ b/scripts/smoke-keeperhub.ts
@@ -1,0 +1,254 @@
+/**
+ * KeeperHub live smoke test (Phase B + Phase C).
+ *
+ * Phase B (always runs):
+ *   - OAuth round-trip: discover -> DCR -> loopback -> browser -> exchange -> save
+ *   - MCP connect + listTools()
+ *   - One read attempt (get_execution_logs with empty args, fail-soft)
+ *
+ * Phase C (gated on confirm):
+ *   - executeTransfer on Sepolia
+ *   - Poll until terminal status, print workflow URL + tx hash
+ *
+ * Token is written to a TEMP path. The real session at
+ * ~/.config/talos/keeperhub.token is never touched.
+ *
+ * Run: pnpm smoke:kh
+ */
+
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { confirm, input } from '@inquirer/prompts'
+import { openInBrowser } from '@/init/browser'
+import { startLoopback } from '@/init/loopback'
+import { createKeeperHubClient } from '@/keeperhub/client'
+import {
+  buildAuthorizeUrl,
+  discoverAuthServer,
+  exchangeCode,
+  generatePkce,
+  generateState,
+  registerClient,
+} from '@/keeperhub/oauth'
+import { saveSession, sessionFromResponse } from '@/keeperhub/token'
+
+const PREFIX = '[smoke:kh]'
+const LOOPBACK_TIMEOUT_MS = 180_000
+const POLL_TIMEOUT_MS = 90_000
+const POLL_INTERVAL_MS = 3_000
+
+function log(line: string): void {
+  process.stdout.write(`${PREFIX} ${line}\n`)
+}
+function ok(line: string): void {
+  process.stdout.write(`${PREFIX} OK   ${line}\n`)
+}
+function warn(line: string): void {
+  process.stdout.write(`${PREFIX} WARN ${line}\n`)
+}
+function failLine(line: string): void {
+  process.stderr.write(`${PREFIX} FAIL ${line}\n`)
+}
+function redact(token: string): string {
+  if (token.length <= 12) return '***'
+  return `${token.slice(0, 8)}...${token.slice(-4)} (len=${token.length})`
+}
+
+async function phaseB(tokenPath: string): Promise<{
+  toolNames: string[]
+  client: Awaited<ReturnType<typeof createKeeperHubClient>>
+}> {
+  log('=== Phase B: OAuth + MCP listTools (live) ===')
+
+  log('1/5 discover auth server')
+  const meta = await discoverAuthServer()
+  ok(`issuer=${meta.issuer}`)
+  ok(`authorization_endpoint=${meta.authorization_endpoint}`)
+  ok(`token_endpoint=${meta.token_endpoint}`)
+
+  log('2/5 start loopback (binds 127.0.0.1:<ephemeral>)')
+  const expectedState = generateState()
+  const lb = await startLoopback({ expectedState, timeoutMs: LOOPBACK_TIMEOUT_MS })
+  ok(`redirect_uri=${lb.redirectUri}`)
+
+  let registered: Awaited<ReturnType<typeof registerClient>> | null = null
+  let success = false
+  try {
+    log('3/5 dynamic client registration (DCR)')
+    registered = await registerClient({
+      meta,
+      redirectUri: lb.redirectUri,
+      clientName: 'talos-smoke',
+    })
+    ok(`client_id=${registered.client_id}`)
+
+    log('4/5 build authorize URL + open browser')
+    const pkce = generatePkce()
+    const authorizeUrl = buildAuthorizeUrl({
+      meta,
+      clientId: registered.client_id,
+      redirectUri: lb.redirectUri,
+      pkce,
+      state: expectedState,
+    })
+    const opener = await openInBrowser(authorizeUrl)
+    if (opener.opened) {
+      ok('browser opened, complete consent there')
+    } else {
+      warn('could not open browser automatically; paste this URL manually:')
+      log(`  ${authorizeUrl}`)
+    }
+
+    log(`     waiting up to ${LOOPBACK_TIMEOUT_MS / 1000}s for callback...`)
+    const { code } = await lb.result
+    ok(`callback received (code length=${code.length})`)
+
+    log('5/5 exchange code for token + save to temp path')
+    const tokenRes = await exchangeCode({
+      meta,
+      clientId: registered.client_id,
+      ...(registered.client_secret !== undefined ? { clientSecret: registered.client_secret } : {}),
+      redirectUri: lb.redirectUri,
+      code,
+      pkceVerifier: pkce.verifier,
+    })
+    ok(`access_token=${redact(tokenRes.access_token)}`)
+    ok(`scope=${tokenRes.scope ?? '(none)'}`)
+    ok(`expires_in=${tokenRes.expires_in ?? '(none)'}s`)
+    ok(`refresh_token=${tokenRes.refresh_token ? 'present' : 'absent'}`)
+
+    const session = sessionFromResponse(registered, tokenRes)
+    await saveSession(tokenPath, session)
+    ok(`session saved -> ${tokenPath}`)
+
+    log('     creating KeeperHub MCP client')
+    const client = await createKeeperHubClient({ tokenPath })
+    const tools = await client.listTools()
+    const toolNames = Object.keys(tools)
+    if (toolNames.length === 0) {
+      throw new Error('listTools() returned 0 tools')
+    }
+    ok(`listTools() returned ${toolNames.length} tool(s)`)
+    log(`     first 10: ${toolNames.slice(0, 10).join(', ')}`)
+
+    if (toolNames.includes('get_execution_logs')) {
+      try {
+        const result = await client.callTool('get_execution_logs', {})
+        ok('get_execution_logs() returned (truncated):')
+        const preview = JSON.stringify(result).slice(0, 200)
+        log(`     ${preview}${preview.length === 200 ? '...' : ''}`)
+      } catch (err) {
+        warn(`get_execution_logs failed: ${err instanceof Error ? err.message : String(err)}`)
+        warn('continuing — listTools() handshake already proves auth + transport')
+      }
+    } else {
+      warn('get_execution_logs not in tool surface; skipped read attempt')
+    }
+
+    success = true
+    return { toolNames, client }
+  } finally {
+    await lb.close()
+    if (!success) {
+      log('     (loopback closed; cleanup partial — see error above)')
+    }
+  }
+}
+
+async function phaseC(client: Awaited<ReturnType<typeof createKeeperHubClient>>): Promise<void> {
+  log('=== Phase C: live mutate (Sepolia executeTransfer) ===')
+  log('This will fire a REAL KeeperHub workflow against your KH-linked wallet.')
+  log('Make sure that wallet has Sepolia ETH. KH chooses the sender; we pick recipient + amount.')
+
+  const proceed = await confirm({
+    message: 'Proceed with Phase C?',
+    default: false,
+  })
+  if (!proceed) {
+    warn('Phase C skipped (user declined)')
+    return
+  }
+
+  const recipient = await input({
+    message:
+      'Recipient address on Sepolia (recommend YOUR OWN address for a no-loss self-transfer):',
+    validate: (v) =>
+      /^0x[a-fA-F0-9]{40}$/.test(v.trim()) || 'must be a 0x-prefixed 40-char hex address',
+  })
+  const amount = await input({
+    message: 'Amount in ETH:',
+    default: '0.0001',
+    validate: (v) => Number.parseFloat(v) > 0 || 'must be > 0',
+  })
+
+  log(`firing executeTransfer: sepolia, ${amount} ETH -> ${recipient.trim()}`)
+  const exec = await client.executeTransfer({
+    network: 'sepolia',
+    recipient_address: recipient.trim(),
+    amount,
+  })
+  ok(`execution_id=${exec.executionId || '(empty)'}`)
+  ok(`initial status=${exec.status}`)
+  if (exec.txHash) ok(`tx_hash=${exec.txHash}`)
+  if (exec.error) warn(`initial error field=${exec.error}`)
+
+  if (!exec.executionId) {
+    warn('no execution_id returned; cannot poll. Raw output above.')
+    return
+  }
+
+  log(`polling status every ${POLL_INTERVAL_MS / 1000}s (up to ${POLL_TIMEOUT_MS / 1000}s)...`)
+  const startedAt = Date.now()
+  let last = exec
+  while (Date.now() - startedAt < POLL_TIMEOUT_MS) {
+    if (last.status === 'success' || last.status === 'failed' || last.status === 'cancelled') {
+      break
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS))
+    last = await client.getExecutionStatus(exec.executionId)
+    log(`     status=${last.status}${last.txHash ? ` tx=${last.txHash}` : ''}`)
+  }
+
+  if (last.status === 'success') {
+    ok(`workflow succeeded`)
+    if (last.txHash) {
+      ok(`tx_hash=${last.txHash}`)
+      ok(`explorer: https://sepolia.etherscan.io/tx/${last.txHash}`)
+    }
+  } else {
+    failLine(`workflow terminal status=${last.status}${last.error ? ` error=${last.error}` : ''}`)
+    process.exitCode = 2
+  }
+}
+
+async function main(): Promise<void> {
+  const tokenPath = path.join(os.tmpdir(), `talos-smoke-kh-${process.pid}-${Date.now()}.json`)
+  log(`temp token path: ${tokenPath}`)
+
+  let client: Awaited<ReturnType<typeof createKeeperHubClient>> | undefined
+  try {
+    const phaseBResult = await phaseB(tokenPath)
+    client = phaseBResult.client
+
+    log('')
+    ok('Phase B passed.')
+    log('')
+
+    await phaseC(client)
+
+    log('')
+    ok('smoke test complete')
+  } catch (err) {
+    failLine(err instanceof Error ? (err.stack ?? err.message) : String(err))
+    process.exitCode = 1
+  } finally {
+    if (client) {
+      await client.close().catch(() => undefined)
+    }
+    await fs.unlink(tokenPath).catch(() => undefined)
+    log(`(cleanup) temp token removed: ${tokenPath}`)
+  }
+}
+
+main()

--- a/src/keeperhub/client.ts
+++ b/src/keeperhub/client.ts
@@ -46,8 +46,13 @@ export type ExecutionResult = {
   executionId: string
   status: WorkflowExecutionStatus
   txHash?: string
+  transactionLink?: string
   output?: unknown
   error?: string
+}
+
+const STATUS_SYNONYMS: Record<string, WorkflowExecutionStatus> = {
+  completed: 'success',
 }
 
 export interface KeeperHubClient {
@@ -130,7 +135,17 @@ export async function createKeeperHubClient(opts: KeeperHubClientOpts): Promise<
         headers: { Authorization: `Bearer ${token}` },
       } as unknown as MCPTransport,
       name: 'talos-keeperhub',
-      onUncaughtError: (err) => log.error({ err }, 'KeeperHub MCP uncaught error'),
+      onUncaughtError: (err) => {
+        // KH's MCP server rejects the SDK's optional GET-SSE inbound channel
+        // with 400 instead of the spec-conforming 405; downgrade since it's
+        // expected and harmless. All other transport errors still surface.
+        const msg = err instanceof Error ? err.message : String(err)
+        if (msg.includes('GET SSE failed: 400')) {
+          log.debug({ err }, 'KeeperHub MCP: optional inbound SSE not supported (expected)')
+          return
+        }
+        log.error({ err }, 'KeeperHub MCP uncaught error')
+      },
     })
     return mcp
   }
@@ -161,22 +176,34 @@ export async function createKeeperHubClient(opts: KeeperHubClientOpts): Promise<
           ? r.executionId
           : ''
     const statusRaw = (r.status ?? r.state) as string | undefined
+    const normalized = statusRaw ? (STATUS_SYNONYMS[statusRaw] ?? statusRaw) : ''
     const status = (
-      ['pending', 'running', 'success', 'failed', 'cancelled'].includes(statusRaw ?? '')
-        ? statusRaw
+      ['pending', 'running', 'success', 'failed', 'cancelled'].includes(normalized)
+        ? normalized
         : 'pending'
     ) as WorkflowExecutionStatus
     const txHash =
-      typeof r.tx_hash === 'string'
-        ? r.tx_hash
-        : typeof r.txHash === 'string'
-          ? r.txHash
+      typeof r.transactionHash === 'string'
+        ? r.transactionHash
+        : typeof r.transaction_hash === 'string'
+          ? r.transaction_hash
+          : typeof r.tx_hash === 'string'
+            ? r.tx_hash
+            : typeof r.txHash === 'string'
+              ? r.txHash
+              : undefined
+    const transactionLink =
+      typeof r.transactionLink === 'string'
+        ? r.transactionLink
+        : typeof r.transaction_link === 'string'
+          ? r.transaction_link
           : undefined
     const error = typeof r.error === 'string' ? r.error : undefined
     return {
       executionId,
       status,
       ...(txHash !== undefined ? { txHash } : {}),
+      ...(transactionLink !== undefined ? { transactionLink } : {}),
       ...(error !== undefined ? { error } : {}),
       output: r,
     }

--- a/tests/integration/keeperhub.test.ts
+++ b/tests/integration/keeperhub.test.ts
@@ -868,6 +868,57 @@ describe('createKeeperHubClient', () => {
     await client.close()
   })
 
+  it('parses live KH direct-execution response (completed, transactionHash, transactionLink)', async () => {
+    const mockMcp = {
+      tools: vi.fn().mockResolvedValue({
+        get_direct_execution_status: {
+          description: 'status',
+          execute: vi.fn().mockResolvedValue({
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  executionId: 'spgrp6oi4d5ea2fdugdny',
+                  status: 'completed',
+                  type: 'transfer',
+                  transactionHash:
+                    '0xb6e8ad92f820436900a447dcb3490dfea65851de0c4f1276fc5d067e31ffcdd9',
+                  transactionLink:
+                    'https://sepolia.etherscan.io/tx/0xb6e8ad92f820436900a447dcb3490dfea65851de0c4f1276fc5d067e31ffcdd9',
+                  error: null,
+                  network: 'sepolia',
+                }),
+              },
+            ],
+          }),
+        },
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    mockCreateMCPClient.mockResolvedValue(mockMcp)
+
+    await saveSession(tokenPath, {
+      client: { client_id: 'client-abc' },
+      accessToken: 'at-fresh',
+      refreshToken: 'rt-1',
+      expiresAt: Date.now() + 3_600_000,
+      tokenType: 'Bearer',
+    })
+    const client = await createKeeperHubClient({
+      tokenPath,
+      authServerMetadata: FAKE_META,
+    })
+    const out = await client.getExecutionStatus('spgrp6oi4d5ea2fdugdny')
+    expect(out.executionId).toBe('spgrp6oi4d5ea2fdugdny')
+    expect(out.status).toBe('success')
+    expect(out.txHash).toBe('0xb6e8ad92f820436900a447dcb3490dfea65851de0c4f1276fc5d067e31ffcdd9')
+    expect(out.transactionLink).toBe(
+      'https://sepolia.etherscan.io/tx/0xb6e8ad92f820436900a447dcb3490dfea65851de0c4f1276fc5d067e31ffcdd9',
+    )
+    expect(out.error).toBeUndefined()
+    await client.close()
+  })
+
   it('callTool throws when target tool is missing on the server', async () => {
     const mockMcp = {
       tools: vi.fn().mockResolvedValue({}),


### PR DESCRIPTION
## Summary

Live smoke test caught two parser bugs in `getExecutionStatus`. KH returns `status: "completed"` (we only mapped `"success"`) and the tx hash field is `transactionHash` (we only probed `tx_hash` / `txHash`). Result: poll loop returned `pending` forever even after on-chain confirmation. Runtime audit trail would have been silently broken in the demo.

Also: KH's MCP server returns 400 instead of 405 when the @ai-sdk/mcp client opens the optional GET-SSE inbound channel, producing a noisy `ERROR: KeeperHub MCP uncaught error` in every run. Downgrade just that specific case to debug.

Discovered by running `pnpm smoke:kh` against `app.keeperhub.com` on 2026-05-02. Tx confirmed on-chain ([`0xb6e8ad92...`](https://sepolia.etherscan.io/tx/0xb6e8ad92f820436900a447dcb3490dfea65851de0c4f1276fc5d067e31ffcdd9)), KH dashboard showed Success, our code showed pending. Captured the raw response via `scripts/debug-kh-status.ts` and fed the actual JSON into the new test.

## Changes

- `src/keeperhub/client.ts`
  - `STATUS_SYNONYMS = { completed: 'success' }` lookup
  - `transactionHash` + `transaction_hash` added to txHash field probe
  - `transactionLink` extracted onto `ExecutionResult` so audit log can show explorer URLs
  - `onUncaughtError`: filter `GET SSE failed: 400` to debug; everything else still surfaces as error
- `tests/integration/keeperhub.test.ts` + 1 test asserting the exact live KH JSON shape
- `docs/spec.md` F2.4 corrected: name `get_direct_execution_status` for the audit-log CLI surface (the path the audit middleware uses); note that `get_execution_logs` is workflow-only with camelCase `executionId`
- `scripts/smoke-keeperhub.ts` + `scripts/debug-kh-status.ts` + `pnpm smoke:kh` — live integration test scaffolding

## Test plan

- [x] `pnpm test` — 425 passed (was 424; +1 for the new live-shape test)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean on changed files
- [ ] Re-run `pnpm smoke:kh` post-merge, decline Phase C, confirm no `ERROR: KeeperHub MCP uncaught error` appears