### PR TITLE
feat: openclaw-parity quickstart (one-line installer + first-run hints + dual-runtime memory docs)

### DIFF
--- a/site/public/install.sh
+++ b/site/public/install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Talos one-line installer.
+#
+#   curl -fsSL https://talos.allensaji.dev/install.sh | bash
+#
+# Or, with a custom target dir:
+#
+#   curl -fsSL https://talos.allensaji.dev/install.sh | TALOS_DIR=$HOME/code/talos bash
+#
+# Requires: git, node (>= 22), pnpm (>= 9). The script will fail fast with a
+# clear message if any of these are missing.
+
+set -euo pipefail
+
+TALOS_DIR="${TALOS_DIR:-$HOME/.local/share/talos}"
+TALOS_REPO="${TALOS_REPO:-https://github.com/Allen-Saji/talos.git}"
+TALOS_BRANCH="${TALOS_BRANCH:-main}"
+
+PREFIX="[talos:install]"
+
+log()  { printf '%s %s\n' "$PREFIX" "$*"; }
+fail() { printf '%s ERROR: %s\n' "$PREFIX" "$*" >&2; exit 1; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 not found on PATH; install $1 and re-run"
+}
+
+require git
+require node
+require pnpm
+
+NODE_MAJOR=$(node -p 'process.versions.node.split(".")[0]')
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  fail "Node 22+ required (you have $(node -v))"
+fi
+
+if [ -d "$TALOS_DIR/.git" ]; then
+  log "found existing checkout at $TALOS_DIR; updating"
+  git -C "$TALOS_DIR" fetch --quiet origin "$TALOS_BRANCH"
+  git -C "$TALOS_DIR" checkout --quiet "$TALOS_BRANCH"
+  git -C "$TALOS_DIR" pull --ff-only --quiet
+else
+  log "cloning $TALOS_REPO into $TALOS_DIR"
+  git clone --quiet --branch "$TALOS_BRANCH" "$TALOS_REPO" "$TALOS_DIR"
+fi
+
+cd "$TALOS_DIR"
+
+log "installing dependencies"
+pnpm install --frozen-lockfile --silent
+
+log "building"
+pnpm build > /dev/null
+
+log "linking globally so 'talos' is on PATH"
+if pnpm link --global > /dev/null 2>&1; then
+  log "linked"
+else
+  log "global link failed (often needs sudo); to link manually:"
+  log "  cd $TALOS_DIR && pnpm link --global"
+fi
+
+cat <<EOF
+
+$PREFIX done.
+
+  installed at: $TALOS_DIR
+
+  next:
+    talos init       # bootstrap config, wallet, KeeperHub OAuth
+    talos repl       # interactive chat after init
+    talos doctor     # diagnose any misconfig
+
+  docs: https://talos.allensaji.dev/docs/get-started/overview
+
+EOF

--- a/site/src/content/docs/docs/embedding/overview.md
+++ b/site/src/content/docs/docs/embedding/overview.md
@@ -16,11 +16,34 @@ For the per-host config snippets, see [Channels → MCP server](/docs/channels/m
 | `eth_status` | no | Wallet, chains, last-sync, enabled MCPs. |
 | `talos_new_thread` | no | Reset the host's session thread. Useful when context shifts and you want a clean slate. |
 
+## How Talos coexists with the host's memory
+
+When OpenClaw, Claude Desktop, or Cursor embeds Talos, you have **two runtimes and two memory stores side by side**. They do not merge — the only thing crossing the boundary is the input string going in and the result string coming out.
+
+| Store | Owner | Contents |
+|---|---|---|
+| Host session log (e.g. `~/.openclaw/agents/<id>/sessions/<sid>.jsonl`) | Host | Full user-host conversation, including the `eth_action` call and result |
+| Host persona files (`SOUL.md`, `AGENTS.md`, etc.) | Host | Host's persona, your profile, host-side tool conventions |
+| `~/.config/talos/talos.db` (PGLite) | Talos | Threads, runs, steps, tool_calls, embeddings — only the ETH conversation |
+| `~/.config/talos/burner.json` | Talos | The wallet that signs every tx |
+
+What this means in practice:
+
+- **The host's persona doesn't reach Talos.** Talos has its own ETH-specialist persona on the inside.
+- **You can nudge the host to delegate.** In OpenClaw's `AGENTS.md` for example: *"For any ETH/DeFi questions, prefer the talos_eth tools (`eth_action`, `eth_status`, `query_eth_knowledge`). Don't try to do ETH math directly."*
+- **Talos owns the wallet.** Whether you drive it from your host or from `talos repl` directly, the same wallet signs.
+- **Audit is unified on the Talos side.** Every mutating call from any host (or any Talos channel) lands in the same `tool_calls` table behind the KH middleware.
+
 ## Threading
 
-When a host spawns Talos via stdio, the thread keys as `mcp:{pid}:{startedAt}`. **Per host session.** Each Claude Desktop launch gets a fresh thread — but cross-thread recall still bridges to your CLI and Telegram history at cosine ≥ 0.78.
+When a host spawns Talos via stdio, the thread keys as `mcp:{pid}:{startedAt}`. **Per host session.** Each Claude Desktop launch gets a fresh thread — but Talos's cross-thread recall still bridges to your CLI and Telegram history at cosine ≥ 0.78.
 
 If you want continuity across host launches, call `talos_new_thread` and pass `threadId` explicitly via the host's MCP routing (some hosts allow this).
+
+## Tool surface today vs roadmap
+
+- **Today (Path A):** the host sees four flat tools — `eth_action`, `query_eth_knowledge`, `eth_status`, `talos_new_thread`. Inside `eth_action`, Talos runs its own LLM loop over the curated DeFi MCPs (Aave, Uniswap, Li.Fi, Blockscout, AgentKit, EVM-MCP) and returns the result.
+- **Roadmap (Path B, spec F9.8):** Talos re-exports its DeFi MCPs under a `talos.*` namespace so the host's LLM can call `talos.aave_supply` / `talos.uniswap_quote` directly without nested LLM loops. Useful for hosts that want a curated tool bundle rather than a delegated agent.
 
 ## Streaming semantics
 

--- a/site/src/content/docs/docs/get-started/install.md
+++ b/site/src/content/docs/docs/get-started/install.md
@@ -7,19 +7,30 @@ description: Install Talos from source. Node 22+, pnpm 9+, an OpenAI API key.
 
 - **Node.js** ≥ 22
 - **pnpm** ≥ 9
+- **git**
 - An **OpenAI API key** (BYOK — Talos never sees keys you don't paste in)
 
-## Install from source
+## Install (one-liner)
+
+```bash
+curl -fsSL https://talos.allensaji.dev/install.sh | bash
+```
+
+Installs to `~/.local/share/talos`, builds, and links `talos` globally. Override the location with `TALOS_DIR=...`.
+
+:::note
+npm publish is on the roadmap. The package name is TBD because `talos` collides with Talos Linux on npm. Until then, the installer above (or the manual path below) is the canonical install.
+:::
+
+## Install from source (manual)
 
 ```bash
 git clone https://github.com/Allen-Saji/talos.git
 cd talos
 pnpm install
+pnpm build
+pnpm link --global
 ```
-
-:::note
-npm publish is on the roadmap. The package name is TBD because `talos` collides with Talos Linux on npm. Until then, install from source.
-:::
 
 ## Verify
 
@@ -28,15 +39,11 @@ pnpm typecheck
 pnpm test
 ```
 
-Expect all 35 test files green and ~424 individual tests passing.
+Expect 35 test files green and 425+ individual tests passing.
 
-## Build
+## Binaries
 
-```bash
-pnpm build
-```
-
-Produces two binaries in `dist/bin/`:
+`pnpm build` produces two entrypoints in `dist/bin/`:
 
 | Binary | Role |
 |---|---|

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -15,6 +15,14 @@
         { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
         { "key": "Cache-Control", "value": "public, max-age=300" }
       ]
+    },
+    {
+      "source": "/install.sh",
+      "headers": [
+        { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
+        { "key": "Cache-Control", "value": "public, max-age=300" },
+        { "key": "X-Talos-Channel", "value": "install-sh" }
+      ]
     }
   ],
   "cleanUrls": true

--- a/src/init/steps/summary.ts
+++ b/src/init/steps/summary.ts
@@ -38,6 +38,15 @@ export function runSummaryStep(ctx: WizardContext, deps: SummaryStepDeps = {}): 
     print('    talos install-service      # run as a background service')
   }
   print('')
+  print('  Try this in the REPL:')
+  print('    > what is my balance on sepolia?')
+  print('    > supply 0.0001 USDC to aave on sepolia')
+  print('    > what changed in the eth ecosystem since yesterday?')
+  print('')
+  print('  Embed Talos in another agent host:')
+  print('    Claude Desktop / Cursor / OpenClaw — see docs/channels/mcp')
+  print('    Direct stdio:                       talos serve --mcp')
+  print('')
 
   return { status: 'done', summary: 'Summary printed' }
 }


### PR DESCRIPTION
## Summary

Closes the three OpenClaw-parity gaps surfaced when comparing our docs side-by-side:

1. **One-line installer** (`curl -fsSL .../install.sh | bash`) so we match OpenClaw's `npm install -g openclaw@latest` UX without waiting on npm publish.
2. **First-run hints** in the wizard summary — three example REPL queries + an embed-in-host pointer. Closer to OpenClaw's BOOTSTRAP.md vibe without a full SOUL.md system.
3. **Dual-runtime memory section** in the embedding docs. Answers the question "OpenClaw has its own memory, how does our arch play there?" — explicit table of who-owns-what plus Path A (today) vs Path B (F9.8 roadmap).

## Changes

- `src/init/steps/summary.ts` — appended "Try this" + "Embed in another host" blocks to the post-init printout
- `site/public/install.sh` — new one-liner; verifies git/node>=22/pnpm, clones into `TALOS_DIR` (default `~/.local/share/talos`), `pnpm install + build + link --global`, prints next-steps banner
- `site/vercel.json` — serve `/install.sh` as `text/plain; charset=utf-8` so curl-pipe-bash works cleanly
- `site/src/content/docs/docs/get-started/install.md` — lead with the curl one-liner; demote git-clone to "manual" path; updated test count claim 424 -> 425
- `site/src/content/docs/docs/embedding/overview.md` — new "How Talos coexists with the host's memory" section + "Tool surface today vs roadmap"

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run tests/integration/init-wizard.test.ts` — 3/3 pass (existing assertions on "Talos init complete" + "talos repl" still hold)
- [x] `bash -n site/public/install.sh` — syntax-clean
- [ ] CI green
- [ ] Post-deploy: `curl -fsSL https://talos.allensaji.dev/install.sh` returns the script as text/plain