### PR TITLE
docs(keeperhub): document KEEPERHUB_DISABLE_MUTATES escape hatch

### DIFF
--- a/site/src/content/docs/docs/architecture/keeperhub.md
+++ b/site/src/content/docs/docs/architecture/keeperhub.md
@@ -47,3 +47,24 @@ Read this table to reconstruct any agent run, audit it, replay it, or pull tx ha
 ## Bypass list
 
 The `KNOWN_READONLY` regex is in `src/keeperhub/middleware.ts`. Adding to it requires a code change — intentionally; it's a security boundary. To override per call, set `annotations.readonly: true` on the MCP tool itself.
+
+## Escape hatch: `KEEPERHUB_DISABLE_MUTATES`
+
+Set `KEEPERHUB_DISABLE_MUTATES=true` in `~/.config/talos/.env` (or your shell) to skip KH routing for mutates. When the flag is on:
+
+| What | Behaviour |
+|---|---|
+| Mutate tools | Execute directly via viem against the configured RPC |
+| Read-only tools | Unchanged — still bypass KH as usual |
+| Audit log | Still written to `tool_calls` (no `kh_workflow_id`, no `executionId`) |
+| Latency | ~5s per swap on Sepolia vs ~2 min KH polling timeout |
+
+When to use it:
+
+- KH origin is returning 5xx or opaque `failed` workflow results
+- You're recording a demo and need predictable confirmation latency
+- Debugging encoding issues — direct viem surfaces the raw revert reason
+
+The flag is parsed by `envBool()`, which accepts `true`/`1`/`yes`/`on` (and the matching false values). No other variant.
+
+Long-term, KH stays the default. The flag exists so KH-side problems never block the local agent.

--- a/site/src/content/docs/docs/get-started/init.md
+++ b/site/src/content/docs/docs/get-started/init.md
@@ -28,7 +28,7 @@ The wizard walks you through seven steps:
 | Flag | What it does |
 |---|---|
 | `--non-interactive` | Skip all prompts; fail if any required input is missing. For CI. |
-| `--skip-keeperhub` | Defer the KeeperHub OAuth handoff. Talos starts without audit; mutating tools 502 until you finish OAuth via `talos doctor --keeperhub`. |
+| `--skip-keeperhub` | Defer the KeeperHub OAuth handoff. Talos starts without KH; mutating tools fail until you either finish OAuth via `talos doctor --keeperhub` or set [`KEEPERHUB_DISABLE_MUTATES=true`](/docs/architecture/keeperhub#escape-hatch-keeperhub_disable_mutates) to route mutates directly through viem (audit log stays on). |
 | `--reset-keeperhub` | Forget existing KeeperHub credentials; re-run OAuth only. |
 | `--reset-wallet` | Generate a fresh burner. **Destructive** — your old burner address is forgotten. |
 

--- a/site/src/content/docs/docs/reference/env.md
+++ b/site/src/content/docs/docs/reference/env.md
@@ -49,6 +49,12 @@ Talos reads its `.env` from the install directory and merges with the user shell
 | `TALOS_DB_PATH` | PGLite directory override (default `~/.config/talos/db`) |
 | `TALOS_LOG_LEVEL` | pino level: `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
 
+## KeeperHub
+
+| Var | Purpose |
+|---|---|
+| `KEEPERHUB_DISABLE_MUTATES` | When `true`, mutate tools skip KH routing and execute directly via viem. Audit logging to `tool_calls` stays on. Use during KH outages or to cut latency for demos. Accepts `true`/`1`/`yes`/`on` (and false equivalents). |
+
 ## Locations
 
 | File | Mode |


### PR DESCRIPTION
## Summary
- Add the env flag to `reference/env.md` under a new KeeperHub section
- Add an "Escape hatch" section to `architecture/keeperhub.md` covering when to use it and what stays / what changes (audit log: stays; KH workflow: skipped; signing: direct viem)
- Cross-link from `--skip-keeperhub` in `get-started/init.md` so the "mutating tools fail" story is no longer a dead end

Follow-up to #50, which shipped the flag with no doc coverage.

## Test plan
- [x] Astro dev server renders all three pages with the new content
- [ ] After deploy, verify the in-page anchor link in `init.md` resolves