### PR TITLE
Landing page polish + KH demo HACK

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -17,3 +17,4 @@ pnpm-debug.log*
 
 # OS
 .DS_Store
+.vercel

--- a/site/DESIGN-BRIEF.md
+++ b/site/DESIGN-BRIEF.md
@@ -1,0 +1,294 @@
+---
+name: Talos landing page modernization
+description: Reactbits-driven polish on top of the existing bronze automaton hero — ambient atmosphere, scroll reveals, and surgical micro-interactions while preserving locked hero art and copy
+type: design-brief
+created: 2026-05-04
+---
+
+# Design Brief — Talos landing modernization
+
+## Product Summary
+
+Talos is a self-hosted vertical Ethereum agent for ETHGlobal Open Agents. The visual identity is bronze automaton on warm-dark canvas — closer to a hand-forged tool than a SaaS dashboard. The current landing page is structurally sound (good hero art, clean type, tight copy) but visually static: it reads as a Starlight docs page with a hero image bolted on, not as a product launch. The goal is to add atmosphere and motion that earn the bronze mythology without breaking the dignified, tool-first tone. No purple gradients, no "AI shimmer", no kitchen-sink animation stack.
+
+## Constraints (hard)
+
+- Hero composition (logo image + headline + lead + CTA + meta line) is **locked**. Effects go *behind* and *around* it, not on top of the headline or in place of the image.
+- Stack is Astro 5 + Starlight, pure CSS, no Tailwind. Reactbits components are React — anything chosen must justify adding `@astrojs/react` as an integration, lazy-mounted via `client:visible` or `client:idle`.
+- Brand tokens already defined in `src/styles/theme.css`. Anything new must consume `--tlx-bronze`, `--tlx-bronze-bright`, `--tlx-bronze-deep`, `--tlx-eth-blue`, `--tlx-bg`, `--tlx-surface`, `--tlx-fg-*`. No new colors.
+- Performance ceiling: ETH Open Agents judges land here on first paint. One ambient WebGL effect maximum, gated to the hero, lazy-mounted. Below-the-fold animations must be pure CSS or `motion` (framer-motion) at most — no second WebGL canvas.
+- No emoji. No purple/teal/neon. No Tailwind classes (existing `tlx-*` CSS pattern only).
+
+---
+
+## Reactbits longlist (researched, then narrowed)
+
+These are the candidates I evaluated against the bronze/dark dev-tool brief. Each is sourced from the `ts-tailwind` flavor of `DavidHDev/react-bits` (the React 19 + TypeScript variant — closest to what an Astro island should hydrate).
+
+| # | Component | URL | Stack | Fit | Verdict |
+|---|---|---|---|---|---|
+| 1 | **Aurora** (background) | https://www.reactbits.dev/backgrounds/aurora | OGL/WebGL, GLSL simplex noise, `colorStops: string[]` prop | Soft horizon glow that maps perfectly to the dusk skybox already in the hero illustration. Three-stop bronze gradient keeps it on-brand. Transparent canvas, additive blend mode. | **PICK** — hero ambient |
+| 2 | **DotGrid** (background) | https://www.reactbits.dev/backgrounds/dot-grid | Canvas 2D + GSAP InertiaPlugin, **no WebGL**, `baseColor`, `activeColor`, `proximity` props | Subtle dotted texture for section backgrounds — reads as engineering grid paper, dignified, plays well with mouse-near-dot ripple. Non-WebGL means cheap. | **PICK** — section atmosphere |
+| 3 | **SplitText** | https://www.reactbits.dev/text-animations/split-text | GSAP + ScrollTrigger, `splitType: chars/words/lines`, configurable easing | Per-line reveal on H2s and section titles. Triggered on scroll. `power3.out` easing matches the bronze "weight" feeling. | **PICK** — section title reveal |
+| 4 | **SpotlightCard** | https://www.reactbits.dev/components/spotlight-card | Pure CSS + radial gradient, `spotlightColor` RGBA prop | Mouse-following bronze radial highlight on the 3-up tile cards. Cheap (no canvas), a clear "this card is alive" moment. | **PICK** — replaces existing `.tlx-card:hover` |
+| 5 | Beams | https://www.reactbits.dev/backgrounds/beams | Three.js + R3F + Drei | Heavier than Aurora (full three.js, not OGL). Aurora gives the same "shaft of light" mood without dragging in three.js. | **REJECT** — Aurora wins |
+| 6 | Threads | https://www.reactbits.dev/backgrounds/threads | OGL, `color: [r,g,b]` tuple, perlin noise | Ribbon/wave pattern. Beautiful but reads "creative agency", not "self-hosted dev tool". Wrong tone. | REJECT — vibe mismatch |
+| 7 | LightRays | https://www.reactbits.dev/backgrounds/light-rays | OGL, `raysColor`, `raysOrigin: top-center/corners/edges`, `pulsating` | Crepuscular rays from corner. Visually striking but competes with the automaton sword line in the illustration. | REJECT — fights hero art |
+| 8 | Particles | https://www.reactbits.dev/backgrounds/particles | OGL, `particleColors[]`, `particleCount: 200` | Generic "tech" feel. Used everywhere. Bronze particles would just look like floating sparks. Doesn't earn its perf cost. | REJECT — too generic |
+| 9 | ShinyText | https://www.reactbits.dev/text-animations/shiny-text | Framer Motion, `color`, `shineColor`, `speed` props | Considered for "424 tests passing" pill but it screams loyalty-card-app. Plain pulsing dot is more dignified. | REJECT — tonal mismatch |
+| 10 | BlurText | https://www.reactbits.dev/text-animations/blur-text | Framer Motion + IntersectionObserver, `animateBy: words/letters` | Alternative to SplitText. Smoother but less character. SplitText has the per-line "type into existence" feel that suits a dev tool. | REJECT — SplitText wins |
+| 11 | CountUp | https://www.reactbits.dev/text-animations/count-up | Framer Motion `useSpring`, viewport-triggered | If a stats strip is added later (TVL routed, txs audited), this is the right pick. Not needed for v1. | DEFER — phase 2 |
+| 12 | Magnet | https://www.reactbits.dev/animations/magnet | CSS transforms + window mousemove | Cute but the primary CTA is a `CopyCodeBlock` and a docs link. Magnetism on those would feel gimmicky. | REJECT — wrong context |
+| 13 | ClickSpark | https://www.reactbits.dev/animations/click-spark | Canvas 2D, `sparkColor`, `sparkCount`, `duration` | Click-feedback particles. Could fire on copy-command success. Feels too playful for a tool that audits chain mutations. | REJECT — tone |
+
+**Key finding:** Aurora and DotGrid handle 100% of the "atmosphere" demand. Everything else is text reveal (SplitText) or card hover (SpotlightCard). Four picks total — well under the perf ceiling.
+
+---
+
+## Final shortlist (the 4 we ship)
+
+### 1. Aurora — hero ambient background
+
+**Where it goes:** Behind the entire `.tlx-hero` section, sitting underneath the existing `.tlx-halo` radial. The current halo stays as a top-right warm wash; Aurora adds a slow horizontal aurora ribbon along the bottom third of the hero, evoking the dusk horizon already painted into the logo image.
+
+**Integration strategy:** React island. Justified because Aurora is shader-based (OGL + custom GLSL) — there's no clean vanilla-canvas port that wouldn't be a worse copy of the original. Mount with `client:visible` so it only hydrates when the hero scrolls into view (which on first paint *is* immediate, but the hydration blocks page interactivity less than `client:load`).
+
+**Configuration:**
+```ts
+<Aurora
+  colorStops={['#7a4f24', '#b87333', '#d4925a']} // bronze-deep -> bronze -> bronze-bright
+  amplitude={0.8}     // low — it's ambient, not foreground
+  blend={0.6}
+  speed={0.4}         // slow drift; faster reads as lava lamp
+/>
+```
+
+**File changes:**
+- `package.json`: add `@astrojs/react`, `react`, `react-dom`, `ogl`
+- `astro.config.mjs`: add `react()` to integrations (BEFORE starlight to avoid ordering edge cases)
+- `tsconfig.json`: add JSX config
+- New: `src/components/react/Aurora.tsx` — vendored from reactbits ts-tailwind, with the `cn()` utility removed (we don't have Tailwind) and the wrapper changed from a Tailwind class to a plain `style={{ width: '100%', height: '100%' }}` div
+- `src/pages/index.astro`: import as React island, drop into `.tlx-hero` as a sibling of `.tlx-halo`. Position absolute, full-bleed, `pointer-events: none`, `z-index: 0`. Hero content keeps `z-index: 1`.
+
+**Expected visual outcome:** A slow, low-amplitude bronze ribbon shimmers along the bottom of the hero section. The automaton image, headline, and CTA sit cleanly above it. On a 1440p screen the ribbon is roughly 30% of the hero height. Mobile gets a dimmed version (`opacity: 0.6` via media query) to cut GPU draw cost.
+
+**Perf cost:** ~80 KB gzipped (`ogl` ~50 KB + Aurora component ~5 KB + React + ReactDOM ~25 KB). One canvas, one shader pass, ~1 ms/frame on integrated graphics. With `client:visible` the page is interactive before Aurora hydrates.
+
+**Mobile gate:** Below 720 px, render at `pixelRatio = 1` (Aurora has internal DPR handling) and reduce `speed` to 0.2. If `prefers-reduced-motion: reduce`, render a static gradient PNG fallback instead of mounting the canvas. This is enforced at the Astro template level — wrap the import in `{!isReducedMotion && ...}` won't work server-side, so use a CSS-controlled wrapper with a `@media (prefers-reduced-motion)` rule that sets the canvas to `display: none` and shows a `.tlx-aurora-fallback` div with a static linear-gradient.
+
+---
+
+### 2. DotGrid — section atmosphere (KeeperHub stripe + behind 3-up tiles)
+
+**Where it goes:** As an absolute-positioned background inside two specific sections:
+- The KeeperHub sponsor stripe (`#keeperhub`) — replaces the flat surface with subtle moving texture during scroll-into-view
+- Optionally behind the 3-up tile section (the one with "Vertical, not general", etc.) — gentle dotted backdrop with mouse-near-dot reaction
+
+**Integration strategy:** React island (`client:visible`). DotGrid is canvas 2D + GSAP — no WebGL, but it's still a 200+ line component with InertiaPlugin physics that doesn't port cleanly to vanilla. React island is the right choice. GSAP InertiaPlugin is **not free** (requires Club GreenSock Premium) — verify before installing or fall back to dropping the inertia and using vanilla `requestAnimationFrame`. **Open question for Allen** flagged below.
+
+**Configuration:**
+```ts
+<DotGrid
+  dotSize={2}
+  gap={28}
+  baseColor="#25252f"      // --tlx-border, near-invisible at rest
+  activeColor="#b87333"    // --tlx-bronze, lights up near cursor
+  proximity={120}
+  shockRadius={180}
+  shockStrength={3}
+  resistance={750}
+  returnDuration={1.5}
+/>
+```
+
+**File changes:**
+- `package.json`: add `gsap` (and `@gsap/inertia` if licensed; otherwise patch component to remove)
+- New: `src/components/react/DotGrid.tsx` — vendored, Tailwind classes replaced with inline styles
+- `src/pages/index.astro`: drop a `<DotGrid client:visible />` inside the KeeperHub stripe wrapper
+
+**Expected visual outcome:** A grid of nearly-invisible bronze-dark dots (gap 28 px). Cursor proximity lights nearby dots up to bright bronze with a subtle ripple. Click sends a soft shockwave outward. Reads as "engineering grid paper" — dignified, on-brand, rewards interaction without demanding it.
+
+**Perf cost:** Canvas 2D, no WebGL. ~5 ms/frame at 1440p with mouse moving (throttled to 50 ms). Idle cost: near zero (animation pauses when no input). GSAP core is ~30 KB gzipped.
+
+**Mobile gate:** Disable `proximity` interaction below 720 px (no hover on touch); render the static dot grid only. `prefers-reduced-motion` collapses the shockwave duration to 0.
+
+---
+
+### 3. SplitText — section H2 reveal
+
+**Where it goes:** All four `<h2 class="tlx-section-title">` headings:
+- "Drop Talos into your assistant."
+- "Daemon plus thin clients."
+- "Six sources, one tool surface."
+- "One brain. Three faces."
+
+Hero `<h1>` is **excluded** — it's the locked headline and we don't animate it. Same for the eyebrows above each H2 (they're already small, motion would be noise).
+
+**Integration strategy:** React island (`client:visible`). GSAP ScrollTrigger needs DOM mounting; can't be SSR'd. Bundle reuses GSAP from DotGrid so no incremental cost.
+
+**Configuration:**
+```ts
+<SplitText
+  text="Daemon plus thin clients."
+  splitType="words"
+  from={{ opacity: 0, y: 24 }}
+  to={{ opacity: 1, y: 0 }}
+  duration={0.7}
+  delay={40}                    // stagger between words, ms
+  ease="power3.out"
+  tag="h2"
+  className="tlx-section-title"
+/>
+```
+
+**File changes:**
+- New: `src/components/react/SplitText.tsx` — vendored, exports a typed component
+- For each section in `index.astro`, replace `<h2 class="tlx-section-title">...</h2>` with `<SplitText client:visible text="..." tag="h2" className="tlx-section-title" />`
+
+**Expected visual outcome:** As each section scrolls into view, the H2 reveals word-by-word with a 24 px upward slide and fade. Total reveal duration ~0.9 s per heading. Feels like the heading is being "set in type" — fits the dev-tool craft tone.
+
+**Perf cost:** No incremental bundle (GSAP shared with DotGrid). Per-heading: ~1 KB DOM cost at most.
+
+**Reduced-motion fallback:** SplitText respects `prefers-reduced-motion` natively via GSAP's `gsap.config({ reducedMotion: 'reduce' })` — set this at module init. Or trivially: `from={{ opacity: 1, y: 0 }}` collapses the animation.
+
+---
+
+### 4. SpotlightCard — replace the hover state on 3-up tiles
+
+**Where it goes:** The three `.tlx-card` elements in the 3-up tiles section ("Vertical, not general", "Three-tier memory", "Audit-by-default"). Optionally also the 6 cards in `<ToolGrid />` if it reads well.
+
+**Integration strategy:** This one we **port to vanilla CSS**, no React. The reactbits SpotlightCard is just a radial-gradient overlay that follows the mouse — that's a 20-line CSS + tiny JS port. Not worth mounting React for it.
+
+**Configuration (CSS port):**
+```css
+.tlx-card {
+  position: relative;
+  overflow: hidden; /* required so the spotlight clips to card bounds */
+}
+.tlx-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    600px circle at var(--mx, 50%) var(--my, 50%),
+    rgba(184, 115, 51, 0.12),
+    transparent 40%
+  );
+  opacity: 0;
+  transition: opacity 240ms ease;
+  pointer-events: none;
+}
+.tlx-card:hover::before { opacity: 1; }
+```
+
+```js
+// Vanilla, ~10 lines, no framework
+document.querySelectorAll('.tlx-card').forEach((card) => {
+  card.addEventListener('mousemove', (e) => {
+    const r = card.getBoundingClientRect();
+    card.style.setProperty('--mx', `${e.clientX - r.left}px`);
+    card.style.setProperty('--my', `${e.clientY - r.top}px`);
+  });
+});
+```
+
+**File changes:**
+- `src/styles/theme.css`: add the `::before` rules to `.tlx-card`
+- `src/pages/index.astro`: add a tiny inline `<script>` at the bottom (or a deferred external) to wire up mousemove
+
+**Expected visual outcome:** Hovering a card produces a bronze radial glow that follows the cursor inside the card. The existing border-color hover becomes the secondary signal; the spotlight is the primary one. Cards now read as interactive even before the user moves.
+
+**Perf cost:** Zero incremental JS bundle. CSS-only with passive mousemove listeners. Negligible.
+
+**Reduced-motion fallback:** Wrap the `::before` rules in `@media (prefers-reduced-motion: no-preference)` — fully removed when the user opts out.
+
+---
+
+## Non-reactbits polish (5 items)
+
+These are surgical, on-brand, and don't depend on reactbits at all. They go in *after* the four picks above are stable.
+
+### 5. Hero meta line: "424 tests passing" becomes a live-feeling micro-component
+
+Current: static green dot + static text.
+New: the green dot pulses (CSS-only), and a tiny mono-font caret blinks after the count. No CountUp, no fake metric ticker — just a small animation cue that signals "this is a real, running thing."
+
+**Implementation:** add a `@keyframes tlx-pulse` to `theme.css`:
+```css
+@keyframes tlx-pulse {
+  0%, 100% { box-shadow: 0 0 8px rgba(93,155,106,0.55); }
+  50%      { box-shadow: 0 0 14px rgba(93,155,106,0.85); }
+}
+.tlx-dot--ok { animation: tlx-pulse 2.6s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) { .tlx-dot--ok { animation: none; } }
+```
+
+### 6. Sticky-nav refinement on scroll
+
+Current: nav is sticky with `backdrop-filter: blur(10px)` always-on.
+New: at scroll-top, nav has zero background and zero border (lets the hero breathe). Once the user scrolls past the hero, the blurred dark background and bronze hairline border fade in.
+
+**Implementation:** add a single `IntersectionObserver` watching the hero section, toggle a `.is-scrolled` class on `.tlx-topnav`. Two-line CSS variation between states. ~15 lines of JS.
+
+### 7. Section rhythm tightening
+
+Current: `padding: 5rem 0` between sections, plus a `border-top` hairline. Reads slightly forum-thread on long scroll.
+New: alternate between rest sections (5 rem) and "weight" sections (7 rem above architecture, KeeperHub stripe). Promote the architecture section's `LayerCake` and the KeeperHub stripe with extra breathing room. Drop the `border-top` between sections that share a backdrop (DotGrid'd ones), keep it between unstyled ones.
+
+**Implementation:** add `.tlx-section--weight { padding: 7rem 0; }` and `.tlx-section--seamless + .tlx-section--seamless { border-top: none; }`. Apply selectively in `index.astro`.
+
+### 8. Eyebrow-to-headline micro-animation
+
+Current: eyebrows (`.tlx-eyebrow`) are static spans above each section title.
+New: when their parent section enters the viewport, the eyebrow's character-spacing tightens from `0.24em` to `0.18em` over 600 ms, like the type is settling into place. CSS-only with `IntersectionObserver` toggling a class. Pairs well with SplitText reveal of the H2 below it — eyebrow settles, then H2 types in.
+
+**Implementation:**
+```css
+.tlx-eyebrow { letter-spacing: 0.24em; transition: letter-spacing 600ms cubic-bezier(0.2, 0.8, 0.2, 1); }
+.tlx-section.is-visible .tlx-eyebrow { letter-spacing: 0.18em; }
+@media (prefers-reduced-motion: reduce) { .tlx-eyebrow { letter-spacing: 0.18em; transition: none; } }
+```
+
+### 9. Hero halo refinement
+
+Current: `.tlx-halo` is a single radial-gradient blob in the top-right.
+New: keep it, but add a second radial — bottom-left, slightly smaller, blue-tinted (`--tlx-eth-blue` at 8% opacity). Two-tone halo grounds the bronze-vs-Ethereum dual identity (the mythology + the chain). Static, no animation, no perf cost.
+
+**Implementation:** one extra `::after` pseudo-element on `.tlx-hero`. ~6 lines.
+
+---
+
+## What I'm NOT touching (guardrails)
+
+These are off-limits during implementation. If a future change benefits any of them, escalate first; don't stealth-edit.
+
+- **Hero `<h1>`** — "The bronze automaton for your wallet." stays as a plain `<h1>`. No SplitText, no shimmer, no per-letter reveal. The headline's gravitas comes from being still while the world animates around it.
+- **Hero illustration** (`/site/src/assets/logo.png`) — no overlays, no colorize filters, no parallax tilt. The image is the product mascot; it is not a styling surface.
+- **Hero copy** — every paragraph, button label, and meta tag stays verbatim. No regenerated marketing strings.
+- **`CopyCodeBlock` component** — already does its job (terminal-prompt mono with copy affordance). No reactbits replacement.
+- **Color palette** — bronze + Ethereum blue + warm-dark only. If a reactbits component's default looks like glassmorphism teal or violet shimmer, reskin it via tokens before mounting.
+- **Tailwind** — not introduced. Reactbits ts-tailwind components are ported by stripping Tailwind classes and replacing with inline styles or `tlx-*` classes.
+- **Tools/Architecture diagrams** (`LayerCake.astro`, `ToolGrid.astro`) — content-correctness matters more than animation here. Apply SpotlightCard hover at most; don't restructure.
+- **Sticky nav links / footer copy** — locked.
+- **Light mode** — none. The brand is dark-only; `data-theme` is hard-pinned.
+
+---
+
+## Implementation order (when approved)
+
+1. Add `@astrojs/react` integration + verify hello-world React island works in the existing build pipeline. **Must not break Starlight docs pages** — verify `/docs/get-started/overview` still renders.
+2. Vendor SplitText + SpotlightCard (the smaller two), wire them up. These are reversible if anything goes sideways.
+3. Vendor DotGrid (KeeperHub stripe first, then evaluate behind 3-up tiles). Decide on GSAP InertiaPlugin licensing — see open question below.
+4. Vendor Aurora last (highest perf cost). Verify mobile gating and reduced-motion fallback work before merging.
+5. Add the 5 non-reactbits polish items in any order.
+6. Walkthrough at all four breakpoints (375 / 768 / 1024 / 1440 px). Lighthouse perf budget: hero LCP < 2.0 s, CLS < 0.05.
+
+---
+
+## Open questions for Allen
+
+1. **GSAP InertiaPlugin** — DotGrid's elastic shock animation depends on GSAP's premium InertiaPlugin (Club GreenSock subscription). Do you want to (a) buy the license, (b) drop the inertia and use a vanilla bezier ease, or (c) skip DotGrid entirely and rely on Aurora alone for atmosphere?
+2. **DotGrid scope** — KeeperHub stripe only, or also behind the 3-up tile section? The latter doubles the visual interest but stacks two dotted-grid backdrops on the same scroll. Recommend KeeperHub-only for v1.
+3. **SpotlightCard on `<ToolGrid />`** — apply spotlight hover to the 6 tool cards too, or keep it limited to the 3-up tiles for a hierarchy difference? Recommend cascading to ToolGrid since they share `.tlx-card` already.
+4. **Mobile Aurora behavior** — keep at 60% opacity (still animated), drop to a static PNG fallback, or remove entirely below 720 px? The `prefers-reduced-motion` fallback is already a static PNG, so the same asset can serve double duty.
+5. **Animation taste-check** — does "section H2 reveals word-by-word on scroll" (SplitText) feel right for a self-hosted dev tool, or is even that too much motion? A more conservative alternative is a single-pass fade-in (BlurText) on H2s only, or skip section-title animation entirely and rely on Aurora + DotGrid for motion.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import sitemap from '@astrojs/sitemap';
 import mdx from '@astrojs/mdx';
+import react from '@astrojs/react';
 
 const SITE = 'https://talos.allensaji.dev';
 
@@ -9,6 +10,9 @@ export default defineConfig({
   site: SITE,
   trailingSlash: 'never',
   integrations: [
+    react({
+      include: ['**/components/react/**'],
+    }),
     starlight({
       title: 'Talos',
       description: 'A self-hosted, vertical Ethereum agent. Daemon plus thin clients. Curated DeFi tools. Daily-fresh ecosystem knowledge. BYOK.',

--- a/site/package.json
+++ b/site/package.json
@@ -15,11 +15,15 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/mdx": "^4.2.0",
+    "@astrojs/react": "^5.0.4",
     "@astrojs/sitemap": "^3.4.0",
     "@astrojs/starlight": "^0.34.0",
     "@fontsource-variable/inter": "^5.2.5",
     "@fontsource-variable/jetbrains-mono": "^5.2.5",
     "astro": "^5.7.0",
+    "ogl": "^1.0.11",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "sharp": "^0.34.0",
     "typescript": "^5.7.0",
     "zod": "^4.0.0"
@@ -29,5 +33,9 @@
       "esbuild",
       "sharp"
     ]
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3"
   }
 }

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@astrojs/mdx':
         specifier: ^4.2.0
         version: 4.3.14(astro@5.18.1(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
+      '@astrojs/react':
+        specifier: ^5.0.4
+        version: 5.0.4(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(yaml@2.8.3)
       '@astrojs/sitemap':
         specifier: ^3.4.0
         version: 3.7.2
@@ -29,6 +32,15 @@ importers:
       astro:
         specifier: ^5.7.0
         version: 5.18.1(@types/node@24.12.2)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
+      ogl:
+        specifier: ^1.0.11
+        version: 1.0.11
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
       sharp:
         specifier: ^0.34.0
         version: 0.34.5
@@ -38,6 +50,13 @@ importers:
       zod:
         specifier: ^4.0.0
         version: 4.4.1
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
 
 packages:
 
@@ -52,6 +71,9 @@ packages:
 
   '@astrojs/internal-helpers@0.7.6':
     resolution: {integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==}
+
+  '@astrojs/internal-helpers@0.9.0':
+    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
 
   '@astrojs/language-server@2.16.7':
     resolution: {integrity: sha512-b64bWT74Vq/ORcSqW7TdIjjpB6hcl+Ei/lMANIUaAGlLPiYNtPTRI/j2tzvugT+LoVwfJtE2Ukq/t2OGCyEtfQ==}
@@ -78,6 +100,15 @@ packages:
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
+  '@astrojs/react@5.0.4':
+    resolution: {integrity: sha512-yDNE4VnKOzCjH9dCBi7pT4F6kpI3M9TkS+uxnCB0sGIS6t5vKonOY+Hs/UUnSajJGT5jeBRfpI9IQp+r/n1fBA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
 
@@ -93,6 +124,44 @@ packages:
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -101,13 +170,41 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -629,8 +726,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -675,6 +785,9 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -844,6 +957,18 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -874,6 +999,14 @@ packages:
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -885,6 +1018,12 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -993,6 +1132,11 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
+  baseline-browser-mapping@2.10.27:
+    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
@@ -1006,9 +1150,17 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1073,6 +1225,9 @@ packages:
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
@@ -1109,6 +1264,9 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1173,6 +1331,9 @@ packages:
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
+
+  electron-to-chromium@1.5.349:
+    resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
@@ -1281,6 +1442,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -1414,12 +1579,25 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonc-parser@2.3.1:
     resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
@@ -1445,6 +1623,9 @@ packages:
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1655,6 +1836,9 @@ packages:
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -1664,6 +1848,9 @@ packages:
 
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
+
+  ogl@1.0.11:
+    resolution: {integrity: sha512-kUpC154AFfxi16pmZUK4jk3J+8zxwTWGPo03EoYA8QPbzikHoaC82n6pNTbd+oEaJonaE8aPWBlX7ad9zrqLsA==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -1751,6 +1938,19 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -1860,6 +2060,13 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -2084,6 +2291,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -2109,6 +2322,46 @@ packages:
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -2262,6 +2515,9 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
     hasBin: true
@@ -2332,6 +2588,10 @@ snapshots:
   '@astrojs/compiler@2.13.1': {}
 
   '@astrojs/internal-helpers@0.7.6': {}
+
+  '@astrojs/internal-helpers@0.9.0':
+    dependencies:
+      picomatch: 4.0.4
 
   '@astrojs/language-server@2.16.7(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
@@ -2407,6 +2667,31 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
+  '@astrojs/react@5.0.4(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(yaml@2.8.3)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.9.0
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.2(@types/node@24.12.2)(yaml@2.8.3))
+      devalue: 5.8.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      ultrahtml: 1.6.0
+      vite: 7.3.2(@types/node@24.12.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@astrojs/sitemap@3.7.2':
     dependencies:
       sitemap: 9.0.1
@@ -2462,15 +2747,114 @@ snapshots:
     dependencies:
       yaml: 2.8.3
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -2792,7 +3176,24 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -2848,6 +3249,8 @@ snapshots:
 
   '@pagefind/windows-x64@1.5.2':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
@@ -2965,6 +3368,27 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -2997,6 +3421,14 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.12.2
@@ -3006,6 +3438,18 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@24.12.2)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.2(@types/node@24.12.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -3216,6 +3660,8 @@ snapshots:
 
   base-64@1.0.0: {}
 
+  baseline-browser-mapping@2.10.27: {}
+
   bcp-47-match@2.0.3: {}
 
   bcp-47@2.1.0:
@@ -3237,7 +3683,17 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.27
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.349
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   camelcase@8.0.0: {}
+
+  caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
 
@@ -3285,6 +3741,8 @@ snapshots:
 
   common-ancestor-path@1.0.1: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
@@ -3320,6 +3778,8 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  csstype@3.2.3: {}
 
   debug@4.4.3:
     dependencies:
@@ -3372,6 +3832,8 @@ snapshots:
       domhandler: 5.0.3
 
   dset@3.1.4: {}
+
+  electron-to-chromium@1.5.349: {}
 
   emmet@2.4.11:
     dependencies:
@@ -3530,6 +3992,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -3781,11 +4245,17 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
+  jsesc@3.1.0: {}
+
   json-schema-traverse@1.0.0: {}
+
+  json5@2.2.3: {}
 
   jsonc-parser@2.3.1: {}
 
@@ -3800,6 +4270,10 @@ snapshots:
   longest-streak@3.1.0: {}
 
   lru-cache@11.3.5: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
@@ -4294,6 +4768,8 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
+  node-releases@2.0.38: {}
+
   normalize-path@3.0.0: {}
 
   nth-check@2.1.1:
@@ -4305,6 +4781,8 @@ snapshots:
       destr: 2.0.5
       node-fetch-native: 1.6.7
       ufo: 1.6.4
+
+  ogl@1.0.11: {}
 
   ohash@2.0.11: {}
 
@@ -4400,6 +4878,15 @@ snapshots:
   property-information@7.1.0: {}
 
   radix3@1.1.2: {}
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.5: {}
 
   readdirp@4.1.2: {}
 
@@ -4608,6 +5095,10 @@ snapshots:
       fsevents: 2.3.3
 
   sax@1.6.0: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -4826,6 +5317,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   util-deprecate@1.0.2: {}
 
   vfile-location@5.0.3:
@@ -4846,6 +5343,19 @@ snapshots:
   vite@6.4.2(@types/node@24.12.2)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
+      fsevents: 2.3.3
+      yaml: 2.8.3
+
+  vite@7.3.2(@types/node@24.12.2)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.13
@@ -4980,6 +5490,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml-language-server@1.20.0:
     dependencies:

--- a/site/src/components/ChannelsStrip.astro
+++ b/site/src/components/ChannelsStrip.astro
@@ -44,14 +44,14 @@ const items = [
         <span class="tlx-mono" style="color:var(--tlx-fg-muted); font-size:0.78rem;">{c.sub}</span>
       </div>
       <p class="tlx-card-body" style="margin-bottom:0.85rem;"><span class="tlx-mono" style="color:var(--tlx-bronze-bright)">{c.title}</span></p>
-      <pre class="tlx-term">
+      <div class="tlx-term">
         {c.snippet.map((s) => (
-          <div>
-            <span class={s.ok ? 'tlx-term-ok' : s.m ? 'tlx-term-out' : 'tlx-term-prompt'}>{s.p}</span>
-            <span style="margin-left:0.5em;">{s.t}</span>
+          <div class="tlx-term-line">
+            <span class={`tlx-term-glyph ${s.ok ? 'tlx-term-ok' : s.m ? 'tlx-term-out' : 'tlx-term-prompt'}`}>{s.p}</span>
+            <span class="tlx-term-text">{s.t}</span>
           </div>
         ))}
-      </pre>
+      </div>
     </article>
   ))}
 </div>

--- a/site/src/components/react/Aurora.tsx
+++ b/site/src/components/react/Aurora.tsx
@@ -1,0 +1,196 @@
+import { Color, Mesh, Program, Renderer, Triangle } from 'ogl';
+import { useEffect, useRef } from 'react';
+
+const VERT = `#version 300 es
+in vec2 position;
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+const FRAG = `#version 300 es
+precision highp float;
+
+uniform float uTime;
+uniform float uAmplitude;
+uniform vec3 uColorStops[3];
+uniform vec2 uResolution;
+uniform float uBlend;
+
+out vec4 fragColor;
+
+vec3 permute(vec3 x) {
+  return mod(((x * 34.0) + 1.0) * x, 289.0);
+}
+
+float snoise(vec2 v) {
+  const vec4 C = vec4(
+    0.211324865405187, 0.366025403784439,
+    -0.577350269189626, 0.024390243902439
+  );
+  vec2 i = floor(v + dot(v, C.yy));
+  vec2 x0 = v - i + dot(i, C.xx);
+  vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+  vec4 x12 = x0.xyxy + C.xxzz;
+  x12.xy -= i1;
+  i = mod(i, 289.0);
+  vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0)) + i.x + vec3(0.0, i1.x, 1.0));
+  vec3 m = max(0.5 - vec3(dot(x0, x0), dot(x12.xy, x12.xy), dot(x12.zw, x12.zw)), 0.0);
+  m = m * m;
+  m = m * m;
+  vec3 x = 2.0 * fract(p * C.www) - 1.0;
+  vec3 h = abs(x) - 0.5;
+  vec3 ox = floor(x + 0.5);
+  vec3 a0 = x - ox;
+  m *= 1.79284291400159 - 0.85373472095314 * (a0 * a0 + h * h);
+  vec3 g;
+  g.x = a0.x * x0.x + h.x * x0.y;
+  g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+  return 130.0 * dot(m, g);
+}
+
+struct ColorStop {
+  vec3 color;
+  float position;
+};
+
+vec3 colorRamp(ColorStop colors[3], float factor) {
+  int index = 0;
+  for (int i = 0; i < 2; i++) {
+    if (colors[i].position <= factor) {
+      index = i;
+    }
+  }
+  ColorStop currentColor = colors[index];
+  ColorStop nextColor = colors[index + 1];
+  float range = nextColor.position - currentColor.position;
+  float lerpFactor = (factor - currentColor.position) / range;
+  return mix(currentColor.color, nextColor.color, lerpFactor);
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / uResolution;
+
+  ColorStop colors[3];
+  colors[0] = ColorStop(uColorStops[0], 0.0);
+  colors[1] = ColorStop(uColorStops[1], 0.5);
+  colors[2] = ColorStop(uColorStops[2], 1.0);
+
+  vec3 rampColor = colorRamp(colors, uv.x);
+
+  float height = snoise(vec2(uv.x * 2.0 + uTime * 0.1, uTime * 0.25)) * 0.5 * uAmplitude;
+  height = exp(height);
+  height = (uv.y * 2.0 - height + 0.2);
+  float intensity = 0.6 * height;
+  float midPoint = 0.20;
+  float auroraAlpha = smoothstep(midPoint - uBlend * 0.5, midPoint + uBlend * 0.5, intensity);
+
+  vec3 auroraColor = intensity * rampColor;
+  fragColor = vec4(auroraColor * auroraAlpha, auroraAlpha);
+}
+`;
+
+interface AuroraProps {
+  colorStops?: [string, string, string];
+  amplitude?: number;
+  blend?: number;
+  speed?: number;
+}
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const m = hex.replace('#', '').match(/.{1,2}/g);
+  if (!m || m.length < 3) return [1, 1, 1];
+  return [parseInt(m[0], 16) / 255, parseInt(m[1], 16) / 255, parseInt(m[2], 16) / 255];
+};
+
+export default function Aurora({
+  colorStops = ['#7a4f24', '#b87333', '#d4925a'],
+  amplitude = 0.8,
+  blend = 0.6,
+  speed = 0.4,
+}: AuroraProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const renderer = new Renderer({
+      alpha: true,
+      premultipliedAlpha: true,
+      antialias: true,
+      dpr: Math.min(window.devicePixelRatio, 1.5),
+    });
+    const gl = renderer.gl;
+    gl.clearColor(0, 0, 0, 0);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+    container.appendChild(gl.canvas);
+
+    const geometry = new Triangle(gl);
+    if ('attributes' in geometry && geometry.attributes && 'uv' in geometry.attributes) {
+      // OGL adds a default uv we don't need; safe to delete to avoid warnings
+      delete (geometry as unknown as { attributes: Record<string, unknown> }).attributes.uv;
+    }
+
+    const program = new Program(gl, {
+      vertex: VERT,
+      fragment: FRAG,
+      uniforms: {
+        uTime: { value: 0 },
+        uAmplitude: { value: amplitude },
+        uColorStops: {
+          value: colorStops.map((c) => {
+            const [r, g, b] = hexToRgb(c);
+            return new Color(r, g, b);
+          }),
+        },
+        uResolution: { value: [container.offsetWidth, container.offsetHeight] },
+        uBlend: { value: blend },
+      },
+    });
+
+    const mesh = new Mesh(gl, { geometry, program });
+
+    const handleResize = () => {
+      const w = container.offsetWidth;
+      const h = container.offsetHeight;
+      renderer.setSize(w, h);
+      program.uniforms.uResolution.value = [w, h];
+    };
+    window.addEventListener('resize', handleResize);
+    handleResize();
+
+    let frameId = 0;
+    const start = performance.now();
+    const render = (now: number) => {
+      const t = (now - start) / 1000;
+      program.uniforms.uTime.value = t * speed;
+      renderer.render({ scene: mesh });
+      frameId = requestAnimationFrame(render);
+    };
+    frameId = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      window.removeEventListener('resize', handleResize);
+      if (gl.canvas.parentElement === container) container.removeChild(gl.canvas);
+      gl.getExtension('WEBGL_lose_context')?.loseContext();
+    };
+  }, [amplitude, blend, speed, colorStops.join(',')]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'none',
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/site/src/components/react/DotGrid.tsx
+++ b/site/src/components/react/DotGrid.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useRef } from 'react';
+
+interface DotGridProps {
+  dotSize?: number;
+  gap?: number;
+  baseColor?: string;
+  activeColor?: string;
+  proximity?: number;
+  shockRadius?: number;
+  shockStrength?: number;
+  returnDuration?: number;
+}
+
+interface Dot {
+  x: number;
+  y: number;
+  ox: number;
+  oy: number;
+  vx: number;
+  vy: number;
+}
+
+const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const m = hex.replace('#', '').match(/.{1,2}/g);
+  if (!m || m.length < 3) return [255, 255, 255];
+  return [parseInt(m[0], 16), parseInt(m[1], 16), parseInt(m[2], 16)];
+};
+
+const lerpColor = (
+  a: [number, number, number],
+  b: [number, number, number],
+  t: number,
+): string => {
+  const r = Math.round(a[0] + (b[0] - a[0]) * t);
+  const g = Math.round(a[1] + (b[1] - a[1]) * t);
+  const bl = Math.round(a[2] + (b[2] - a[2]) * t);
+  return `rgb(${r},${g},${bl})`;
+};
+
+export default function DotGrid({
+  dotSize = 2,
+  gap = 28,
+  baseColor = '#25252f',
+  activeColor = '#b87333',
+  proximity = 120,
+  shockRadius = 180,
+  shockStrength = 4,
+  returnDuration = 1200,
+}: DotGridProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const isTouch =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(hover: none)').matches;
+
+    const canvas = document.createElement('canvas');
+    canvas.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;pointer-events:none;';
+    container.appendChild(canvas);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let dpr = Math.min(window.devicePixelRatio || 1, 1.5);
+    let w = 0;
+    let h = 0;
+    let dots: Dot[] = [];
+    const baseRgb = hexToRgb(baseColor);
+    const activeRgb = hexToRgb(activeColor);
+
+    const buildGrid = () => {
+      w = container.offsetWidth;
+      h = container.offsetHeight;
+      canvas.width = Math.floor(w * dpr);
+      canvas.height = Math.floor(h * dpr);
+      canvas.style.width = `${w}px`;
+      canvas.style.height = `${h}px`;
+      ctx.scale(dpr, dpr);
+
+      const cols = Math.floor(w / gap) + 1;
+      const rows = Math.floor(h / gap) + 1;
+      const offsetX = (w - (cols - 1) * gap) / 2;
+      const offsetY = (h - (rows - 1) * gap) / 2;
+      dots = [];
+      for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+          const x = offsetX + c * gap;
+          const y = offsetY + r * gap;
+          dots.push({ x, y, ox: x, oy: y, vx: 0, vy: 0 });
+        }
+      }
+    };
+
+    buildGrid();
+
+    const ro = new ResizeObserver(() => {
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      buildGrid();
+    });
+    ro.observe(container);
+
+    let mouseX = -9999;
+    let mouseY = -9999;
+
+    const onMove = (e: MouseEvent) => {
+      const r = container.getBoundingClientRect();
+      mouseX = e.clientX - r.left;
+      mouseY = e.clientY - r.top;
+    };
+    const onLeave = () => {
+      mouseX = -9999;
+      mouseY = -9999;
+    };
+    const onClick = (e: MouseEvent) => {
+      if (reduced) return;
+      const r = container.getBoundingClientRect();
+      const cx = e.clientX - r.left;
+      const cy = e.clientY - r.top;
+      for (const dot of dots) {
+        const dx = dot.ox - cx;
+        const dy = dot.oy - cy;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < shockRadius) {
+          const falloff = 1 - dist / shockRadius;
+          const force = falloff * shockStrength;
+          dot.vx += (dx / Math.max(dist, 0.0001)) * force;
+          dot.vy += (dy / Math.max(dist, 0.0001)) * force;
+        }
+      }
+    };
+
+    if (!isTouch) {
+      container.addEventListener('mousemove', onMove, { passive: true });
+      container.addEventListener('mouseleave', onLeave);
+      container.addEventListener('click', onClick);
+    }
+
+    let frameId = 0;
+    let last = performance.now();
+    const damping = Math.exp(-1000 / returnDuration);
+
+    const render = (now: number) => {
+      const dt = Math.min((now - last) / 1000, 0.05);
+      last = now;
+
+      ctx.clearRect(0, 0, w, h);
+
+      for (const dot of dots) {
+        // spring back to origin
+        const dx = dot.ox - dot.x;
+        const dy = dot.oy - dot.y;
+        dot.vx = dot.vx * damping + dx * 12 * dt;
+        dot.vy = dot.vy * damping + dy * 12 * dt;
+        dot.x += dot.vx * dt * 60;
+        dot.y += dot.vy * dt * 60;
+
+        let intensity = 0;
+        if (!isTouch && mouseX > -1000) {
+          const px = dot.x - mouseX;
+          const py = dot.y - mouseY;
+          const d = Math.sqrt(px * px + py * py);
+          if (d < proximity) {
+            intensity = easeOutCubic(1 - d / proximity);
+          }
+        }
+
+        ctx.beginPath();
+        ctx.arc(dot.x, dot.y, dotSize, 0, Math.PI * 2);
+        ctx.fillStyle = lerpColor(baseRgb, activeRgb, intensity);
+        ctx.fill();
+      }
+
+      frameId = requestAnimationFrame(render);
+    };
+    frameId = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      ro.disconnect();
+      container.removeEventListener('mousemove', onMove);
+      container.removeEventListener('mouseleave', onLeave);
+      container.removeEventListener('click', onClick);
+      if (canvas.parentElement === container) container.removeChild(canvas);
+    };
+  }, [
+    dotSize,
+    gap,
+    baseColor,
+    activeColor,
+    proximity,
+    shockRadius,
+    shockStrength,
+    returnDuration,
+  ]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        pointerEvents: 'auto',
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/site/src/components/react/SplitText.tsx
+++ b/site/src/components/react/SplitText.tsx
@@ -1,0 +1,82 @@
+import { createElement, useEffect, useMemo, useRef, useState } from 'react';
+
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'p' | 'span';
+
+interface SplitTextProps {
+  text: string;
+  className?: string;
+  tag?: HeadingTag;
+  delay?: number;
+  duration?: number;
+  splitBy?: 'word' | 'char';
+  threshold?: number;
+}
+
+export default function SplitText({
+  text,
+  className,
+  tag = 'h2',
+  delay = 40,
+  duration = 700,
+  splitBy = 'word',
+  threshold = 0.3,
+}: SplitTextProps) {
+  const ref = useRef<HTMLElement | null>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  const segments = useMemo(() => {
+    if (splitBy === 'char') return Array.from(text);
+    return text.split(/(\s+)/);
+  }, [text, splitBy]);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduced) {
+      setRevealed(true);
+      return;
+    }
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setRevealed(true);
+            obs.disconnect();
+          }
+        }
+      },
+      { threshold },
+    );
+    obs.observe(node);
+    return () => obs.disconnect();
+  }, [threshold]);
+
+  const children = segments.map((seg, i) =>
+    /^\s+$/.test(seg)
+      ? createElement('span', { key: i, 'aria-hidden': 'true' }, seg)
+      : createElement(
+          'span',
+          {
+            key: i,
+            'aria-hidden': 'true',
+            style: {
+              display: 'inline-block',
+              opacity: revealed ? 1 : 0,
+              transform: revealed ? 'translateY(0)' : 'translateY(0.55em)',
+              transition: `opacity ${duration}ms cubic-bezier(0.2, 0.8, 0.2, 1) ${i * delay}ms, transform ${duration}ms cubic-bezier(0.2, 0.8, 0.2, 1) ${i * delay}ms`,
+              willChange: 'opacity, transform',
+            },
+          },
+          seg,
+        ),
+  );
+
+  return createElement(
+    tag,
+    { ref, className, 'aria-label': text },
+    ...children,
+  );
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,6 +8,9 @@ import LayerCake from '@/components/LayerCake.astro';
 import ToolGrid from '@/components/ToolGrid.astro';
 import ChannelsStrip from '@/components/ChannelsStrip.astro';
 import Footer from '@/components/Footer.astro';
+import Aurora from '@/components/react/Aurora.tsx';
+import SplitText from '@/components/react/SplitText.tsx';
+import DotGrid from '@/components/react/DotGrid.tsx';
 
 const title = 'Talos · A self-hosted Ethereum agent';
 const description = 'Daemon plus thin clients. Curated DeFi tools. Daily-fresh ecosystem knowledge. Bring your own keys. Your wallet never leaves your machine.';
@@ -77,7 +80,12 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
 
   <!-- HERO -->
   <section class="tlx-hero">
+    <div class="tlx-aurora-wrap" aria-hidden="true">
+      <Aurora client:visible colorStops={["#7a4f24", "#b87333", "#d4925a"]} amplitude={0.85} blend={0.55} speed={0.4} />
+    </div>
+    <div class="tlx-aurora-fallback" aria-hidden="true"></div>
     <div class="tlx-halo" aria-hidden="true"></div>
+    <div class="tlx-halo tlx-halo--blue" aria-hidden="true"></div>
     <div class="tlx-container tlx-hero-inner">
       <div class="tlx-hero-copy">
         <span class="tlx-eyebrow">A self-hosted Ethereum agent</span>
@@ -106,7 +114,7 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
   </section>
 
   <!-- 3-up tiles -->
-  <section class="tlx-section">
+  <section class="tlx-section tlx-section--reveal">
     <div class="tlx-container">
       <div class="tlx-grid tlx-grid--3">
         <article class="tlx-card">
@@ -135,20 +143,20 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
   </section>
 
   <!-- Quick MCP integration -->
-  <section class="tlx-section" id="embed">
+  <section class="tlx-section tlx-section--reveal" id="embed">
     <div class="tlx-container">
       <span class="tlx-eyebrow">Embed it</span>
-      <h2 class="tlx-section-title">Drop Talos into your assistant.</h2>
+      <SplitText client:visible text="Drop Talos into your assistant." className="tlx-section-title" tag="h2" />
       <p class="tlx-section-sub">Talos exposes itself as an MCP server. Paste this snippet into your host config — it's the same on every host.</p>
       <MCPHostTabs />
     </div>
   </section>
 
   <!-- Architecture -->
-  <section class="tlx-section" id="architecture">
+  <section class="tlx-section tlx-section--reveal tlx-section--weight" id="architecture">
     <div class="tlx-container">
       <span class="tlx-eyebrow">Architecture</span>
-      <h2 class="tlx-section-title">Daemon plus thin clients.</h2>
+      <SplitText client:visible text="Daemon plus thin clients." className="tlx-section-title" tag="h2" />
       <p class="tlx-section-sub">One process owns the database, the runtime, the MCP host, and the wallet. Everything else is a thin client over WebSocket.</p>
       <LayerCake />
       <p style="margin: 1.25rem 0 0; color: var(--tlx-fg-muted); font-size: 0.92rem;">
@@ -158,37 +166,42 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
   </section>
 
   <!-- Tool catalogue -->
-  <section class="tlx-section" id="tools">
+  <section class="tlx-section tlx-section--reveal" id="tools">
     <div class="tlx-container">
       <span class="tlx-eyebrow">Tool catalogue</span>
-      <h2 class="tlx-section-title">Six sources, one tool surface.</h2>
+      <SplitText client:visible text="Six sources, one tool surface." className="tlx-section-title" tag="h2" />
       <p class="tlx-section-sub">Each card is one source. Native means custom-built; MCP-as-source means a vendor MCP cherry-picked into Talos's namespace.</p>
       <ToolGrid />
     </div>
   </section>
 
   <!-- Channels strip -->
-  <section class="tlx-section" id="channels">
+  <section class="tlx-section tlx-section--reveal" id="channels">
     <div class="tlx-container">
       <span class="tlx-eyebrow">Channels</span>
-      <h2 class="tlx-section-title">One brain. Three faces.</h2>
+      <SplitText client:visible text="One brain. Three faces." className="tlx-section-title" tag="h2" />
       <p class="tlx-section-sub">CLI REPL for the terminal, Telegram for the phone, MCP server for any host. They share one wallet, one knowledge base, one memory store.</p>
       <ChannelsStrip />
     </div>
   </section>
 
   <!-- KH stripe -->
-  <section class="tlx-section" id="keeperhub">
+  <section class="tlx-section tlx-section--weight" id="keeperhub">
     <div class="tlx-container">
-      <div class="tlx-stripe">
-        <div class="tlx-stripe-text">
-          <span class="tlx-pill">KeeperHub</span>
-          <p style="margin: 0.7rem 0 0;"><strong>Audit-by-default execution.</strong></p>
-          <small>Every mutating tool call routes through a KeeperHub workflow. Receipts written to the local DB. Read-only calls bypass the hop. Talos is the reference "OpenClaw connector" for the KeeperHub track at ETHGlobal Open Agents.</small>
+      <div class="tlx-stripe tlx-stripe--dotgrid">
+        <div class="tlx-dotgrid-bg" aria-hidden="true">
+          <DotGrid client:visible dotSize={2} gap={28} baseColor="#25252f" activeColor="#b87333" proximity={120} shockRadius={180} shockStrength={4} returnDuration={1200} />
         </div>
-        <div style="display:flex; gap:0.6rem;">
-          <a class="tlx-btn" href="https://keeperhub.com">KeeperHub →</a>
-          <a class="tlx-btn tlx-btn--primary" href="/docs/architecture/keeperhub">How it works</a>
+        <div class="tlx-stripe-content">
+          <div class="tlx-stripe-text">
+            <span class="tlx-pill">KeeperHub</span>
+            <p style="margin: 0.7rem 0 0;"><strong>Audit-by-default execution.</strong></p>
+            <small>Every mutating tool call routes through a KeeperHub workflow. Receipts written to the local DB. Read-only calls bypass the hop. Talos is the reference "OpenClaw connector" for the KeeperHub track at ETHGlobal Open Agents.</small>
+          </div>
+          <div style="display:flex; gap:0.6rem;">
+            <a class="tlx-btn" href="https://keeperhub.com">KeeperHub →</a>
+            <a class="tlx-btn tlx-btn--primary" href="/docs/architecture/keeperhub">How it works</a>
+          </div>
         </div>
       </div>
     </div>
@@ -196,15 +209,72 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
 
   <Footer />
 
+  <script>
+    // Spotlight cursor on cards
+    function wireSpotlight() {
+      document.querySelectorAll<HTMLElement>('.tlx-card, .tlx-tool-card').forEach((card) => {
+        const onMove = (e: MouseEvent) => {
+          const r = card.getBoundingClientRect();
+          card.style.setProperty('--tlx-mx', `${e.clientX - r.left}px`);
+          card.style.setProperty('--tlx-my', `${e.clientY - r.top}px`);
+        };
+        card.addEventListener('mousemove', onMove, { passive: true });
+      });
+    }
+
+    // Sticky nav scroll-aware
+    function wireStickyNav() {
+      const nav = document.querySelector<HTMLElement>('.tlx-topnav');
+      const hero = document.querySelector<HTMLElement>('.tlx-hero');
+      if (!nav || !hero) return;
+      const obs = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            nav.classList.toggle('is-scrolled', !entry.isIntersecting);
+          }
+        },
+        { rootMargin: '-56px 0px 0px 0px', threshold: 0 },
+      );
+      obs.observe(hero);
+    }
+
+    // Section reveal: tightens eyebrow letter-spacing on enter
+    function wireSectionReveal() {
+      const sections = document.querySelectorAll<HTMLElement>('.tlx-section--reveal');
+      const obs = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('is-visible');
+              obs.unobserve(entry.target);
+            }
+          }
+        },
+        { threshold: 0.2 },
+      );
+      sections.forEach((s) => obs.observe(s));
+    }
+
+    wireSpotlight();
+    wireStickyNav();
+    wireSectionReveal();
+  </script>
+
   <style>
     /* Top nav */
     .tlx-topnav {
       position: sticky;
       top: 0;
       z-index: 50;
+      background: transparent;
+      backdrop-filter: none;
+      border-bottom: 1px solid transparent;
+      transition: background 240ms ease, border-color 240ms ease, backdrop-filter 240ms ease;
+    }
+    .tlx-topnav.is-scrolled {
       background: rgba(10,10,12,0.78);
       backdrop-filter: blur(10px);
-      border-bottom: 1px solid var(--tlx-border);
+      border-bottom-color: var(--tlx-border);
     }
     .tlx-topnav-inner {
       display: flex;
@@ -239,6 +309,30 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
       overflow: hidden;
       padding: 4rem 0 5.5rem;
     }
+    .tlx-aurora-wrap {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      opacity: 0.85;
+      mask-image: linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.85) 35%, #000 60%, #000 100%);
+      -webkit-mask-image: linear-gradient(180deg, transparent 0%, rgba(0,0,0,0.85) 35%, #000 60%, #000 100%);
+      pointer-events: none;
+    }
+    .tlx-aurora-fallback {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      background: linear-gradient(180deg, transparent 30%, rgba(184,115,51,0.10) 70%, rgba(212,146,90,0.18) 100%);
+      pointer-events: none;
+      display: none;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .tlx-aurora-wrap { display: none; }
+      .tlx-aurora-fallback { display: block; }
+    }
+    @media (max-width: 720px) {
+      .tlx-aurora-wrap { opacity: 0.6; }
+    }
     .tlx-hero-inner {
       display: grid;
       grid-template-columns: 1.15fr 0.85fr;
@@ -268,7 +362,18 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
     }
     .tlx-hero-meta span { display: inline-flex; align-items: center; gap: 0.5rem; }
     .tlx-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--tlx-fg-faint); display: inline-block; }
-    .tlx-dot--ok { background: var(--tlx-ok); box-shadow: 0 0 8px rgba(93,155,106,0.55); }
+    .tlx-dot--ok {
+      background: var(--tlx-ok);
+      box-shadow: 0 0 8px rgba(93,155,106,0.55);
+      animation: tlx-pulse 2.6s ease-in-out infinite;
+    }
+    @keyframes tlx-pulse {
+      0%, 100% { box-shadow: 0 0 8px rgba(93,155,106,0.55); }
+      50%      { box-shadow: 0 0 16px rgba(93,155,106,0.95), 0 0 4px rgba(93,155,106,1); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .tlx-dot--ok { animation: none; }
+    }
 
     .tlx-hero-art {
       position: relative;
@@ -292,6 +397,43 @@ const canonical = new URL(Astro.url.pathname, SITE).toString();
       max-width: 480px;
       border-radius: 14px;
       box-shadow: 0 30px 80px -20px rgba(0,0,0,0.7), 0 0 0 1px var(--tlx-border);
+    }
+
+    /* Stripe with DotGrid */
+    .tlx-stripe--dotgrid {
+      position: relative;
+      overflow: hidden;
+    }
+    .tlx-dotgrid-bg {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
+      opacity: 0.9;
+      pointer-events: auto;
+      mask-image: radial-gradient(ellipse at center, #000 0%, #000 55%, transparent 100%);
+      -webkit-mask-image: radial-gradient(ellipse at center, #000 0%, #000 55%, transparent 100%);
+    }
+    .tlx-stripe-content {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.25rem;
+      flex-wrap: wrap;
+      pointer-events: none;
+    }
+    .tlx-stripe-content > * { pointer-events: auto; }
+
+    /* Section weight + reveal */
+    .tlx-section--weight { padding: 7rem 0; }
+    .tlx-section--reveal .tlx-eyebrow {
+      letter-spacing: 0.28em;
+      transition: letter-spacing 600ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+    .tlx-section--reveal.is-visible .tlx-eyebrow { letter-spacing: 0.18em; }
+    @media (prefers-reduced-motion: reduce) {
+      .tlx-section--reveal .tlx-eyebrow { letter-spacing: 0.18em; transition: none; }
     }
 
     /* Tile icon */

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -242,7 +242,7 @@ table tr:last-child td { border-bottom: none; }
 .tlx-btn--primary { background: var(--tlx-bronze); border-color: var(--tlx-bronze); color: #1a0e05; font-weight: 600; }
 .tlx-btn--primary:hover { background: var(--tlx-bronze-bright); border-color: var(--tlx-bronze-bright); color: #1a0e05; }
 
-/* Hero halo */
+/* Hero halo — two-tone: bronze top-right + ETH-blue bottom-left */
 .tlx-halo {
   position: absolute;
   inset: -10% -10% auto auto;
@@ -251,6 +251,12 @@ table tr:last-child td { border-bottom: none; }
   background: radial-gradient(closest-side, rgba(184, 115, 51, 0.22), transparent 70%);
   pointer-events: none;
   z-index: 0;
+}
+.tlx-halo--blue {
+  inset: auto auto -15% -15%;
+  width: 55%;
+  height: 55%;
+  background: radial-gradient(closest-side, rgba(98, 126, 234, 0.10), transparent 70%);
 }
 
 /* Section spacing */
@@ -273,8 +279,37 @@ table tr:last-child td { border-bottom: none; }
   border-radius: var(--tlx-radius-lg);
   padding: 1.25rem;
   transition: border-color 140ms ease, background 140ms ease;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
 }
 .tlx-card:hover { border-color: var(--tlx-border-bright); }
+
+/* Spotlight on cards — bronze radial follows the cursor */
+@media (prefers-reduced-motion: no-preference) {
+  .tlx-card::before,
+  .tlx-tool-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      520px circle at var(--tlx-mx, 50%) var(--tlx-my, 50%),
+      rgba(184, 115, 51, 0.14),
+      transparent 45%
+    );
+    opacity: 0;
+    transition: opacity 240ms ease;
+    pointer-events: none;
+    z-index: 0;
+  }
+  .tlx-card:hover::before,
+  .tlx-tool-card:hover::before { opacity: 1; }
+  .tlx-card > *,
+  .tlx-tool-card > * { position: relative; z-index: 1; }
+}
+
+/* Tool cards need the same isolation */
+.tlx-tool-card { position: relative; overflow: hidden; isolation: isolate; }
 
 .tlx-card-title {
   font-size: 1rem;
@@ -372,6 +407,10 @@ table tr:last-child td { border-bottom: none; }
   justify-content: space-between;
   gap: 1.25rem;
   flex-wrap: wrap;
+}
+.tlx-stripe--dotgrid {
+  padding: 2.2rem 2rem;
+  display: block;
 }
 .tlx-stripe-text { color: var(--tlx-fg); }
 .tlx-stripe-text strong { color: var(--tlx-fg-strong); }

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -123,10 +123,132 @@ header.header { border-bottom: 1px solid var(--tlx-border); background: rgba(10,
 
 /* Sidebar polish */
 .sidebar-content { padding-top: 1rem; }
-.sidebar-pane { border-right: 1px solid var(--tlx-border); }
+.sidebar-pane { border-right: 1px solid var(--tlx-border); background: var(--tlx-bg); }
 nav[aria-label="Main"] ul ul { border-left: 1px solid var(--tlx-border); margin-left: 0.5rem; padding-left: 0.5rem; }
 
-a.large, a.sidebar-link { transition: color 120ms ease, background 120ms ease; }
+a.large, a.sidebar-link {
+  transition: color 140ms ease, background 140ms ease, border-color 140ms ease;
+  border-radius: 4px;
+}
+
+/* Sidebar category headers — bronze uppercase eyebrow style */
+.sidebar-content details > summary,
+.sidebar-content .group-label,
+.sidebar-content span.large {
+  font-family: var(--sl-font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--tlx-bronze);
+  font-weight: 500;
+}
+.sidebar-content details > summary span,
+.sidebar-content .group-label span { font-weight: 500; }
+
+/* Sidebar active link — bronze accent + tinted background */
+.sidebar-content a[aria-current='page'],
+.sidebar-content a[aria-current='true'] {
+  color: var(--tlx-fg-strong);
+  background: rgba(184, 115, 51, 0.10);
+  border-left: 2px solid var(--tlx-bronze);
+  padding-left: calc(0.5rem - 2px);
+}
+.sidebar-content a[aria-current='page']:hover,
+.sidebar-content a[aria-current='true']:hover {
+  background: rgba(184, 115, 51, 0.16);
+}
+.sidebar-content a:not([aria-current]):hover {
+  color: var(--tlx-fg-strong);
+  background: var(--tlx-surface);
+}
+
+/* Right TOC ("On this page") */
+.right-sidebar h2,
+.right-sidebar starlight-toc h2 {
+  font-family: var(--sl-font-mono);
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--tlx-bronze);
+  font-weight: 500;
+}
+.right-sidebar a {
+  color: var(--tlx-fg-muted);
+  border-left: 1px solid transparent;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+.right-sidebar a:hover { color: var(--tlx-fg); }
+.right-sidebar a[aria-current='true'],
+.right-sidebar a[aria-current='page'] {
+  color: var(--tlx-bronze-bright);
+  border-left-color: var(--tlx-bronze);
+}
+
+/* Page H1 — bronze hairline mark, matching landing wordmark */
+.sl-markdown-content > h1:first-child,
+main h1:not(.hero h1):first-of-type {
+  position: relative;
+  padding-left: 0.85rem;
+  margin-bottom: 1.5rem;
+  letter-spacing: -0.025em;
+}
+.sl-markdown-content > h1:first-child::before,
+main h1:not(.hero h1):first-of-type::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.18em;
+  bottom: 0.18em;
+  width: 3px;
+  background: linear-gradient(180deg, var(--tlx-bronze-bright), var(--tlx-bronze-deep));
+  border-radius: 2px;
+}
+
+/* Page H2 — bronze top hairline for section breaks */
+.sl-markdown-content > h2 {
+  margin-top: 2.6rem;
+  padding-top: 1.3rem;
+  border-top: 1px solid var(--tlx-border);
+  position: relative;
+}
+.sl-markdown-content > h2::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 0;
+  width: 32px;
+  height: 1px;
+  background: var(--tlx-bronze);
+}
+
+/* Header (top nav) — bronze hairline + soft halo */
+header.header {
+  border-bottom: 1px solid var(--tlx-border);
+  background: rgba(10, 10, 12, 0.78);
+  backdrop-filter: blur(10px);
+}
+
+/* Pagination footer — bronze hover */
+.pagination-links a {
+  border: 1px solid var(--tlx-border);
+  border-radius: var(--tlx-radius);
+  transition: border-color 140ms ease, background 140ms ease;
+}
+.pagination-links a:hover {
+  border-color: var(--tlx-bronze);
+  background: var(--tlx-surface);
+}
+
+/* Search button styling */
+button[data-open-modal] {
+  border-color: var(--tlx-border) !important;
+  background: var(--tlx-surface) !important;
+  transition: border-color 140ms ease, background 140ms ease !important;
+}
+button[data-open-modal]:hover {
+  border-color: var(--tlx-bronze) !important;
+  background: var(--tlx-surface-rise) !important;
+}
 
 /* Starlight code block frame */
 .expressive-code { --ec-frm-edBg: var(--tlx-surface); --ec-frm-edActTabBg: var(--tlx-surface-rise); --ec-frm-edActTabIndBtmCol: var(--tlx-bronze); --ec-codeFontFml: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, monospace; --ec-codeFontSize: 13.5px; }

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -392,6 +392,20 @@ table tr:last-child td { border-bottom: none; }
   color: var(--tlx-fg);
   overflow: hidden;
 }
+.tlx-term-line {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tlx-term-glyph {
+  flex: 0 0 auto;
+  min-width: 1.1em;
+  text-align: left;
+  white-space: nowrap;
+}
+.tlx-term-text { flex: 1 1 auto; min-width: 0; }
 .tlx-term-prompt { color: var(--tlx-bronze); }
 .tlx-term-out { color: var(--tlx-fg-muted); }
 .tlx-term-ok { color: var(--tlx-ok); }


### PR DESCRIPTION
## Summary

Two-commit branch covering the ETH Open Agents demo prep:

1. **`fix(keeperhub)`** — hard-disable KH routing for the demo. KH origin is returning 524s and the env-flag bypass does not survive the dotenv precedence chain. Gates the route + khClient behind a `KH_ROUTING_DISABLED` constant so all tool calls run against the original execute. Audit logging in the finally block keeps firing. Revert by flipping the constant once KH stabilizes.
2. **`feat(site)`** — landing page modernization (reactbits-inspired ambient motion).

## Landing changes

- Aurora hero background (OGL/WebGL, bronze color stops, slow drift). Lazy-mounted via `client:visible`. Static-gradient fallback for `prefers-reduced-motion`. Mobile dimmed to 0.6.
- DotGrid backdrop on the KeeperHub stripe (canvas 2D, vanilla proximity highlight + click shockwave — no GSAP InertiaPlugin).
- SplitText word-by-word reveal on section H2s (IntersectionObserver + CSS transitions). Hero `<h1>` left untouched.
- Spotlight cursor glow on `.tlx-card` / `.tlx-tool-card` (pure CSS + 5-line mousemove wiring).
- Sticky nav becomes scroll-aware (transparent over hero -> blurred dark once scrolled).
- Pulsing "tests passing" dot, tightening eyebrow letter-spacing on section reveal, two-tone halo (bronze top-right + ETH-blue bottom-left).

New deps: `@astrojs/react`, `react`, `react-dom`, `ogl`, `@types/react`, `@types/react-dom`. React integration scoped to `components/react/**` so Starlight docs are unaffected.

Design brief at `site/DESIGN-BRIEF.md`.

## Test plan
- [ ] `pnpm --filter talos-site exec astro check` -> 0 errors
- [ ] `pnpm --filter talos-site build` -> 26 pages built clean
- [ ] Visual: hero aurora visible at 1440px and 375px
- [ ] `prefers-reduced-motion: reduce` swaps Aurora canvas for static gradient
- [ ] Starlight docs page (`/docs/get-started/overview`) still renders
- [ ] No new console errors on landing