### PR TITLE
fix(keeperhub): log refresh outcomes (success / failure / skew)

### DIFF
--- a/src/keeperhub/client.ts
+++ b/src/keeperhub/client.ts
@@ -7,6 +7,7 @@ import {
   type AuthServerMetadata,
   discoverAuthServer,
   refreshToken as refreshTokenRpc,
+  type TokenResponse,
 } from './oauth'
 import { EXPIRY_BUFFER_MS, isExpired, loadSession, saveSession, sessionFromResponse } from './token'
 
@@ -109,17 +110,41 @@ export async function createKeeperHubClient(opts: KeeperHubClientOpts): Promise<
     }
     const meta = await authMetadata()
     log.info({ msUntilExpiry: session.expiresAt - Date.now() }, 'refreshing KeeperHub token')
-    const tokenRes = await refreshTokenRpc({
-      fetch: fetchImpl,
-      meta,
-      clientId: session.client.client_id,
-      ...(session.client.client_secret !== undefined
-        ? { clientSecret: session.client.client_secret }
-        : {}),
-      refreshToken: session.refreshToken,
-    })
+    let tokenRes: TokenResponse
+    try {
+      tokenRes = await refreshTokenRpc({
+        fetch: fetchImpl,
+        meta,
+        clientId: session.client.client_id,
+        ...(session.client.client_secret !== undefined
+          ? { clientSecret: session.client.client_secret }
+          : {}),
+        refreshToken: session.refreshToken,
+      })
+    } catch (err) {
+      log.error(
+        { err, clientId: session.client.client_id },
+        'KeeperHub token refresh failed — re-run `talos init` to re-auth',
+      )
+      throw err
+    }
     session = sessionFromResponse(session.client, tokenRes)
     await saveSession(opts.tokenPath, session)
+    const newMsUntilExpiry = session.expiresAt - Date.now()
+    if (newMsUntilExpiry <= 0) {
+      log.warn(
+        { newMsUntilExpiry, expiresAt: session.expiresAt },
+        'KeeperHub refresh returned an already-expired token — server clock skew or short TTL',
+      )
+    } else {
+      log.info(
+        {
+          newMsUntilExpiry,
+          newRefreshToken: tokenRes.refresh_token ? 'rotated' : 'unchanged',
+        },
+        'KeeperHub token refreshed',
+      )
+    }
     return session.accessToken
   }
 


### PR DESCRIPTION
## Summary

Surfaced while debugging an MCP-driven Uniswap swap: the daemon log printed `refreshing KeeperHub token` and then went silent, leaving no way to tell whether refresh succeeded, hung, or failed. Adding three log lines inside \`ensureToken\` closes the diagnostic gap permanently.

## Changes

\`src/keeperhub/client.ts\` — in the refresh path of \`ensureToken\`:
- **info** \`KeeperHub token refreshed\` on success, with \`newMsUntilExpiry\` + whether the refresh_token \`rotated\` (some auth servers rotate the RT on every refresh; others reuse — useful to know which KH does)
- **error** \`KeeperHub token refresh failed\` if \`refreshTokenRpc\` throws, with the original error and \`clientId\`. Wrapped in try/catch so the error is logged BEFORE rethrowing — surfaces the cause even if a downstream catch swallows it
- **warn** \`KeeperHub refresh returned an already-expired token\` if the new token's \`expiresAt\` is in the past — catches server clock skew and unusually short TTLs

No behavior change beyond logging.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm vitest run tests/integration/keeperhub.test.ts\` — 46/46 pass
- [x] \`pnpm lint\` clean
- [ ] CI green

## Why this is worth landing regardless of KH's future role

If KH stays primary: refresh observability is essential for ops.
If KH becomes optional: same — anyone enabling it gets useful logs.
If KH gets removed: this PR is a no-op cost (one file, ~25 LoC).

Same shape as the SSE 400 / SyntaxError filters from #45 / #48 — small, defensive, doesn't change architecture.