### PR TITLE
fix(keeperhub): repair execute_contract_call shape + add disable-mutates escape hatch

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -73,6 +73,13 @@ const EnvSchema = z.object({
   KNOWLEDGE_CRON_DISABLE: envBool(false),
   /** Run the knowledge cron once at boot — used by `talos init`'s sync first-fetch. */
   KNOWLEDGE_CRON_RUN_ON_BOOT: envBool(false),
+  /**
+   * Skip routing mutate tools through KeeperHub. When `true`, the audit
+   * middleware still records each call but the tool's original `execute`
+   * runs (direct viem TX from the burner wallet). Useful when the upstream
+   * KH service is degraded or for demos where deterministic latency matters.
+   */
+  KEEPERHUB_DISABLE_MUTATES: envBool(false),
   NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
 })
 

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -203,6 +203,17 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
     )
   }
 
+  // Operators can force mutate routing off (KEEPERHUB_DISABLE_MUTATES=true) to
+  // bypass an unhealthy upstream while keeping audit logging intact. Mutate
+  // tools fall through to direct viem execute; audit rows still get written.
+  const khMutatesDisabled = env.KEEPERHUB_DISABLE_MUTATES
+  if (khMutatesDisabled && khClient) {
+    logger.info(
+      'KEEPERHUB_DISABLE_MUTATES=true — mutate tools will execute directly via viem (audit logging still active)',
+    )
+  }
+  const khForMiddleware = khMutatesDisabled ? undefined : khClient
+
   // Per-run middleware factory. Bound at boot to db + annotation lookup +
   // optional KH client/routes; the runtime calls it per run with the runId so
   // audit rows carry the right run context. Single writer for `tool_calls`.
@@ -211,7 +222,7 @@ export async function startDaemon(startOpts: StartDaemonOpts = {}): Promise<Daem
       db: dbHandle.db,
       runContext: () => ctx,
       annotations: annotationLookup,
-      ...(khClient ? { kh: { client: khClient, routes } } : {}),
+      ...(khForMiddleware ? { kh: { client: khForMiddleware, routes } } : {}),
     })
 
   // Build runtime deps. Summarizer / fact pipeline still deferred (#16/#17).

--- a/src/keeperhub/client.ts
+++ b/src/keeperhub/client.ts
@@ -190,6 +190,7 @@ export async function createKeeperHubClient(opts: KeeperHubClientOpts): Promise<
   }
 
   function asExecutionResult(raw: unknown): ExecutionResult {
+    log.info({ raw, rawType: typeof raw }, 'KeeperHub raw execution response (pre-parse)')
     if (typeof raw !== 'object' || raw === null) {
       return { executionId: '', status: 'pending', output: raw }
     }

--- a/src/keeperhub/client.ts
+++ b/src/keeperhub/client.ts
@@ -191,6 +191,12 @@ export async function createKeeperHubClient(opts: KeeperHubClientOpts): Promise<
 
   function asExecutionResult(raw: unknown): ExecutionResult {
     log.info({ raw, rawType: typeof raw }, 'KeeperHub raw execution response (pre-parse)')
+    if (typeof raw === 'string') {
+      // KH surfaces tool-level failures as MCP error strings (e.g. schema-validation
+      // rejections). Treat these as failed executions so the middleware throws
+      // and the agent sees a real error instead of an empty `pending` shell.
+      return { executionId: '', status: 'failed', error: raw, output: raw }
+    }
     if (typeof raw !== 'object' || raw === null) {
       return { executionId: '', status: 'pending', output: raw }
     }
@@ -243,7 +249,21 @@ export async function createKeeperHubClient(opts: KeeperHubClientOpts): Promise<
     },
     callTool,
     async executeContractCall(input) {
-      return asExecutionResult(await callTool('execute_contract_call', input))
+      // KH's `execute_contract_call` schema requires `function_args` and `abi`
+      // as JSON strings (not arrays/objects). Serialize before sending so each
+      // protocol route can keep building structured payloads.
+      const payload: Record<string, unknown> = {
+        network: input.network,
+        contract_address: input.contract_address,
+        function_name: input.function_name,
+      }
+      if (input.function_args !== undefined) {
+        payload.function_args = JSON.stringify(input.function_args)
+      }
+      if (input.abi !== undefined) {
+        payload.abi = JSON.stringify(input.abi)
+      }
+      return asExecutionResult(await callTool('execute_contract_call', payload))
     },
     async executeTransfer(input) {
       return asExecutionResult(await callTool('execute_transfer', input))

--- a/src/keeperhub/middleware.ts
+++ b/src/keeperhub/middleware.ts
@@ -137,6 +137,17 @@ function wrapTool(name: string, original: Tool, deps: KeeperHubMiddlewareDeps): 
         if (route && khClient) {
           const callInput = await Promise.resolve(route(args))
           const exec = await khClient.executeContractCall(callInput)
+          log.info(
+            {
+              toolName: name,
+              executionId: exec.executionId,
+              status: exec.status,
+              txHash: exec.txHash,
+              transactionLink: exec.transactionLink,
+              error: exec.error,
+            },
+            'tool routed through keeperhub',
+          )
           executionId = exec.executionId
           if (exec.txHash) txHash = exec.txHash
           if (exec.status === 'failed' || exec.error) {


### PR DESCRIPTION
## Summary

Three commits on the KeeperHub integration, surfaced during May 2 demo prep when the upstream began returning Cloudflare 502/524 and accepting our `execute_contract_call` payloads only after a silent schema change.

- **feat(keeperhub): log raw + parsed execution responses** — adds two info-level log lines (raw response in `client.ts`'s `asExecutionResult`, parsed `{ executionId, status, txHash, error }` in middleware after `executeContractCall`). Future schema drifts leave a forensic breadcrumb instead of a silent empty-pending result.
- **fix(keeperhub): serialize function_args/abi + surface string errors as failed** — KH's `execute_contract_call` schema now requires `function_args` and `abi` as JSON strings. We now serialize them centrally in the client so route builders keep emitting structured `ContractCallInput`. Also: when KH returns its MCP error envelope as a string, we now treat it as a failed execution (with the string as `error`) so the middleware throws and the agent sees a real error instead of a phantom `pending` shell.
- **feat(keeperhub): add KEEPERHUB_DISABLE_MUTATES escape hatch** — operator-controlled fallback. When `KEEPERHUB_DISABLE_MUTATES=true`, mutate tools execute directly via viem (audit logging stays on, only the KH-routing branch is skipped). Used during demo prep when KH's `uniswap_swap_exact_in` workflow began returning `{ status: 'failed' }` with no error detail.

## Verification

- `uniswap_approve_router` succeeds end-to-end through KH after the JSON-stringify fix (`{ status: 'completed' }`).
- With `KEEPERHUB_DISABLE_MUTATES=true`, `swap 0.001 ETH for USDC on sepolia` via the Talos MCP integration in Claude Code completes via direct viem TX — no KH refresh, no `tool routed through keeperhub`, no errors.
- Daemon log shows: `KEEPERHUB_DISABLE_MUTATES=true — mutate tools will execute directly via viem (audit logging still active)` at boot when the flag is set.

## Test plan

- [ ] CI green (lint + typecheck + vitest).
- [ ] Existing keeperhub middleware tests still pass (no signature changes; route gating is still by `kh` presence in deps).
- [ ] Daemon boot still logs the existing `keeperhub session not configured` info when no token is on disk (separate code path; flag only affects the case where a client *was* built).