### PR TITLE
fix: walkthrough gaps (autostart + env bool + dotenv multi-path + stdio banner noise)

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,6 +1,14 @@
-import 'dotenv/config'
+import path from 'node:path'
+import { config as loadDotenv } from 'dotenv'
 import { z } from 'zod'
+import { paths } from '@/config/paths'
 import { TalosConfigError } from '@/shared/errors'
+
+// Load configDir/.env first (the canonical location the wizard writes to).
+// Then CWD/.env with default override:false — dev-time project-root .env can
+// add extras but won't shadow values the wizard placed under ~/.config/talos.
+loadDotenv({ path: path.join(paths.configDir, '.env') })
+loadDotenv()
 
 /** Coerce empty string to undefined (dotenv sets VAR= as "") */
 const optionalUrl = z.preprocess((v) => (v === '' ? undefined : v), z.string().url().optional())
@@ -9,6 +17,26 @@ const optionalNonEmpty = z.preprocess(
   (v) => (v === '' ? undefined : v),
   z.string().min(1).optional(),
 )
+
+/**
+ * String-aware boolean for env vars. `z.coerce.boolean()` is a footgun: every
+ * non-empty string (including the literal "false") coerces to `true`. This
+ * parser respects "true|1|yes|on" / "false|0|no|off" with a configurable
+ * default for missing/empty values.
+ */
+function envBool(def: boolean): z.ZodType<boolean> {
+  return z
+    .preprocess((v) => {
+      if (v === undefined || v === null || v === '') return def
+      if (typeof v === 'boolean') return v
+      if (typeof v !== 'string') return Boolean(v)
+      const s = v.trim().toLowerCase()
+      if (s === 'true' || s === '1' || s === 'yes' || s === 'on') return true
+      if (s === 'false' || s === '0' || s === 'no' || s === 'off') return false
+      return def
+    }, z.boolean())
+    .default(def)
+}
 
 const EnvSchema = z.object({
   OPENAI_API_KEY: optionalNonEmpty,
@@ -42,9 +70,9 @@ const EnvSchema = z.object({
     .min(1)
     .default(24 * 60 * 60 * 1000),
   /** Disable the knowledge cron entirely (tests, dev). */
-  KNOWLEDGE_CRON_DISABLE: z.coerce.boolean().default(false),
+  KNOWLEDGE_CRON_DISABLE: envBool(false),
   /** Run the knowledge cron once at boot — used by `talos init`'s sync first-fetch. */
-  KNOWLEDGE_CRON_RUN_ON_BOOT: z.coerce.boolean().default(false),
+  KNOWLEDGE_CRON_RUN_ON_BOOT: envBool(false),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 })
 

--- a/src/daemon/autostart.ts
+++ b/src/daemon/autostart.ts
@@ -66,14 +66,20 @@ export async function ensureDaemonRunning(opts: EnsureDaemonOpts): Promise<Ensur
   const stdoutLog = fs.openSync(paths.logPath, 'a')
   const stderrLog = fs.openSync(paths.logPath, 'a')
 
-  const child = spawner(binPath, [], {
+  // Dev-mode source paths (.ts) need a tsx wrapper. Production paths (.js,
+  // bin entrypoints) are spawned directly.
+  const isDevSource = binPath.endsWith('.ts')
+  const cmd = isDevSource ? resolveTsxBin(binPath) : binPath
+  const cmdArgs = isDevSource ? [binPath] : []
+
+  const child = spawner(cmd, cmdArgs, {
     detached: true,
     stdio: ['ignore', stdoutLog, stderrLog],
     env: process.env,
   })
   child.unref()
   const pid = child.pid ?? 0
-  log.info({ pid, binPath }, 'spawned talosd; waiting for WS to come up')
+  log.info({ pid, binPath, cmd }, 'spawned talosd; waiting for WS to come up')
 
   const ok = await pollUntilReady(opts.url, bootTimeoutMs, probeTimeoutMs)
   if (!ok) {
@@ -149,18 +155,35 @@ function isAlive(pid: number): boolean {
 
 function resolveTalosdBin(): string {
   // Resolve relative to the running script. After build the binaries end up
-  // at dist/bin/talos.js + dist/bin/talosd.js. In dev (tsx) we resolve via
-  // the bin dir of the current process.
+  // at dist/bin/talos.js + dist/bin/talosd.js. In dev (tsx) the source lives
+  // at bin/talosd.ts. The .ts case is handled in ensureDaemonRunning by
+  // spawning through tsx.
   const argv1 = process.argv[1] ?? ''
   const here = path.dirname(argv1)
   const candidates = [
     path.join(here, 'talosd.js'),
     path.join(here, 'talosd'),
+    path.join(here, 'talosd.ts'),
     path.resolve(here, '..', 'bin', 'talosd.js'),
+    path.resolve(here, '..', 'bin', 'talosd.ts'),
   ]
   for (const c of candidates) {
     if (fs.existsSync(c)) return c
   }
   // Last resort: assume on PATH.
   return 'talosd'
+}
+
+function resolveTsxBin(scriptPath: string): string {
+  // Walk up from the script looking for node_modules/.bin/tsx. Falls back
+  // to the bare `tsx` command if nothing turns up — caller will get ENOENT.
+  let dir = path.dirname(scriptPath)
+  for (let depth = 0; depth < 8; depth++) {
+    const candidate = path.join(dir, 'node_modules', '.bin', 'tsx')
+    if (fs.existsSync(candidate)) return candidate
+    const parent = path.dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return 'tsx'
 }

--- a/src/mcp-host/host.ts
+++ b/src/mcp-host/host.ts
@@ -262,6 +262,18 @@ export class McpHost {
           transport: transport as MCPTransport | HttpTransportConfig,
           name: `talos-${config.name}`,
           onUncaughtError: (err) => {
+            // Some stdio MCP servers (e.g. mcpdotdirect/evm-mcp-server) print
+            // a startup banner to stdout before their first JSON-RPC frame.
+            // The transport JSON.parses every line and throws SyntaxError on
+            // the banner. The actual connection completes a beat later, so
+            // these are benign — log at debug, don't mark unhealthy.
+            if (err instanceof SyntaxError && /Unexpected token/.test(err.message)) {
+              log.debug(
+                { err, server: name },
+                'MCP stdio non-JSON line ignored (likely a startup banner)',
+              )
+              return
+            }
             log.error({ err, server: name }, 'uncaught MCP error — marking unhealthy')
             this.markUnhealthy(name, err instanceof Error ? err.message : String(err))
           },

--- a/tests/integration/autostart.test.ts
+++ b/tests/integration/autostart.test.ts
@@ -102,6 +102,34 @@ describe('ensureDaemonRunning — needs spawn', () => {
     expect(calls).toBe(1)
   })
 
+  it('spawns dev-mode .ts paths through tsx (not as a bare binary)', async () => {
+    type SpawnerFn = (cmd: string, args: string[], options: Record<string, unknown>) => ChildProcess
+    const fakeSpawner = vi.fn<SpawnerFn>(() => {
+      const fakeChild = new EventEmitter() as unknown as ChildProcess
+      ;(fakeChild as { pid: number }).pid = 99998
+      ;(fakeChild as { unref: () => void }).unref = () => {}
+      return fakeChild
+    })
+
+    await expect(
+      ensureDaemonRunning({
+        url: 'ws://127.0.0.1:1',
+        paths: {
+          pidPath: path.join(tmpDir, 'daemon.pid'),
+          logPath: path.join(tmpDir, 'talos.log'),
+        },
+        binPath: '/some/repo/bin/talosd.ts',
+        spawner: fakeSpawner,
+        bootTimeoutMs: 500,
+        probeTimeoutMs: 100,
+      }),
+    ).rejects.toThrow(/failed to come up/)
+
+    const [cmd, args] = fakeSpawner.mock.calls[0] ?? []
+    expect(cmd).toMatch(/(?:^|\/)tsx$/) // resolved tsx binary or bare 'tsx'
+    expect(args).toEqual(['/some/repo/bin/talosd.ts'])
+  })
+
   it('returns "started" when the spawner brings up a daemon', async () => {
     // We'll start the plane on a known port, then point autostart at it.
     // The spawner is a no-op; the plane is already-up but autostart's pre-check

--- a/tests/integration/mcp-host.test.ts
+++ b/tests/integration/mcp-host.test.ts
@@ -301,6 +301,23 @@ describe('McpHost', () => {
     await host.stop()
   })
 
+  it('ignores stdio JSON.parse SyntaxErrors (server startup banners)', async () => {
+    // Some stdio MCP servers print a banner before the first JSON-RPC frame.
+    // The transport throws SyntaxError on the banner; we should NOT mark
+    // the server unhealthy, since the connection completes a beat later.
+    const host = new McpHost()
+    await host.start([{ name: 'evmmcp', transport: 'http', url: 'https://mcp.evmmcp.com' }])
+    expect(host.isServerHealthy('evmmcp')).toBe(true)
+
+    const handler = lastOnUncaughtError()
+    handler?.(new SyntaxError('Unexpected token \'S\', "Starting EVM..."... is not valid JSON'))
+
+    expect(host.isServerHealthy('evmmcp')).toBe(true)
+    expect(host.getServerHealth().evmmcp?.lastError).toBeUndefined()
+
+    await host.stop()
+  })
+
   it('applies staticAnnotations overrides during registration', async () => {
     mockCreateMCPClient.mockResolvedValueOnce({
       tools: vi.fn().mockResolvedValue({

--- a/tests/unit/env-bool.test.ts
+++ b/tests/unit/env-bool.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { loadEnv, resetEnvCache } from '@/config/env'
+
+describe('env bool parser (KNOWLEDGE_CRON_DISABLE)', () => {
+  const previousValues: Record<string, string | undefined> = {}
+  const KEY = 'KNOWLEDGE_CRON_DISABLE'
+
+  beforeEach(() => {
+    previousValues[KEY] = process.env[KEY]
+  })
+
+  afterEach(() => {
+    if (previousValues[KEY] === undefined) delete process.env[KEY]
+    else process.env[KEY] = previousValues[KEY]
+    resetEnvCache()
+  })
+
+  for (const v of ['false', 'FALSE', '0', 'no', 'off', '']) {
+    it(`treats "${v}" as false (not the z.coerce.boolean footgun)`, () => {
+      process.env[KEY] = v
+      resetEnvCache()
+      expect(loadEnv().KNOWLEDGE_CRON_DISABLE).toBe(false)
+    })
+  }
+
+  for (const v of ['true', 'TRUE', '1', 'yes', 'on']) {
+    it(`treats "${v}" as true`, () => {
+      process.env[KEY] = v
+      resetEnvCache()
+      expect(loadEnv().KNOWLEDGE_CRON_DISABLE).toBe(true)
+    })
+  }
+
+  it('falls back to the default when unset', () => {
+    delete process.env[KEY]
+    resetEnvCache()
+    expect(loadEnv().KNOWLEDGE_CRON_DISABLE).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Three fixes for gaps surfaced during the live `talos init` walkthrough on 2026-05-02. Each was a real first-run cliff that judges would hit.

### 1. Autostart spawns dev-mode `talosd` via tsx (not bare PATH binary)

`pnpm dev:cli repl` (no global link, no build) failed with `spawn talosd ENOENT` because `resolveTalosdBin()` only checked for `.js` paths and fell through to bare `talosd` on PATH. Now also probes `bin/talosd.ts` and spawns through a resolved tsx binary when the path ends in `.ts`. Production `.js` paths and explicit `binPath` overrides still spawn directly.

### 2. `KNOWLEDGE_CRON_DISABLE` was always-true via the `z.coerce.boolean()` footgun

`z.coerce.boolean()` calls `Boolean(value)`, so any non-empty string coerces to `true` — including the literal `"false"`. Users putting `KNOWLEDGE_CRON_DISABLE=false` in `.env` got the cron DISABLED. Replaced with a string-aware `envBool()` parser (`true|1|yes|on` / `false|0|no|off`). Applied to `KNOWLEDGE_CRON_DISABLE` and `KNOWLEDGE_CRON_RUN_ON_BOOT`. 13 new unit tests cover both directions + unset default.

### 3. Daemon now loads `~/.config/talos/.env` in addition to CWD `.env`

The wizard wrote `TELEGRAM_BOT_TOKEN` to `~/.config/talos/.env` but `import 'dotenv/config'` only loaded CWD `.env`, so the token was invisible at runtime. Replaced with two explicit `loadDotenv()` calls — configDir first (canonical wizard location), then CWD with default `override: false`. Wizard writes are picked up; project-root `.env` can still add extras for dev.

### 4. MCP host ignores stdio banner SyntaxErrors

`mcpdotdirect/evm-mcp-server` prints a banner to stdout before its first JSON-RPC frame. The transport JSON.parses every line and throws SyntaxError. We were logging that as ERROR and marking the server unhealthy (it self-heals a beat later, but the noise stays). Now downgraded to debug log, no health flip. Same shape as the KH GET-SSE 400 filter from #45.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 439/439 pass (was 425; +14 covering all four fixes)
- [x] `pnpm lint` clean on changed files
- [ ] CI green
- [ ] Post-merge: re-run the walkthrough end-to-end on fresh `pnpm install` and confirm `pnpm dev:cli repl` boots talosd via autostart with no banner noise

## What's still open (out of scope here)

- **Test isolation**: `init-wizard.test.ts` migrations step reads global `paths.pidPath` even when test provides custom paths. Surfaced as a false-positive failure when a real `talosd` is running locally. Worth a follow-up but not blocking.
- **Telegram wizard schema mismatch**: deferred — Telegram channel is not in the demo path.