### PR TITLE
fix(ci): drop hardcoded pnpm version, defer to packageManager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

CI broke on PR #45 with:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.30.3+... in the package.json with the key "packageManager"
```

`packageManager` got added to package.json, and `pnpm/action-setup@v4` refuses to run when both `version:` and `packageManager` are present. Drop the workflow's hardcoded `version: 10` so it reads from package.json — keeps the version source-of-truth in one place.

## Test plan
- [ ] CI green on this PR